### PR TITLE
OPT: utils: use printv to avoid color markers printout

### DIFF
--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -76,10 +76,10 @@ def run_old(cmd, verbose=1):
 
 
 def run(cmd, verbose=1, error_exit='error', raise_exception=False):
-    if verbose==2:
-        printv(sys._getframe().f_back.f_code.co_name, 1, 'process')
+    # if verbose == 2:
+    #     printv(sys._getframe().f_back.f_code.co_name, 1, 'process')
     if verbose:
-        print(bcolors.blue+cmd+bcolors.normal)
+        printv(cmd, 1, 'process')
     process = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output_final = ''
     while True:


### PR DESCRIPTION
fixes issue #1035 