### PR TITLE
sct_register_multimodal: make 'step' mandatory 

### DIFF
--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -239,7 +239,7 @@ class ParamregMultiStep:
         # parameters must contain 'step'
         if param_reg.step is None:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
-        elif param_reg.step != 0:
+        elif int(param_reg.step) != 0:
             if param_reg.step in self.steps:
                 self.steps[param_reg.step].update(stepParam)
             else:

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -191,7 +191,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
+    def __init__(self, step, type, algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -239,13 +239,11 @@ class ParamregMultiStep:
         # parameters must contain 'step'
         if param_reg.step is None:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
-        elif int(param_reg.step) != 0:
+        else:
             if param_reg.step in self.steps:
                 self.steps[param_reg.step].update(stepParam)
             else:
                 self.steps[param_reg.step] = param_reg
-        else:
-            sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
         # parameters must contain 'type'
         if int(param_reg.step) != 0 and param_reg.type not in param_reg.type_list:
             sct.printv("ERROR: parameters must contain a type, either 'im' or 'seg'", 1, 'error')

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -233,13 +233,17 @@ class ParamregMultiStep:
         # this function checks if the step is already present. If it is present, it must update it. If it is not, it must add it.
         param_reg = Paramreg()
         param_reg.update(stepParam)
-        if param_reg.step != 0:
+        # step is mandatory
+        if param_reg.step == '':
+            sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
+        elif param_reg.step != 0:
             if param_reg.step in self.steps:
                 self.steps[param_reg.step].update(stepParam)
             else:
                 self.steps[param_reg.step] = param_reg
         else:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
+        # type is mandatory
         if int(param_reg.step) != 0 and param_reg.type not in ['im', 'seg']:
             sct.printv("ERROR: parameters must contain a type, either 'im' or 'seg'", 1, 'error')
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -208,6 +208,9 @@ class Paramreg(object):
         self.smoothWarpXY = smoothWarpXY  # only for algo=columnwise
         self.pca_eigenratio_th = pca_eigenratio_th  # only for algo=centermassrot
 
+        # list of possible values for self.type
+        self.type_list = ['im', 'seg', 'label']
+
     # update constructor with user's parameters
     def update(self, paramreg_user):
         list_objects = paramreg_user.split(',')
@@ -233,7 +236,7 @@ class ParamregMultiStep:
         # this function checks if the step is already present. If it is present, it must update it. If it is not, it must add it.
         param_reg = Paramreg()
         param_reg.update(stepParam)
-        # step is mandatory
+        # parameters must contain 'step'
         if param_reg.step == '':
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
         elif param_reg.step != 0:
@@ -243,8 +246,8 @@ class ParamregMultiStep:
                 self.steps[param_reg.step] = param_reg
         else:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
-        # type is mandatory
-        if int(param_reg.step) != 0 and param_reg.type not in ['im', 'seg']:
+        # parameters must contain 'type'
+        if int(param_reg.step) != 0 and param_reg.type not in param_reg.type_list:
             sct.printv("ERROR: parameters must contain a type, either 'im' or 'seg'", 1, 'error')
 
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -191,7 +191,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step, type, algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
+    def __init__(self, step=None, type=None, algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -237,7 +237,7 @@ class ParamregMultiStep:
         param_reg = Paramreg()
         param_reg.update(stepParam)
         # parameters must contain 'step'
-        if param_reg.step == '':
+        if param_reg.step is None:
             sct.printv("ERROR: parameters must contain 'step'", 1, 'error')
         elif param_reg.step != 0:
             if param_reg.step in self.steps:

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -46,7 +46,7 @@ def get_parser(paramreg=None):
     if paramreg is None:
         step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5',
                          slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
-        step1 = Paramreg()
+        step1 = Paramreg(step='1', type='im')
         paramreg = ParamregMultiStep([step0, step1])
 
     parser = Parser(__file__)
@@ -191,7 +191,7 @@ class Param:
 
 # Parameters for registration
 class Paramreg(object):
-    def __init__(self, step='1', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
+    def __init__(self, step='', type='', algo='syn', metric='MeanSquares', iter='10', shrink='1', smooth='0', gradStep='0.5', init='', poly='5', slicewise='0', laplacian='0', dof='Tx_Ty_Tz_Rx_Ry_Rz', smoothWarpXY='2', pca_eigenratio_th='1.6'):
         self.step = step
         self.type = type
         self.algo = algo
@@ -270,7 +270,7 @@ def main(args=None):
     # get default registration parameters
     # step1 = Paramreg(step='1', type='im', algo='syn', metric='MI', iter='5', shrink='1', smooth='0', gradStep='0.5')
     step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5', slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
-    step1 = Paramreg()
+    step1 = Paramreg(step='1', type='im')
     paramreg = ParamregMultiStep([step0, step1])
 
     parser = get_parser(paramreg=paramreg)


### PR DESCRIPTION
Related to issue #1034 : 
     - keep a param by default with `step=0,[...]:step=1,[...]` (when the user **doesn't** set the flag -param)
     - force `step=x` to be mandatory (when the user **does** set the flag -param) 
