### PR TITLE
jca_columnwise

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 - NEW: **sct_dmri_create_noisemask**: Identification and estimation of noise in the diffusion signal, implemented by the Dipy software project (http://nipy.org/dipy/), based on the PIESNO method
 - NEW: **sct_register_graymatter**: Multi-label registration that accounts for gray matter shape.
 - NEW: **sct_register_multimodal**: features two new transformations: centermassrot and columnwise.
+- NEW: **sct_register_multimodal**: flag smoothWarpXY: regularization of warping field (only for algo=columnwize)
+- NEW: **sct_register_multimodal**: flag pca_eigenratio_th: Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot).
 - BUG: **sct_straighten_spinalcord**: Fixed #917, #924
 - BUG: Fixed issues #715, #719
 - BUG: **sct_propseg**: fixed issues #147, #242, #309, #376, #501, #544, #674, #680

--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -311,6 +311,7 @@ if __name__ == "__main__":
     start_time = time()
     # create single time variable for output names
     output_time = strftime("%y%m%d%H%M%S")
+    print 'Testing started on: '+strftime("%Y-%m-%d %H:%M:%S")
 
     # build log file name
     if create_log:
@@ -320,8 +321,7 @@ if __name__ == "__main__":
         handle_log = file(fname_log, 'w')
         # redirect to log file
         sys.stdout = handle_log
-
-    print 'Testing started on: '+strftime("%Y-%m-%d %H:%M:%S")
+        print 'Testing started on: '+strftime("%Y-%m-%d %H:%M:%S")
 
     # get path of the toolbox
     path_script = os.path.dirname(__file__)
@@ -390,6 +390,7 @@ if __name__ == "__main__":
 
         # count tests that passed
         count_passed = results_subset.status[results_subset.status == 0].count()
+        count_crashed = results_subset.status[results_subset.status == 1].count()
         # count tests that ran
         count_ran = results_subset.status[results_subset.status != 200].count()
 
@@ -405,6 +406,7 @@ if __name__ == "__main__":
         print 'Duration: ' + str(int(round(elapsed_time)))+'s'
         # display results
         print 'Passed: ' + str(count_passed) + '/' + str(count_ran)
+        print 'Crashed: ' + str(count_crashed) + '/' + str(count_ran)
         # build mean/std entries
         dict_mean = results_mean.to_dict()
         dict_mean.pop('status')

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -351,10 +351,18 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
         # get 2d data from the selected slice
         src2d = data_src[:, :, iz]
         dest2d = data_dest[:, :, iz]
+        # julien 20161105
+        #<<<
+        # threshold at 0.5
+        src2d[src2d < th_nonzero] = 0
+        dest2d[dest2d < th_nonzero] = 0
         # get non-zero coordinates, and transpose to obtain nx2 dimensions
+        coord_src2d = np.array(np.where(src2d > 0)).T
+        coord_dest2d = np.array(np.where(dest2d > 0)).T
         # here we use 0.5 as threshold for non-zero value
-        coord_src2d = np.array(np.where(src2d > th_nonzero)).T
-        coord_dest2d = np.array(np.where(dest2d > th_nonzero)).T
+        # coord_src2d = np.array(np.where(src2d > th_nonzero)).T
+        # coord_dest2d = np.array(np.where(dest2d > th_nonzero)).T
+        #>>>
 
         # SCALING R-L (X dimension)
         # ============================================================
@@ -362,15 +370,18 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
         src1d = np.sum(src2d, 1)
         dest1d = np.sum(dest2d, 1)
         # retrieve min/max of non-zeros elements (edge of the segmentation)
-        for i in xrange(len(src1d)):
-            if src1d[i] > 0.5:
-                # found index above 0.5, exit loop
-                break
-        ind_before = i - 1
-        ind_after = i
+        # julien 20161105
+        # <<<
+        src1d_min, src1d_max = min(np.where(src1d != 0)[0]), max(np.where(src1d != 0)[0])
+        dest1d_min, dest1d_max = min(np.where(dest1d != 0)[0]), max(np.where(dest1d != 0)[0])
+        # for i in xrange(len(src1d)):
+        #     if src1d[i] > 0.5:
+        #         found index above 0.5, exit loop
+                # break
         # get indices (in continuous space) at half-maximum of upward and downward slope
-        src1d_min, src1d_max = find_index_halfmax(src1d)
-        dest1d_min, dest1d_max = find_index_halfmax(dest1d)
+        # src1d_min, src1d_max = find_index_halfmax(src1d)
+        # dest1d_min, dest1d_max = find_index_halfmax(dest1d)
+        # >>>
         # 1D matching between src_y and dest_y
         mean_dest_x = (dest1d_max + dest1d_min) / 2
         mean_src_x = (src1d_max + src1d_min) / 2
