### PR TITLE
Add option to compute MI

### DIFF
--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -24,7 +24,7 @@ import shutil
 # from glob import glob
 import numpy as np
 from sct_utils import extract_fname, printv, run, generate_output_file, slash_at_the_end, tmp_create
-from sct_maths import calc_MI
+from sct_maths import mutual_information
 from msct_parser import Parser
 from msct_image import Image
 import sct_utils as sct
@@ -734,7 +734,7 @@ def compute_corr_3d(src=[], target=[], x=0, xshift=0, xsize=0, y=0, yshift=0, ys
             #I_corr[ind_I] = np.corrcoef(data_chunk1d, pattern1d)[0, 1]
             # data_chunk2d = np.mean(data_chunk3d, 1)
             # pattern2d = np.mean(pattern, 1)
-            I_corr[ind_I] = calc_MI(data_chunk1d, pattern1d, nbins=16)
+            I_corr[ind_I] = mutual_information(data_chunk1d, pattern1d, nbins=16)
         else:
             allzeros = 1
             # printv('.. WARNING: iz='+str(iz)+': Data only contains zero. Set correlation to 0.', verbose)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -24,6 +24,7 @@ import shutil
 # from glob import glob
 import numpy as np
 from sct_utils import extract_fname, printv, run, generate_output_file, slash_at_the_end, tmp_create
+from sct_maths import calc_MI
 from msct_parser import Parser
 from msct_image import Image
 import sct_utils as sct
@@ -798,21 +799,6 @@ def compute_corr_3d(src=[], target=[], x=0, xshift=0, xsize=0, y=0, yshift=0, ys
 
     # return z-origin (z) + z-displacement minus zshift (to account for non-centered disc)
     return z + zrange[ind_peak] - zshift
-
-
-def calc_MI(x, y, nbins=32):
-    """
-    Compute mutual information
-    :param x:
-    :param y:
-    :param nbins:
-    :return:
-    """
-    from sklearn.metrics import mutual_info_score
-    c_xy = np.histogram2d(x, y, nbins)[0]
-    mi = mutual_info_score(None, None, contingency=c_xy)
-    # mi = adjusted_mutual_info_score(None, None, contingency=c_xy)
-    return mi
 
 
 def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -507,6 +507,14 @@ def laplacian(data, sigmas):
     # return laplace(data.astype(float))
 
 def compute_similarity(data1, data2, fname_out='', metric='', verbose=1):
+    '''
+    Compute a similarity metric between two images data
+    :param data1: numpy.array 3D data
+    :param data2: numpy.array 3D data
+    :param fname_out: file name of the output file. Output file should be either a text file ('.txt') or a pickle file ('.pkl', '.pklz' or '.pickle')
+    :param metric: 'mi' for mutual information or 'corr' for pearson correlation coefficient
+    :return: None
+    '''
     assert data1.size == data2.size, "\n\nERROR: the data don't have the same size.\nPlease use  \"sct_register_multimodal -i im1.nii.gz -d im2.nii.gz -identity 1\"  to put the input images in the same space"
     data1_1d = data1.ravel()
     data2_1d = data2.ravel()
@@ -539,10 +547,10 @@ def compute_similarity(data1, data2, fname_out='', metric='', verbose=1):
 def mutual_information(x, y, nbins=32, normalized=False):
     """
     Compute mutual information
-    :param x:
-    :param y:
-    :param nbins:
-    :return:
+    :param x: 1D numpy.array : flatten data from an image
+    :param y: 1D numpy.array : flatten data from an image
+    :param nbins: number of bins to compute the contingency matrix (only used if normalized=False)
+    :return: float non negative value : mutual information
     """
     from sklearn.metrics import normalized_mutual_info_score, mutual_info_score
     if normalized:
@@ -557,9 +565,10 @@ def correlation(x, y, type='pearson'):
     """
     Compute pearson or spearman correlation coeff
     Pearson's R is parametric whereas Spearman's R is non parametric (less sensitive)
-    :param x:
-    :param y:
-    :return:
+    :param x: 1D numpy.array : flatten data from an image
+    :param y: 1D numpy.array : flatten data from an image
+    :param type: str:  'pearson' or 'spearman': type of R correlation coeff to compute
+    :return: float value : correlation coefficient (between -1 and 1)
     """
     from scipy.stats import pearsonr, spearmanr
 

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -505,7 +505,7 @@ def mutual_information(data1, data2, fname_out='', verbose=1):
     data1_1d = data1.ravel()
     data2_1d = data2.ravel()
 
-    mi = calc_MI(data1_1d, data2_1d)
+    mi = calc_MI(data1_1d, data2_1d, normalized=True)
 
     path_out, filename_out, ext_out = extract_fname(fname_out)
     printv('\nMutual information: '+str(mi), verbose, 'info')

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -286,7 +286,7 @@ def main(args = None):
         # input 1 = from flag -i --> im
         # input 2 = from flag -mi
         im_2 = Image(arguments['-mi'])
-        compute_similarity(im.data, im_2.data, fname_out, metric='mi')
+        compute_similarity(im.data, im_2.data, fname_out, metric='mi', verbose=verbose)
 
         data_out=None
 
@@ -294,7 +294,7 @@ def main(args = None):
         # input 1 = from flag -i --> im
         # input 2 = from flag -mi
         im_2 = Image(arguments['-corr'])
-        compute_similarity(im.data, im_2.data, fname_out, metric='corr')
+        compute_similarity(im.data, im_2.data, fname_out, metric='corr', verbose=verbose)
 
         data_out=None
 

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -507,7 +507,7 @@ def laplacian(data, sigmas):
     # return laplace(data.astype(float))
 
 def compute_similarity(data1, data2, fname_out='', metric='', verbose=1):
-    assert data1.size == data2.size, "ERROR: the data don't have the same size"
+    assert data1.size == data2.size, "\n\nERROR: the data don't have the same size.\nPlease use  \"sct_register_multimodal -i im1.nii.gz -d im2.nii.gz -identity 1\"  to put the input images in the same space"
     data1_1d = data1.ravel()
     data2_1d = data2.ravel()
 

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -512,10 +512,10 @@ def compute_similarity(data1, data2, fname_out='', metric='', verbose=1):
     data2_1d = data2.ravel()
 
     if metric == 'mi':
-        res = calc_MI(data1_1d, data2_1d, normalized=True)
+        res = mutual_information(data1_1d, data2_1d, normalized=True)
         metric_full = 'Mutual information'
     if metric == 'corr':
-        res = calc_corr(data1_1d, data2_1d)
+        res = correlation(data1_1d, data2_1d)
         metric_full = 'Pearson correlation coefficient'
 
     printv('\n'+ metric_full +': ' + str(res), verbose, 'info')
@@ -536,7 +536,7 @@ def compute_similarity(data1, data2, fname_out='', metric='', verbose=1):
         else:
             pickle.dump(res, open(fname_out, 'w'), protocol=2)
 
-def calc_MI(x, y, nbins=32, normalized=False):
+def mutual_information(x, y, nbins=32, normalized=False):
     """
     Compute mutual information
     :param x:
@@ -553,16 +553,20 @@ def calc_MI(x, y, nbins=32, normalized=False):
     # mi = adjusted_mutual_info_score(None, None, contingency=c_xy)
     return mi
 
-def calc_corr(x, y):
+def correlation(x, y, type='pearson'):
     """
-    Compute pearson correlation coeff
+    Compute pearson or spearman correlation coeff
+    Pearson's R is parametric whereas Spearman's R is non parametric (less sensitive)
     :param x:
     :param y:
     :return:
     """
-    from scipy.stats import pearsonr
+    from scipy.stats import pearsonr, spearmanr
 
-    corr = pearsonr(x, y)[0]
+    if type == 'pearson':
+        corr = pearsonr(x, y)[0]
+    if type == 'spearman':
+        corr = spearmanr(x, y)[0]
 
     return corr
 


### PR DESCRIPTION
Fix issue #1054 

- Add option to compute normalized mutual information in `sct_maths`
- move function `calc_mi` from `sct_label_vertebrae` to `sct_maths` to avoid code duplication
- output (flag `-o`) can be either a text file (`.txt`) or a pickle file (`.pkl`, `.pklz` or `.pickle`)
- Add option to compute the Pearson's R correlation coefficient between two flatten images in `sct_maths`

