### PR TITLE
BUG: Open files exceeds the maximum allowed by the OS.

### DIFF
--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -293,7 +293,7 @@ def dmri_moco(param):
     # file_dwi_groups_means_merge = 'dwi_averaged_groups'
     im_dw_list = []
     for iGroup in range(nb_groups):
-        im_dw_list.append(Image(file_dwi_mean[iGroup] + ext_data))
+        im_dw_list.append(file_dwi_mean[iGroup] + ext_data)
     im_dw_out = concat_data(im_dw_list, 3)
     im_dw_out.setFileName(file_dwi_group + ext_data)
     im_dw_out.save()


### PR DESCRIPTION
By creating a list of Image objects, the object opens the file descriptor.
If the list is larger than the maximum allowed by the OS, the application
crashes. In this case, the function only required a list of file names
instead of a list of Image objects.