### PR TITLE
[sct_segment_graymatter] correct background value

### DIFF
--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -421,6 +421,10 @@ class SegmentGM:
             list_dic_slices = [self.model.slices[j] for j in list_dic_indexes_by_slice[target_slice.id]]
             # average slices GM and WM
             data_mean_gm, data_mean_wm = average_gm_wm(list_dic_slices)
+            # set negative values to 0
+            data_mean_gm[data_mean_gm < 0] = 0
+            data_mean_wm[data_mean_wm < 0] = 0
+
             if self.param_seg.type_seg == 'bin':
                 # binarize GM seg
                 data_mean_gm[data_mean_gm >= 0.5] = 1


### PR DESCRIPTION
Bug was that background value of WM segmentation was not null, inducing a bias when computing WM CSA. 
--> Bug occurred during the interpolation of WM segmentation back into the native image space.
--> Corrected by setting negative values to zero right after the label fusion (only very few voxels had negative values).