@@ -875,9 +886,10 @@ def find_index_halfmax(data1d):
     # compute center of mass to get coordinate at 0.5
     xmax = i - 1 + (0.5 - data1d[i-1]) / float(data1d[i] - data1d[i-1])
     # display
+    # import matplotlib.pyplot as plt
     # plt.figure()
     # plt.plot(src1d)
     # plt.plot(xmin, 0.5, 'o')
     # plt.plot(xmax, 0.5, 'o')
-    # plt.show()
+    # plt.savefig('./normalize1d.png')
     return xmin, xmax

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -58,7 +58,7 @@ def register_slicewise(fname_src,
         register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=0, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose)
     elif paramreg.algo == 'centermassrot':
         # translation of center of mass and rotation based on source and destination first eigenvectors from PCA.
-        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose, pca_eigenratio_th=int(paramreg.pca_eigenratio_th))
+        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose, pca_eigenratio_th=float(paramreg.pca_eigenratio_th))
     elif paramreg.algo == 'columnwise':
         # scaling R-L, then column-wise center of mass alignment and scaling
         register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, path_qc=path_qc, smoothWarpXY=int(paramreg.smoothWarpXY))

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -61,7 +61,7 @@ def register_slicewise(fname_src,
         register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose)
     elif paramreg.algo == 'columnwise':
         # scaling R-L, then column-wise center of mass alignment and scaling
-        register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, path_qc=path_qc, smoothWarpXY=paramreg.smoothWarpXY)
+        register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, path_qc=path_qc, smoothWarpXY=int(paramreg.smoothWarpXY))
     else:
         # convert SCT flags into ANTs-compatible flags
         algo_dic = {'translation': 'Translation', 'rigid': 'Rigid', 'affine': 'Affine', 'syn': 'SyN', 'bsplinesyn': 'BSplineSyN', 'centermass': 'centermass'}

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -372,17 +372,17 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
         src1d_min, src1d_max = find_index_halfmax(src1d)
         dest1d_min, dest1d_max = find_index_halfmax(dest1d)
         # 1D matching between src_y and dest_y
-        mean_dest = (dest1d_max + dest1d_min) / 2
-        mean_src = (src1d_max + src1d_min) / 2
+        mean_dest_x = (dest1d_max + dest1d_min) / 2
+        mean_src_x = (src1d_max + src1d_min) / 2
         # compute x-scaling factor
         Sx = (dest1d_max - dest1d_min) / float(src1d_max - src1d_min)
         # apply transformation to coordinates
         coord_src2d_scaleX = np.copy(coord_src2d)  # need to use np.copy to avoid copying pointer
-        coord_src2d_scaleX[:, 0] = (coord_src2d[:, 0] - mean_src) * Sx + mean_dest
+        coord_src2d_scaleX[:, 0] = (coord_src2d[:, 0] - mean_src_x) * Sx + mean_dest_x
         coord_init_pix_scaleX = np.copy(coord_init_pix)
-        coord_init_pix_scaleX[:, 0] = (coord_init_pix[:, 0] - mean_src) * Sx + mean_dest
+        coord_init_pix_scaleX[:, 0] = (coord_init_pix[:, 0] - mean_src_x) * Sx + mean_dest_x
         coord_init_pix_scaleXinv = np.copy(coord_init_pix)
-        coord_init_pix_scaleXinv[:, 0] = (coord_init_pix[:, 0] - mean_dest) / float(Sx) + mean_src
+        coord_init_pix_scaleXinv[:, 0] = (coord_init_pix[:, 0] - mean_dest_x) / float(Sx) + mean_src_x
         # apply transformation to image
         from skimage.transform import warp
         row_scaleXinv = np.reshape(coord_init_pix_scaleXinv[:, 0], [nx, ny])
@@ -414,8 +414,8 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
                 # src1d_min, src1d_max = np.min(np.where(src1d > th_nonzero)), np.max(np.where(src1d > th_nonzero))
                 # dest1d_min, dest1d_max = np.min(np.where(dest1d > th_nonzero)), np.max(np.where(dest1d > th_nonzero))
                 # 1D matching between src_y and dest_y
-                mean_dest = (dest1d_max + dest1d_min) / 2
-                mean_src = (src1d_max + src1d_min) / 2
+                mean_dest_y = (dest1d_max + dest1d_min) / 2
+                mean_src_y = (src1d_max + src1d_min) / 2
                 # Tx = (dest1d_max + dest1d_min)/2 - (src1d_max + src1d_min)/2
                 Sy = (dest1d_max - dest1d_min) / float(src1d_max - src1d_min)
                 # apply forward transformation (in pixel space)
