### PR TITLE
Fix Issue #1034

### DIFF
--- a/scripts/sct_register_graymatter.py
+++ b/scripts/sct_register_graymatter.py
@@ -20,7 +20,7 @@ class Param:
         self.gap = (100, 200)
         self.smooth = 0.8
 
-        self.param_reg = 'step=1,algo=slicereg,metric=MeanSquares:step=2,algo=syn,metric=MeanSquares,iter=10,smooth=0,shrink=2:step=3,algo=bsplinesyn,metric=MeanSquares,iter=5,smooth=0'
+        self.param_reg = 'step=1,type=im,algo=slicereg,metric=MeanSquares:step=2,type=im,algo=syn,metric=MeanSquares,iter=10,smooth=0,shrink=2:step=3,type=im,algo=bsplinesyn,metric=MeanSquares,iter=5,smooth=0'
         # Previous default param (less efficient): 'step=1,algo=slicereg,metric=MeanSquares:step=2,algo=bsplinesyn,metric=MeanSquares,iter=5,smooth=1'
 
         self.output_folder = './'

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -179,7 +179,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='1', type='im', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
+    def __init__(self, step='1', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -228,6 +228,9 @@ class ParamregMultiStep:
                 self.steps[param_reg.step] = param_reg
         else:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
+        if param_reg.type not in ['im', 'seg']:
+            sct.printv("ERROR: parameters must contain a type, either 'im' or 'seg'", 1, 'error')
+
 
 
 # MAIN

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -228,7 +228,7 @@ class ParamregMultiStep:
                 self.steps[param_reg.step] = param_reg
         else:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
-        if param_reg.type not in ['im', 'seg']:
+        if int(param_reg.step) != 0 and param_reg.type not in ['im', 'seg']:
             sct.printv("ERROR: parameters must contain a type, either 'im' or 'seg'", 1, 'error')
 
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -45,7 +45,7 @@ def get_parser(paramreg=None):
     if paramreg is None:
         step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5',
                          slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
-        step1 = Paramreg()
+        step1 = Paramreg(step='1', type='im')
         paramreg = ParamregMultiStep([step0, step1])
 
     parser = Parser(__file__)
@@ -101,7 +101,7 @@ def get_parser(paramreg=None):
                       description="Parameters for registration. Separate arguments with \",\". Separate steps with \":\".\n"
                                   "step: <int> Step number (starts at 1, except for type=label).\n"
                                   "type: {im,seg,label} type of data used for registration. Use type=label only at step=0.\n"
-                                  "algo: Default=" + paramreg.steps['1'].algo + "\n"
+                                  "algo: Default=" + paramreg.steps[''].algo + "\n"
                                   "  translation: translation in X-Y plane (2dof)\n"
                                   "  rigid: translation + rotation in X-Y plane (4dof)\n"
                                   "  affine: translation + rotation + scaling in X-Y plane (6dof)\n"
@@ -111,20 +111,20 @@ def get_parser(paramreg=None):
                                   "  centermass: slicewise center of mass alignment (seg only).\n"
                                   "  centermassrot: slicewise center of mass and PCA-based rotation alignment (seg only)\n"
                                   "  columnwise: R-L scaling followed by A-P columnwise alignment (seg only).\n"
-                                  "slicewise: <int> Slice-by-slice 2d transformation. Default=" + paramreg.steps['1'].slicewise + "\n"
-                                  "metric: {CC,MI,MeanSquares}. Default=" + paramreg.steps['1'].metric + "\n"
-                                  "iter: <int> Number of iterations. Default=" + paramreg.steps['1'].iter + "\n"
-                                  "shrink: <int> Shrink factor (only for syn/bsplinesyn). Default=" + paramreg.steps['1'].shrink + "\n"
-                                  "smooth: <int> Smooth factor (in mm). Note: if algo={centermassrot,columnwise} the smoothing kernel is: SxSx0. Otherwise it is SxSxS. Default=" + paramreg.steps['1'].smooth + "\n"
-                                  "laplacian: <int> Laplacian filter. Default=" + paramreg.steps['1'].laplacian + "\n"
-                                  "gradStep: <float> Gradient step. Default=" + paramreg.steps['1'].gradStep + "\n"
+                                  "slicewise: <int> Slice-by-slice 2d transformation. Default=" + paramreg.steps[''].slicewise + "\n"
+                                  "metric: {CC,MI,MeanSquares}. Default=" + paramreg.steps[''].metric + "\n"
+                                  "iter: <int> Number of iterations. Default=" + paramreg.steps[''].iter + "\n"
+                                  "shrink: <int> Shrink factor (only for syn/bsplinesyn). Default=" + paramreg.steps[''].shrink + "\n"
+                                  "smooth: <int> Smooth factor (in mm). Note: if algo={centermassrot,columnwise} the smoothing kernel is: SxSx0. Otherwise it is SxSxS. Default=" + paramreg.steps[''].smooth + "\n"
+                                  "laplacian: <int> Laplacian filter. Default=" + paramreg.steps[''].laplacian + "\n"
+                                  "gradStep: <float> Gradient step. Default=" + paramreg.steps[''].gradStep + "\n"
                                   "init: <int> Initial translation alignment based on:\n"
                                   "  geometric: Geometric center of images\n"
                                   "  centermass: Center of mass of images\n"
                                   "  origin: Physical origin of images\n"
-                                  "poly: <int> Polynomial degree of regularization (only for algo=slicereg,centermassrot). Default=" +paramreg.steps['1'].poly + "\n"
-                                  "smoothWarpXY: <int> Smooth XY warping field (only for algo=columnwize). Default=" +paramreg.steps['1'].smoothWarpXY + "\n"
-                                  "pca_eigenratio_th: <int> Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot). Default=" +paramreg.steps['1'].pca_eigenratio_th + "\n"
+                                  "poly: <int> Polynomial degree of regularization (only for algo=slicereg,centermassrot). Default=" +paramreg.steps[''].poly + "\n"
+                                  "smoothWarpXY: <int> Smooth XY warping field (only for algo=columnwize). Default=" +paramreg.steps[''].smoothWarpXY + "\n"
+                                  "pca_eigenratio_th: <int> Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot). Default=" +paramreg.steps[''].pca_eigenratio_th + "\n"
                                   "dof: <str> Degree of freedom for type=label. Separate with '_'. Default=" + paramreg.steps['0'].dof + "\n",
                       mandatory=False,
                       example="step=1,type=seg,algo=slicereg,metric=MeanSquares:step=2,type=im,algo=syn,metric=MI,iter=5,shrink=2")
