### PR TITLE
Display results of isct_test_function

### DIFF
--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -436,9 +436,10 @@ if __name__ == "__main__":
         if verbose == '2':
             import seaborn as sns
             import matplotlib.pyplot as plt
-            from numpy import asarray 
+            from numpy import asarray
 
-            fig, ax = plt.subplots(1, len(results_display.keys()) - 2, gridspec_kw={'wspace': 1})
+            n_plots = len(results_display.keys()) - 2
+            fig, ax = plt.subplots(1, n_plots, gridspec_kw={'wspace': 1}, figsize=(n_plots*4, 15))
             sns.set(style="whitegrid", color_codes=True, font_scale=1)
             i = 0
             ax_array = asarray(ax)
@@ -449,9 +450,10 @@ if __name__ == "__main__":
                         a = ax
                     else:
                         a = ax[i]
-                    sns.violinplot(x='status', y=key, data=results_display, ax=a, inner="quartile", cut=0,
-                                   scale="count", color='lightsteelblue')
-                    sns.swarmplot(x='status', y=key, data=results_display, ax=a, color='dimgrey')
+                    data_passed = results_display[results_display['status']==0]
+                    sns.violinplot(x='status', y=key, data=data_passed, ax=a, inner="quartile", cut=0,
+                                   scale="count", color='lightgray')
+                    sns.swarmplot(x='status', y=key, data=data_passed, ax=a, color='0.3', size=4)
                     i += 1
             if ax_array.size == 1:
                 ax.set_xlabel(ax.get_ylabel())

--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -439,8 +439,8 @@ if __name__ == "__main__":
             from numpy import asarray
 
             n_plots = len(results_display.keys()) - 2
-            fig, ax = plt.subplots(1, n_plots, gridspec_kw={'wspace': 1}, figsize=(n_plots*4, 15))
             sns.set_style("whitegrid")
+            fig, ax = plt.subplots(1, n_plots, gridspec_kw={'wspace': 1}, figsize=(n_plots*4, 15))
             i = 0
             ax_array = asarray(ax)
 

--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -440,7 +440,7 @@ if __name__ == "__main__":
 
             n_plots = len(results_display.keys()) - 2
             fig, ax = plt.subplots(1, n_plots, gridspec_kw={'wspace': 1}, figsize=(n_plots*4, 15))
-            sns.set(style="whitegrid", color_codes=True, font_scale=1)
+            sns.set_style("whitegrid")
             i = 0
             ax_array = asarray(ax)
 

--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -433,6 +433,37 @@ if __name__ == "__main__":
         print results_display.to_string()
         print 'Status: 0: Passed | 1: Crashed | 99: Failed | 200: Input file(s) missing | 201: Ground-truth file(s) missing'
 
+        if verbose == '2':
+            import seaborn as sns
+            import matplotlib.pyplot as plt
+            from numpy import asarray 
+
+            fig, ax = plt.subplots(1, len(results_display.keys()) - 2, gridspec_kw={'wspace': 1})
+            sns.set(style="whitegrid", color_codes=True, font_scale=1)
+            i = 0
+            ax_array = asarray(ax)
+
+            for key in results_display.keys():
+                if key not in ['status', 'subject']:
+                    if ax_array.size == 1:
+                        a = ax
+                    else:
+                        a = ax[i]
+                    sns.violinplot(x='status', y=key, data=results_display, ax=a, inner="quartile", cut=0,
+                                   scale="count", color='lightsteelblue')
+                    sns.swarmplot(x='status', y=key, data=results_display, ax=a, color='dimgrey')
+                    i += 1
+            if ax_array.size == 1:
+                ax.set_xlabel(ax.get_ylabel())
+                ax.set_ylabel('')
+            else:
+                for a in ax:
+                    a.set_xlabel(a.get_ylabel())
+                    a.set_ylabel('')
+            plt.savefig('fig_' + file_log + '.png', bbox_inches='tight', pad_inches=0.5)
+            plt.close()
+
+
     except Exception as err:
         print err
 

--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -316,7 +316,7 @@ if __name__ == "__main__":
         email, passwd = arguments['-email'].split(',')
     else:
         email = ''
-    verbose = arguments["-v"]
+    verbose = int(arguments["-v"])
 
     # start timer
     start_time = time()
@@ -433,7 +433,7 @@ if __name__ == "__main__":
         print results_display.to_string()
         print 'Status: 0: Passed | 1: Crashed | 99: Failed | 200: Input file(s) missing | 201: Ground-truth file(s) missing'
 
-        if verbose == '2':
+        if verbose == 2:
             import seaborn as sns
             import matplotlib.pyplot as plt
             from numpy import asarray


### PR DESCRIPTION
With `-v 2` the results of `isct_test_function` are represented with a violin plot. 
The distribution of all metrics is plotted, if no metrics are outputted with a test, only the processing time is plotted. 

--> This will be useful to compare results of two branches (for example as in issue #1059) 

Example of result for `sct_segment_graymatter` on `sct_testing/large`:
![fig_results_test_sct_segment_graymatter_170118155037](https://cloud.githubusercontent.com/assets/5857909/22112101/c8ed3870-de2f-11e6-8854-102097df6869.png)

Example of result for `sct_propseg` on the t2s of 4 subjects : 

![fig_results_test_sct_propseg_170119102821](https://cloud.githubusercontent.com/assets/5857909/22112770/3c396f5e-de32-11e6-9ad8-e34368f34a09.png)