@@ -425,9 +425,9 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
                 # coord_init_pix_scaleY = np.copy(coord_init_pix)  # need to use np.copy to avoid copying pointer
                 # coord_init_pix_scaleY[:, 0] = (coord_init_pix[:, 0] - mean_src ) * Sx + mean_dest
                 coord_init_pix_scaleY[ix * nx:ny + ix * nx, 1] = (coord_init_pix[ix * nx:ny + ix * nx,
-                                                                  1] - mean_src) * Sy + mean_dest
+                                                                  1] - mean_src_y) * Sy + mean_dest_y
                 coord_init_pix_scaleYinv[ix * nx:ny + ix * nx, 1] = (coord_init_pix[ix * nx:ny + ix * nx,
-                                                                     1] - mean_dest) / float(Sy) + mean_src
+                                                                     1] - mean_dest_y) / float(Sy) + mean_src_y
         # apply transformation to image
         col_scaleYinv = np.reshape(coord_init_pix_scaleYinv[:, 1], [nx, ny])
         src2d_scaleXY = warp(src2d, np.array([row_scaleXinv, col_scaleYinv]), order=1)
@@ -436,59 +436,68 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
             # FIG 1
             plt.figure(figsize=(11, 4))
             # plot #1
-            plt.subplot(131)
+            ax = plt.subplot(131)
             plt.imshow(np.swapaxes(src2d, 1, 0), cmap=plt.cm.gray, interpolation='none')
             plt.hold(True)  # add other layer
             plt.imshow(np.swapaxes(dest2d, 1, 0), cmap=plt.cm.copper, interpolation='none', alpha=0.5)
             plt.title('src')
             plt.xlabel('x')
             plt.ylabel('y')
+            plt.xlim(mean_dest_x - 15, mean_dest_x + 15)
+            plt.ylim(mean_dest_y - 15, mean_dest_y + 15)
+            ax.grid(True, color='w')
             # plot #2
-            plt.subplot(132)
+            ax = plt.subplot(132)
             plt.imshow(np.swapaxes(src2d_scaleX, 1, 0), cmap=plt.cm.gray, interpolation='none')
             plt.hold(True)  # add other layer
             plt.imshow(np.swapaxes(dest2d, 1, 0), cmap=plt.cm.copper, interpolation='none', alpha=0.5)
             plt.title('src_scaleX')
             plt.xlabel('x')
             plt.ylabel('y')
+            plt.xlim(mean_dest_x - 15, mean_dest_x + 15)
+            plt.ylim(mean_dest_y - 15, mean_dest_y + 15)
+            ax.grid(True, color='w')
             # plot #3
-            plt.subplot(133)
+            ax = plt.subplot(133)
             plt.imshow(np.swapaxes(src2d_scaleXY, 1, 0), cmap=plt.cm.gray, interpolation='none')
             plt.hold(True)  # add other layer
             plt.imshow(np.swapaxes(dest2d, 1, 0), cmap=plt.cm.copper, interpolation='none', alpha=0.5)
             plt.title('src_scaleXY')
             plt.xlabel('x')
             plt.ylabel('y')
+            plt.xlim(mean_dest_x - 15, mean_dest_x + 15)
+            plt.ylim(mean_dest_y - 15, mean_dest_y + 15)
+            ax.grid(True, color='w')
             plt.savefig(path_qc + 'register2d_columnwise_image_z' + str(iz) + '.png')
             plt.close()