@@ -179,7 +179,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='1', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
+    def __init__(self, step='', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -221,7 +221,7 @@ class ParamregMultiStep:
         # this function checks if the step is already present. If it is present, it must update it. If it is not, it must add it.
         param_reg = Paramreg()
         param_reg.update(stepParam)
-        if param_reg.step != 0:
+        if param_reg.step not in [0,'']:
             if param_reg.step in self.steps:
                 self.steps[param_reg.step].update(stepParam)
             else:

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -45,7 +45,7 @@ def get_parser(paramreg=None):
     if paramreg is None:
         step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5',
                          slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
-        step1 = Paramreg(step='1', type='im')
+        step1 = Paramreg()
         paramreg = ParamregMultiStep([step0, step1])
 
     parser = Parser(__file__)
@@ -101,7 +101,7 @@ def get_parser(paramreg=None):
                       description="Parameters for registration. Separate arguments with \",\". Separate steps with \":\".\n"
                                   "step: <int> Step number (starts at 1, except for type=label).\n"
                                   "type: {im,seg,label} type of data used for registration. Use type=label only at step=0.\n"
-                                  "algo: Default=" + paramreg.steps[''].algo + "\n"
+                                  "algo: Default=" + paramreg.steps['1'].algo + "\n"
                                   "  translation: translation in X-Y plane (2dof)\n"
                                   "  rigid: translation + rotation in X-Y plane (4dof)\n"
                                   "  affine: translation + rotation + scaling in X-Y plane (6dof)\n"
@@ -111,20 +111,20 @@ def get_parser(paramreg=None):
                                   "  centermass: slicewise center of mass alignment (seg only).\n"
                                   "  centermassrot: slicewise center of mass and PCA-based rotation alignment (seg only)\n"
                                   "  columnwise: R-L scaling followed by A-P columnwise alignment (seg only).\n"
-                                  "slicewise: <int> Slice-by-slice 2d transformation. Default=" + paramreg.steps[''].slicewise + "\n"
-                                  "metric: {CC,MI,MeanSquares}. Default=" + paramreg.steps[''].metric + "\n"
-                                  "iter: <int> Number of iterations. Default=" + paramreg.steps[''].iter + "\n"
-                                  "shrink: <int> Shrink factor (only for syn/bsplinesyn). Default=" + paramreg.steps[''].shrink + "\n"
-                                  "smooth: <int> Smooth factor (in mm). Note: if algo={centermassrot,columnwise} the smoothing kernel is: SxSx0. Otherwise it is SxSxS. Default=" + paramreg.steps[''].smooth + "\n"
-                                  "laplacian: <int> Laplacian filter. Default=" + paramreg.steps[''].laplacian + "\n"
-                                  "gradStep: <float> Gradient step. Default=" + paramreg.steps[''].gradStep + "\n"
+                                  "slicewise: <int> Slice-by-slice 2d transformation. Default=" + paramreg.steps['1'].slicewise + "\n"
+                                  "metric: {CC,MI,MeanSquares}. Default=" + paramreg.steps['1'].metric + "\n"
+                                  "iter: <int> Number of iterations. Default=" + paramreg.steps['1'].iter + "\n"
+                                  "shrink: <int> Shrink factor (only for syn/bsplinesyn). Default=" + paramreg.steps['1'].shrink + "\n"
+                                  "smooth: <int> Smooth factor (in mm). Note: if algo={centermassrot,columnwise} the smoothing kernel is: SxSx0. Otherwise it is SxSxS. Default=" + paramreg.steps['1'].smooth + "\n"
+                                  "laplacian: <int> Laplacian filter. Default=" + paramreg.steps['1'].laplacian + "\n"
+                                  "gradStep: <float> Gradient step. Default=" + paramreg.steps['1'].gradStep + "\n"
                                   "init: <int> Initial translation alignment based on:\n"
                                   "  geometric: Geometric center of images\n"
                                   "  centermass: Center of mass of images\n"
                                   "  origin: Physical origin of images\n"
-                                  "poly: <int> Polynomial degree of regularization (only for algo=slicereg,centermassrot). Default=" +paramreg.steps[''].poly + "\n"
-                                  "smoothWarpXY: <int> Smooth XY warping field (only for algo=columnwize). Default=" +paramreg.steps[''].smoothWarpXY + "\n"
-                                  "pca_eigenratio_th: <int> Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot). Default=" +paramreg.steps[''].pca_eigenratio_th + "\n"
+                                  "poly: <int> Polynomial degree of regularization (only for algo=slicereg,centermassrot). Default=" +paramreg.steps['1'].poly + "\n"
+                                  "smoothWarpXY: <int> Smooth XY warping field (only for algo=columnwize). Default=" +paramreg.steps['1'].smoothWarpXY + "\n"
+                                  "pca_eigenratio_th: <int> Min ratio between the two eigenvalues for PCA-based angular adjustment (only for algo=centermassrot). Default=" +paramreg.steps['1'].pca_eigenratio_th + "\n"
                                   "dof: <str> Degree of freedom for type=label. Separate with '_'. Default=" + paramreg.steps['0'].dof + "\n",
                       mandatory=False,
                       example="step=1,type=seg,algo=slicereg,metric=MeanSquares:step=2,type=im,algo=syn,metric=MI,iter=5,shrink=2")