-
-            # FIG2
-            plt.figure(figsize=(15, 4))
-            list_data = [coord_init_pix, coord_init_pix_scaleX, coord_init_pix_scaleY]
-            list_subplot = [131, 132, 133]
-            list_title = ['src', 'src_scaleX', 'src_scaleY']
-            for i in xrange(len(list_subplot)):
-                plt.subplot(list_subplot[i])
-                plt.scatter([list_data[i][ipix][0] for ipix in xrange(list_data[i].shape[0])],
-                            [list_data[i][ipix][1] for ipix in xrange(list_data[i].shape[0])],
-                            s=15, marker='+', zorder=1, color='black', alpha=1)
-                plt.scatter([coord_dest2d[ipix][0] for ipix in xrange(coord_dest2d.shape[0])],
-                            [coord_dest2d[ipix][1] for ipix in xrange(coord_dest2d.shape[0])],
-                            s=15, marker='x', zorder=2, color='red', alpha=1)
-                plt.scatter([coord_src2d[ipix][0] for ipix in xrange(coord_src2d.shape[0])],
-                            [coord_src2d[ipix][1] for ipix in xrange(coord_src2d.shape[0])],
-                            s=5, marker='o', zorder=2, color='blue', alpha=1)
-                plt.scatter([coord_src2d_scaleX[ipix][0] for ipix in xrange(coord_src2d_scaleX.shape[0])],
-                            [coord_src2d_scaleX[ipix][1] for ipix in xrange(coord_src2d_scaleX.shape[0])],
-                            s=5, marker='o', zorder=2, color='green', alpha=1)
-                plt.xlim(0, nx-1)
-                plt.ylim(0, ny-1)
-                plt.grid()
-                plt.title(list_title[i])
-                plt.xlabel('x')
-                plt.ylabel('y')
-            plt.savefig(path_qc + 'register2d_columnwise_result_z' + str(iz) + '.png')
-            plt.close()
+            #
+            # # FIG2
+            # plt.figure(figsize=(15, 4))
+            # list_data = [coord_init_pix, coord_init_pix_scaleX, coord_init_pix_scaleY]
+            # list_subplot = [131, 132, 133]
+            # list_title = ['src', 'src_scaleX', 'src_scaleY']
+            # for i in xrange(len(list_subplot)):
+            #     plt.subplot(list_subplot[i])
+            #     plt.scatter([list_data[i][ipix][0] for ipix in xrange(list_data[i].shape[0])],
+            #                 [list_data[i][ipix][1] for ipix in xrange(list_data[i].shape[0])],
+            #                 s=15, marker='+', zorder=1, color='black', alpha=1)
+            #     plt.scatter([coord_dest2d[ipix][0] for ipix in xrange(coord_dest2d.shape[0])],
+            #                 [coord_dest2d[ipix][1] for ipix in xrange(coord_dest2d.shape[0])],
+            #                 s=15, marker='x', zorder=2, color='red', alpha=1)
+            #     plt.scatter([coord_src2d[ipix][0] for ipix in xrange(coord_src2d.shape[0])],
+            #                 [coord_src2d[ipix][1] for ipix in xrange(coord_src2d.shape[0])],
+            #                 s=5, marker='o', zorder=2, color='blue', alpha=1)
+            #     plt.scatter([coord_src2d_scaleX[ipix][0] for ipix in xrange(coord_src2d_scaleX.shape[0])],
+            #                 [coord_src2d_scaleX[ipix][1] for ipix in xrange(coord_src2d_scaleX.shape[0])],
+            #                 s=5, marker='o', zorder=2, color='green', alpha=1)
+            #     plt.xlim(0, nx-1)
+            #     plt.ylim(0, ny-1)
+            #     plt.grid()
+            #     plt.title(list_title[i])
+            #     plt.xlabel('x')
+            #     plt.ylabel('y')
+            # plt.savefig(path_qc + 'register2d_columnwise_result_z' + str(iz) + '.png')
+            # plt.close()
 
         # ============================================================
         # CALCULATE TRANSFORMATIONS

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -58,7 +58,7 @@ def register_slicewise(fname_src,
         register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=0, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose)
     elif paramreg.algo == 'centermassrot':
         # translation of center of mass and rotation based on source and destination first eigenvectors from PCA.
-        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose)
+        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose, angle_threshold=int(paramreg.angle_threshold))
     elif paramreg.algo == 'columnwise':
         # scaling R-L, then column-wise center of mass alignment and scaling
         register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, path_qc=path_qc, smoothWarpXY=int(paramreg.smoothWarpXY))
@@ -154,8 +154,8 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
                 eigenv_src = pca_src[iz].components_.T[0][0], pca_src[iz].components_.T[1][0]  # pca_src.components_.T[0]
                 eigenv_dest = pca_dest[iz].components_.T[0][0], pca_dest[iz].components_.T[1][0]  # pca_dest.components_.T[0]
                 angle_src_dest[iz] = angle_between(eigenv_src, eigenv_dest)
-                if 180 * angle_src_dest[iz] / np.pi > angle_threshold:
-                    angle_src_dest[iz] = 0
+                # if 180 * angle_src_dest[iz] / np.pi > angle_threshold:
+                #     angle_src_dest[iz] = 0
             # append to list of z_nonzero
             z_nonzero.append(iz)
         # if one of the slice is empty, ignore it

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -123,6 +123,7 @@ def get_parser(paramreg=None):
                                   "  origin: Physical origin of images\n"
                                   "poly: <int> Polynomial degree of regularization (only for algo=slicereg,centermassrot). Default=" +paramreg.steps['1'].poly + "\n"
                                   "smoothWarpXY: <int> Smooth XY warping field (only for algo=columnwize). Default=" +paramreg.steps['1'].smoothWarpXY + "\n"
+                                  "pca_eigenratio_th: <int> Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot). Default=" +paramreg.steps['1'].pca_eigenratio_th + "\n"
                                   "dof: <str> Degree of freedom for type=label. Separate with '_'. Default=" + paramreg.steps['0'].dof + "\n",
                       mandatory=False,
                       example="step=1,type=seg,algo=slicereg,metric=MeanSquares:step=2,type=im,algo=syn,metric=MI,iter=5,shrink=2")
@@ -177,7 +178,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='1', type='im', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2'):
+    def __init__(self, step='1', type='im', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -192,6 +193,7 @@ class Paramreg(object):
         self.poly = poly  # only for algo=slicereg
         self.dof = dof  # only for type=label
         self.smoothWarpXY = smoothWarpXY  # only for algo=columnwise
+        self.pca_eigenratio_th = pca_eigenratio_th  # only for algo=centermassrot
 
     # update constructor with user's parameters
     def update(self, paramreg_user):

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -101,38 +101,29 @@ def get_parser(paramreg=None):
                                   "step: <int> Step number (starts at 1, except for type=label).\n"
                                   "type: {im,seg,label} type of data used for registration. Use type=label only at step=0.\n"
                                   "algo: Default=" + paramreg.steps['1'].algo + "\n"
-                                                                                "  translation: translation in X-Y plane (2dof)\n"
-                                                                                "  rigid: translation + rotation in X-Y plane (4dof)\n"
-                                                                                "  affine: translation + rotation + scaling in X-Y plane (6dof)\n"
-                                                                                "  syn: non-linear symmetric normalization\n"
-                                                                                "  bsplinesyn: syn regularized with b-splines\n"
-                                                                                "  slicereg: regularized translations (see: goo.gl/Sj3ZeU)\n"
-                                                                                "  centermass: slicewise center of mass alignment (seg only).\n"
-                                                                                "  centermassrot: slicewise center of mass and PCA-based rotation alignment (seg only)\n"
-                                                                                "  columnwise: R-L scaling followed by A-P columnwise alignment (seg only).\n"
-                                  # "  landmark: Landmark-based affine registration (Tx,Ty,Tz,Rx,Ry,Sz). Requires at least two landmarks per image.\n"
-                                                                                "slicewise: <int> Slice-by-slice 2d transformation. Default=" +
-                                  paramreg.steps['1'].slicewise + "\n"
-                                                                  "metric: {CC,MI,MeanSquares}. Default=" +
-                                  paramreg.steps['1'].metric + "\n"
-                                                               "iter: <int> Number of iterations. Default=" +
-                                  paramreg.steps['1'].iter + "\n"
-                                                             "shrink: <int> Shrink factor (only for syn/bsplinesyn). Default=" +
-                                  paramreg.steps['1'].shrink + "\n"
-                                                               "smooth: <int> Smooth factor (in mm). Note: if algo={centermassrot,columnwise} the smoothing kernel is: SxSx0. Otherwise it is SxSxS. Default=" + paramreg.steps[
-                                      '1'].smooth + "\n"
-                                                    "laplacian: <int> Laplacian filter. Default=" + paramreg.steps[
-                                      '1'].laplacian + "\n"
-                                                       "gradStep: <float> Gradient step. Default=" + paramreg.steps[
-                                      '1'].gradStep + "\n"
-                                                      "init: <int> Initial translation alignment based on:\n"
-                                                      "  geometric: Geometric center of images\n"
-                                                      "  centermass: Center of mass of images\n"
-                                                      "  origin: Physical origin of images\n"
-                                                      "poly: <int> Polynomial degree of regularization (only for slicereg and centermassrot). Default=" +
-                                  paramreg.steps['1'].poly + "\n"
-                                                             "dof: <str> Degree of freedom for type=label. Separate with '_'. Default=" +
-                                  paramreg.steps['0'].dof + "\n",
+                                  "  translation: translation in X-Y plane (2dof)\n"
+                                  "  rigid: translation + rotation in X-Y plane (4dof)\n"
+                                  "  affine: translation + rotation + scaling in X-Y plane (6dof)\n"
+                                  "  syn: non-linear symmetric normalization\n"
+                                  "  bsplinesyn: syn regularized with b-splines\n"
+                                  "  slicereg: regularized translations (see: goo.gl/Sj3ZeU)\n"
+                                  "  centermass: slicewise center of mass alignment (seg only).\n"
+                                  "  centermassrot: slicewise center of mass and PCA-based rotation alignment (seg only)\n"
+                                  "  columnwise: R-L scaling followed by A-P columnwise alignment (seg only).\n"
+                                  "slicewise: <int> Slice-by-slice 2d transformation. Default=" + paramreg.steps['1'].slicewise + "\n"
+                                  "metric: {CC,MI,MeanSquares}. Default=" + paramreg.steps['1'].metric + "\n"
+                                  "iter: <int> Number of iterations. Default=" + paramreg.steps['1'].iter + "\n"
+                                  "shrink: <int> Shrink factor (only for syn/bsplinesyn). Default=" + paramreg.steps['1'].shrink + "\n"
+                                  "smooth: <int> Smooth factor (in mm). Note: if algo={centermassrot,columnwise} the smoothing kernel is: SxSx0. Otherwise it is SxSxS. Default=" + paramreg.steps['1'].smooth + "\n"
+                                  "laplacian: <int> Laplacian filter. Default=" + paramreg.steps['1'].laplacian + "\n"
+                                  "gradStep: <float> Gradient step. Default=" + paramreg.steps['1'].gradStep + "\n"
+                                  "init: <int> Initial translation alignment based on:\n"
+                                  "  geometric: Geometric center of images\n"
+                                  "  centermass: Center of mass of images\n"
+                                  "  origin: Physical origin of images\n"
+                                  "poly: <int> Polynomial degree of regularization (only for algo=slicereg,centermassrot). Default=" +paramreg.steps['1'].poly + "\n"
+                                  "smoothWarpXY: <int> Smooth XY warping field (only for algo=columnwize). Default=" +paramreg.steps['1'].smoothWarpXY + "\n"
+                                  "dof: <str> Degree of freedom for type=label. Separate with '_'. Default=" + paramreg.steps['0'].dof + "\n",
                       mandatory=False,
                       example="step=1,type=seg,algo=slicereg,metric=MeanSquares:step=2,type=im,algo=syn,metric=MI,iter=5,shrink=2")
     parser.add_option(name="-identity",
@@ -186,7 +177,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='1', type='im', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz'):
+    def __init__(self, step='1', type='im', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -198,10 +189,9 @@ class Paramreg(object):
         self.gradStep = gradStep
         self.slicewise = slicewise
         self.init = init
-        self.poly = poly  # slicereg only
-        self.dof = dof  # type=label only
-        # self.window_length = window_length  # str
-        # self.detect_outlier = detect_outlier  # str. detect outliers, for methods slicereg2d_xx
+        self.poly = poly  # only for algo=slicereg
+        self.dof = dof  # only for type=label
+        self.smoothWarpXY = smoothWarpXY  # only for algo=columnwise
 
     # update constructor with user's parameters
     def update(self, paramreg_user):
@@ -475,6 +465,7 @@ def register(src, dest, paramreg, param, i_step_str):
     sct.printv('  init ........... '+paramreg.steps[i_step_str].init, param.verbose)
     sct.printv('  poly ........... '+paramreg.steps[i_step_str].poly, param.verbose)
     sct.printv('  dof ............ '+paramreg.steps[i_step_str].dof, param.verbose)
+    sct.printv('  smoothWarpXY ... '+paramreg.steps[i_step_str].smoothWarpXY, param.verbose)
 
     # set metricSize
     if paramreg.steps[i_step_str].metric == 'MI':

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -42,27 +42,19 @@ class Param:
         self.remove_temp_files = 1  # remove temporary files
         self.fname_mask = ''  # this field is needed in the function register@sct_register_multimodal
         self.padding = 10  # this field is needed in the function register@sct_register_multimodal
-        # self.speed = 'fast'  # speed of registration. slow | normal | fast
-        # self.nb_iterations = '5'
-        # self.algo = 'SyN'
-        # self.gradientStep = '0.5'
-        # self.metric = 'MI'
         self.verbose = 1  # verbose
-        # self.folder_template = 'template/'  # folder where template files are stored (MNI-Poly-AMU_T2.nii.gz, etc.)
         self.path_template = path_sct+'/data/PAM50'
         self.path_qc = os.path.abspath(os.curdir)+'/qc/'
-        # self.file_template_label = 'landmarks_center.nii.gz'
         self.zsubsample = '0.25'
         self.param_straighten = ''
-        # self.smoothing_sigma = 5  # Smoothing along centerline to improve accuracy and remove step effects
 
 
 # get default parameters
 # Note: step0 is used as pre-registration
 step0 = Paramreg(step='0', type='label', dof='Tx_Ty_Tz_Sz')  # if ref=template, we only need translations and z-scaling because the cord is already straight
 step1 = Paramreg(step='1', type='seg', algo='centermassrot', smooth='1')
-# step2 = Paramreg(step='2', type='seg', algo='columnwise', smooth='1')
-step2 = Paramreg(step='2', type='seg', algo='bsplinesyn', metric='MeanSquares', iter='5', smooth='1')
+step2 = Paramreg(step='2', type='seg', algo='columnwise', smooth='0', smoothWarpXY='2')
+# step2 = Paramreg(step='2', type='seg', algo='bsplinesyn', metric='MeanSquares', iter='5', smooth='1')
 # step3 = Paramreg(step='3', type='im', algo='syn', metric='CC', iter='1')
 paramreg = ParamregMultiStep([step0, step1, step2])
 
@@ -115,19 +107,9 @@ def get_parser():
                       type_value=[[':'], 'str'],
                       description='Parameters for registration (see sct_register_multimodal). Default: \
                       \n--\nstep=0\ntype=' + paramreg.steps['0'].type + '\ndof=' + paramreg.steps['0'].dof + '\
-                      \n--\nstep=1\ntype=' + paramreg.steps['1'].type + '\nalgo=' + paramreg.steps['1'].algo + '\nmetric=' + paramreg.steps['1'].metric + '\niter=' + paramreg.steps['1'].iter + '\nsmooth=' + paramreg.steps['1'].smooth + '\ngradStep=' + paramreg.steps['1'].gradStep + '\nslicewise=' + paramreg.steps['1'].slicewise + '\
-                      \n--\nstep=2\ntype=' + paramreg.steps['2'].type + '\nalgo=' + paramreg.steps['2'].algo + '\nmetric=' + paramreg.steps['2'].metric + '\niter=' + paramreg.steps['2'].iter + '\nsmooth=' + paramreg.steps['2'].smooth + '\ngradStep=' + paramreg.steps['2'].gradStep + '\n',
-                      # \n--\nstep=3\ntype=' + paramreg.steps['3'].type + '\nalgo=' + paramreg.steps['3'].algo + '\nmetric=' + paramreg.steps['3'].metric + '\niter=' + paramreg.steps['3'].iter + '\nsmooth=' + paramreg.steps['3'].smooth + '\ngradStep=' + paramreg.steps['3'].gradStep + '\n',
-                      mandatory=False,
-                      example="step=2,type=seg,algo=bsplinesyn,metric=MeanSquares,iter=5,shrink=2:step=3,type=im,algo=syn,metric=MI,iter=5,shrink=1,gradStep=0.3")
-    # parser.add_option(name="-p",
-    #                   type_value=None,
-    #                   description='Parameters for registration (see sct_register_multimodal). Default: \
-    #                   \n--\nstep=1\ntype=' + paramreg.steps['1'].type + '\nalgo=' + paramreg.steps['1'].algo + '\nmetric=' + paramreg.steps['1'].metric + '\iter=' + paramreg.steps['1'].iter + '\smooth=' + paramreg.steps['1'].smooth + '\gradStep=' + paramreg.steps['1'].gradStep + '\slicewise=' + paramreg.steps['1'].slicewise + '\
-    #                   \n--\nstep=1\ntype=' + paramreg.steps['2'].type + '\nalgo=' + paramreg.steps['2'].algo + '\nmetric=' + paramreg.steps['2'].metric + '\iter=' + paramreg.steps['2'].iter + '\smooth=' + paramreg.steps['2'].smooth + '\gradStep=' + paramreg.steps['2'].gradStep + '\slicewise=' + paramreg.steps['2'].slicewise + '\
-    #                   \n--\nstep=1\ntype=' + paramreg.steps['3'].type + '\nalgo=' + paramreg.steps['3'].algo + '\nmetric=' + paramreg.steps['3'].metric + '\iter=' + paramreg.steps['3'].iter + '\smooth=' + paramreg.steps['3'].smooth + '\gradStep=' + paramreg.steps['3'].gradStep + '\slicewise=' + paramreg.steps['3'].slicewise + '\n',
-    #                   mandatory=False,
-    #                   deprecated_by='-param')
+                      \n--\nstep=1\ntype=' + paramreg.steps['1'].type + '\nalgo=' + paramreg.steps['1'].algo + '\nmetric=' + paramreg.steps['1'].metric + '\niter=' + paramreg.steps['1'].iter + '\nsmooth=' + paramreg.steps['1'].smooth + '\ngradStep=' + paramreg.steps['1'].gradStep + '\nslicewise=' + paramreg.steps['1'].slicewise + '\nsmoothWarpXY=' + paramreg.steps['1'].smoothWarpXY + '\
+                      \n--\nstep=2\ntype=' + paramreg.steps['2'].type + '\nalgo=' + paramreg.steps['2'].algo + '\nmetric=' + paramreg.steps['2'].metric + '\niter=' + paramreg.steps['2'].iter + '\nsmooth=' + paramreg.steps['2'].smooth + '\ngradStep=' + paramreg.steps['2'].gradStep + '\nslicewise=' + paramreg.steps['2'].slicewise + '\nsmoothWarpXY=' + paramreg.steps['2'].smoothWarpXY,
+                      mandatory=False)
     parser.add_option(name="-param-straighten",
                       type_value='str',
                       description="""Parameters for straightening (see sct_straighten_spinalcord).""",

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -107,8 +107,8 @@ def get_parser():
                       type_value=[[':'], 'str'],
                       description='Parameters for registration (see sct_register_multimodal). Default: \
                       \n--\nstep=0\ntype=' + paramreg.steps['0'].type + '\ndof=' + paramreg.steps['0'].dof + '\
-                      \n--\nstep=1\ntype=' + paramreg.steps['1'].type + '\nalgo=' + paramreg.steps['1'].algo + '\nmetric=' + paramreg.steps['1'].metric + '\niter=' + paramreg.steps['1'].iter + '\nsmooth=' + paramreg.steps['1'].smooth + '\ngradStep=' + paramreg.steps['1'].gradStep + '\nslicewise=' + paramreg.steps['1'].slicewise + '\nsmoothWarpXY=' + paramreg.steps['1'].smoothWarpXY + '\
-                      \n--\nstep=2\ntype=' + paramreg.steps['2'].type + '\nalgo=' + paramreg.steps['2'].algo + '\nmetric=' + paramreg.steps['2'].metric + '\niter=' + paramreg.steps['2'].iter + '\nsmooth=' + paramreg.steps['2'].smooth + '\ngradStep=' + paramreg.steps['2'].gradStep + '\nslicewise=' + paramreg.steps['2'].slicewise + '\nsmoothWarpXY=' + paramreg.steps['2'].smoothWarpXY,
+                      \n--\nstep=1\ntype=' + paramreg.steps['1'].type + '\nalgo=' + paramreg.steps['1'].algo + '\nmetric=' + paramreg.steps['1'].metric + '\niter=' + paramreg.steps['1'].iter + '\nsmooth=' + paramreg.steps['1'].smooth + '\ngradStep=' + paramreg.steps['1'].gradStep + '\nslicewise=' + paramreg.steps['1'].slicewise + '\nsmoothWarpXY=' + paramreg.steps['1'].smoothWarpXY + '\npca_eigenratio_th=' + paramreg.steps['1'].pca_eigenratio_th + '\
+                      \n--\nstep=2\ntype=' + paramreg.steps['2'].type + '\nalgo=' + paramreg.steps['2'].algo + '\nmetric=' + paramreg.steps['2'].metric + '\niter=' + paramreg.steps['2'].iter + '\nsmooth=' + paramreg.steps['2'].smooth + '\ngradStep=' + paramreg.steps['2'].gradStep + '\nslicewise=' + paramreg.steps['2'].slicewise + '\nsmoothWarpXY=' + paramreg.steps['2'].smoothWarpXY + '\npca_eigenratio_th=' + paramreg.steps['1'].pca_eigenratio_th,
                       mandatory=False)
     parser.add_option(name="-param-straighten",
                       type_value='str',


### PR DESCRIPTION
- NEW: **sct_register_multimodal**: flag smoothWarpXY: regularization of warping field (only for algo=columnwize)
- NEW: **sct_register_multimodal**: flag pca_eigenratio_th: Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot).