@@ -179,7 +179,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
+    def __init__(self, step='1', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -221,7 +221,7 @@ class ParamregMultiStep:
         # this function checks if the step is already present. If it is present, it must update it. If it is not, it must add it.
         param_reg = Paramreg()
         param_reg.update(stepParam)
-        if param_reg.step not in [0,'']:
+        if param_reg.step != 0:
             if param_reg.step in self.steps:
                 self.steps[param_reg.step].update(stepParam)
             else:

--- a/testing/test_sct_register_multimodal.py
+++ b/testing/test_sct_register_multimodal.py
@@ -35,7 +35,7 @@ def test(path_data='', parameters=''):
         cmd = '-i '  + folder_data + file_data[0] \
               + ' -d ' +  folder_data + file_data[1] \
               + ' -o ' + sct.add_suffix(file_data[0], '_reg_'+algo)  \
-              + ' -param step=1,algo='+algo+',iter=1,smooth=1,shrink=2,metric=MI'  \
+              + ' -param step=1,algo='+algo+',type=im,iter=1,smooth=1,shrink=2,metric=MI'  \
               + ' -x linear' \
               + ' -r 0' \
               + ' -v 1'
@@ -59,7 +59,7 @@ def test(path_data='', parameters=''):
         cmd = '-i ' +  folder_data + file_data[0] \
               + ' -d ' +  folder_data + file_data[1] \
               + ' -o ' + sct.add_suffix(file_data[0], '_reg_'+algo)  \
-              + ' -param step=1,algo='+algo+',iter=5,smooth=0,metric=MeanSquares'  \
+              + ' -param step=1,algo='+algo+',type=im,iter=5,smooth=0,metric=MeanSquares'  \
               + ' -x linear' \
               + ' -r 0' \
               + ' -v 1'

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -34,7 +34,7 @@ def test(path_data='', parameters=''):
 
     if not parameters:
         parameters = '-i t2/t2.nii.gz -l t2/labels.nii.gz -s t2/t2_seg.nii.gz ' \
-                     '-param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares:step=3,iter=0 ' \
+                     '-param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares ' \
                      '-t template/ -r 0'
         add_path_for_template = True  # in this case, path to data should be added
 


### PR DESCRIPTION
Make the 'type' param mandatory for sct_register_multimodal.

Results of batch processing:
On this branch : 
```
t2/CSA:   /Users/saradupont/Neuropoly/process/2016-11-24-issue1034/sct_example_data/t2/t2_seg.nii.gz, 76.753884, 2.049822
mt/MTR:   51, white matter, 387.801068, 33.744919, 0.000000
mt/CSA:   /Users/saradupont/Neuropoly/process/2016-11-24-issue1034/sct_example_data/mt/dorsal_column.nii.gz, 20.052757, 1.286250
dmri/FA:  4, WM left lateral corticospinal tract, 22.799808, 0.734177, 0.000000
dmri/FA:  5, WM right lateral corticospinal tract, 20.828494, 0.790546, 0.000000
```


VS 

On master: 
```
t2/CSA:   /Users/saradupont/Neuropoly/process/2016-11-24-issue1034/sct_example_data/t2/t2_seg.nii.gz, 76.753884, 2.049822
mt/MTR:   51, white matter, 387.801068, 33.744919, 0.000000
mt/CSA:   /Users/saradupont/Neuropoly/process/2016-11-24-issue1034/sct_example_data/mt/dorsal_column.nii.gz, 20.052757, 1.286250
dmri/FA:  4, WM left lateral corticospinal tract, 22.799808, 0.734177, 0.000000
dmri/FA:  5, WM right lateral corticospinal tract, 20.828494, 0.790546, 0.000000
```