jca_columnwise:
~~~
Testing started on: 2016-11-05 20:11:38
SCT commit/branch: 9732c0035c5bf48704bb5db13c23d53fbc6d9642/(detached from 9732c00)
OS: linux (Linux-3.19.0-71-generic-x86_64-with-debian-jessie-sid)
Command: "sct_register_to_template -i t2/t2.nii.gz -s t2/t2_seg_manual.nii.gz -l t2/labels.nii.gz
Dataset: /mnt/data_shared/sct_testing/large/

GLOBAL RESULTS:
Duration: 2656s
Passed: 94/95
Crashed: 0/95
Mean: {'dice_anat2template': 0.9380718315789475, 'dice_template2anat': 0.9430814526315787, 'duration 
[s]': 280.5130437098051}
STD: {'dice_anat2template': 0.004720252512296695, 'dice_template2anat': 0.009781032015740732, 'durati
on [s]': 48.475142999539536}
~~~

master:
~~~
Testing started on: 2016-11-05 15:43:01
SCT commit/branch: d279d0cb3c2385e74e78f2a0d00533577535c1de/master
OS: linux (Linux-3.19.0-71-generic-x86_64-with-debian-jessie-sid)
Command: "sct_register_to_template -i t2/t2.nii.gz -s t2/t2_seg_manual.nii.gz -l t2/labels.nii.gz
Dataset: /mnt/data_shared/sct_testing/large/

GLOBAL RESULTS:
Duration: 4606s
Passed: 91/95
Mean: {'dice_anat2template': 0.9350427578947369, 'dice_template2anat': 0.9470335473684206, 'duration [s]': 483.8648285489333}
STD: {'dice_anat2template': 0.010308039365874624, 'dice_template2anat': 0.017867637498030633, 'duration [s]': 69.03722549243498}
~~~

jca_columnwise (-ref subject):
~~~
Testing started on: 2016-11-05 20:18:14
SCT commit/branch: 9732c0035c5bf48704bb5db13c23d53fbc6d9642/(detached from 9732c00)
OS: osx (Darwin-14.4.0-x86_64-i386-64bit)
Command: "sct_register_to_template -i t2/t2.nii.gz -s t2/t2_seg_manual.nii.gz -l t2/labels.nii.gz -ref subject
Dataset: /Volumes/data_raid/data_shared/sct_testing/large/

GLOBAL RESULTS:
Duration: 2380s
Passed: 46/95
Crashed: 0/95
Mean: {'dice_anat2template': 0.9040186421052632, 'dice_template2anat': 0.8974270105263159, 'duration [s]': 176.94490251792104}
STD: {'dice_anat2template': 0.018548391004897132, 'dice_template2anat': 0.03430954711697938, 'duration [s]': 28.31048903279802}
~~~