### PR TITLE
Downloading the binaries using the python module instead of CURL

### DIFF
--- a/install/requirements/requirementsPip.txt
+++ b/install/requirements/requirementsPip.txt
@@ -1,3 +1,4 @@
 nipy==0.4.0
 nibabel==2.1.0
 dipy==0.11.0
+requests[security]==2.12.4

--- a/install_sct
+++ b/install_sct
@@ -332,7 +332,7 @@ if [ ! -f "version.txt" ]; then
   exit 1
 fi
 
-# Create launchers for Python scripts
+## Create launchers for Python scripts
 echo -e "\nCreate launchers for Python scripts"
 cmd="mkdir -p ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
 # update_bin has to be executed from the install directory
@@ -340,27 +340,7 @@ cmd="cd ${SCT_DIR}/install"; echo ">> "$cmd; $cmd
 cmd="./update_bin.sh"; echo ">> "$cmd; $cmd  # N.B. This script needs to be run from /install folder (because uses relative path)
 # Copy binaries
 
-if [ ${NO_SCT_BIN_INSTALL} ]; then
-  echo "SCT binaries will not be (re)-install"
-elif [ ${OFFLINE_INSTALL} ]; then
-  cmd="tar -C ${SCT_DIR}/${BIN_DIR} -zxvf ${SCT_SOURCE}/offline/sct_binaries_${OS}.tar.gz"; echo ">> "$cmd; $cmd
-else
-  echo -e "\nInstalling binaries..."
-  if [ $OS == "linux" ]; then
-    download ${TMP_DIR}/sct_binaries.tar.gz https://osf.io/2pztn/?action=download
-  elif [ $OS == "linux_centos6" ]; then
-    download ${TMP_DIR}/sct_binaries.tar.gz https://osf.io/4wbgt/?action=download
-  elif [ $OS == "osx" ]; then
-    download ${TMP_DIR}/sct_binaries.tar.gz https://osf.io/ceg8p/?action=download
-  fi
-  # force disk buffer to refresh
-  ls ${TMP_DIR} > /dev/null
-
-  # unzip binaries
-  cmd="tar -C ${SCT_DIR}/${BIN_DIR} -zxvf ${TMP_DIR}/sct_binaries.tar.gz"; echo ">> "$cmd; $cmd
-fi
-
-# INSTALL PYTHON
+## INSTALL PYTHON
 if [ ${NO_CONDA_INSTALL} ]; then
   echo "python/ will not be (re)-install"
 elif [ ${OFFLINE_INSTALL} ]; then
@@ -443,6 +423,24 @@ else
   fi
 
 fi
+
+## Install binaries
+if [ ${NO_SCT_BIN_INSTALL} ]; then
+    echo "SCT binaries will not be (re)-install"
+elif [ ${OFFLINE_INSTALL} ]; then
+    cmd="tar -C ${SCT_DIR}/${BIN_DIR} -zxvf ${SCT_SOURCE}/offline/sct_binaries_${OS}.tar.gz"; echo ">> "$cmd; $cmd
+else
+    echo -e "\nInstalling binaries..."
+    cmd=". ${SCT_DIR}/${PYTHON_DIR}/bin/activate ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
+    if [ $OS == "linux" ]; then
+        cmd="python ../scripts/sct_download_data.py -d binaries_debian -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
+    elif [ $OS == "linux_centos6" ]; then
+        cmd="python ../scripts/sct_download_data.py -d binaries_centos -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
+    elif [ $OS == "osx" ]; then
+        cmd="python ../scripts/sct_download_data.py -d binaries_osx -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
+    fi
+fi
+
 
 echo -e "All requirements installed!"
 

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -72,7 +72,7 @@ def main():
 
     # use variable "verbose" when calling sct.run for more clarity
     verbose = complete_test
-    
+
     # redirect to log file
     if create_log_file:
         orig_stdout = sys.stdout
@@ -229,7 +229,7 @@ def main():
         install_software = 1
 
     # CHECK EXTERNAL MODULES:
-    
+
     # Check if dipy is installed
     # print_line('Check if dipy ('+dipy_version+') is installed')
     # try:
@@ -315,7 +315,7 @@ def main():
         print "File generated: "+file_log+'\n'
     print ''
     sys.exit(e + install_software)
-    
+
 
 # print without carriage return
 # ==========================================================================================
@@ -331,7 +331,8 @@ def make_dot_lines(string):
     if len(string) < 52:
         dot_lines = '.'*(52 - len(string))
         return dot_lines
-    else: return ''
+    else:
+        return ''
 
 
 def print_ok():
@@ -344,13 +345,12 @@ def print_warning():
 
 def print_fail():
     print "[" + bcolors.FAIL + "FAIL" + bcolors.ENDC + "]"
-    
+
 
 def add_bash_profile(string):
     from os.path import expanduser
     home = expanduser("~")
     with open(home+"/.bash_profile", "a") as file_bash:
-    # with open("test.txt", "a") as file_bash:
         file_bash.write("\n"+string)
 
 
@@ -367,6 +367,7 @@ def get_version_requirements():
     file.close()
     return dict
 
+
 def get_version_requirements_pip():
     status, path_sct = sct.run('echo $SCT_DIR', 0)
     file = open(path_sct+"/install/requirements/requirementsPip.txt")
@@ -376,9 +377,11 @@ def get_version_requirements_pip():
         if line == "":
             break  # OH GOD HELP
         arg = line.split("==")
+        arg[0] = arg[0].split('[')[0]
         dict[arg[0]] = arg[1].rstrip("\n")
     file.close()
     return dict
+
 
 def get_package_version(package_name):
     cmd = "conda list "+package_name

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -1,114 +1,145 @@
 #!/usr/bin/env python
-#########################################################################################
+##############################################################################
 #
 # Download data using http.
 #
-# ---------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Copyright (c) 2015 Polytechnique Montreal <www.neuro.polymtl.ca>
 # Author: Julien Cohen-Adad
 #
 # About the license: see the file LICENSE.TXT
-#########################################################################################
+###############################################################################
 
-import sys
-from os import remove, rename, path
-import urllib2
 import httplib
+import os
+import shutil
+import sys
+import tarfile
 import time
-# from urllib import urlretrieve
+import urllib2
 import zipfile
-from sct_utils import run, printv, check_folder_exist
+
+import requests
+
 from msct_parser import Parser
+from sct_utils import printv
 
 
-# PARSER
-# ==========================================================================================
 def get_parser():
-    # parser initialisation
     parser = Parser(__file__)
-    parser.usage.set_description('''Download dataset from the web.''')
-    parser.add_option(name="-d",
-                      type_value="multiple_choice",
-                      description="Name of the dataset.",
-                      mandatory=True,
-                      example=['sct_example_data', 'sct_testing_data', 'PAM50', 'MNI-Poly-AMU', 'gm_model'])
-    parser.add_option(name="-v",
-                      type_value="multiple_choice",
-                      description="""Verbose. 0: nothing. 1: basic. 2: extended.""",
-                      mandatory=False,
-                      example=['0', '1', '2'])
-    parser.add_option(name="-h",
-                      type_value=None,
-                      description="Display this help",
-                      mandatory=False)
+    parser.usage.set_description('''Download binaries from the web.''')
+    parser.add_option(
+        name="-d",
+        type_value="multiple_choice",
+        description="Name of the dataset.",
+        mandatory=True,
+        example=[
+            'sct_example_data', 'sct_testing_data', 'PAM50', 'MNI-Poly-AMU',
+            'gm_model', 'binaries_debian', 'binaries_centos', 'binaries_osx'
+        ])
+    parser.add_option(
+        name="-v",
+        type_value="multiple_choice",
+        description="Verbose. 0: nothing. 1: basic. 2: extended.",
+        mandatory=False,
+        default_value=1,
+        example=['0', '1', '2'])
+    parser.add_option(
+        name="-o",
+        type_value="folder_creation",
+        description="path to save the downloaded data",
+        mandatory=False)
+    parser.add_option(
+        name="-h",
+        type_value=None,
+        description="Display this help",
+        mandatory=False)
     return parser
 
 
-# MAIN
-# ==========================================================================================
 def main(args=None):
 
     if args is None:
         args = sys.argv[1:]
 
     # initialization
-    verbose = 1
-    dict_url = {'sct_example_data': 'https://osf.io/feuef/?action=download',
-                'sct_testing_data': 'https://osf.io/uqcz5/?action=download',
-                'PAM50': 'https://osf.io/gdwn6/?action=download',
-                'MNI-Poly-AMU': 'https://osf.io/b26vh/?action=download',
-                'gm_model': 'https://osf.io/ugscu/?action=download'}
+    dict_url = {
+        'sct_example_data': 'https://osf.io/feuef/?action=download',
+        'sct_testing_data': 'https://osf.io/uqcz5/?action=download',
+        'PAM50': 'https://osf.io/gdwn6/?action=download',
+        'MNI-Poly-AMU': 'https://osf.io/b26vh/?action=download',
+        'gm_model': 'https://osf.io/ugscu/?action=download',
+        'binaries_debian': 'https://osf.io/2pztn/?action=download',
+        'binaries_centos': 'https://osf.io/4wbgt/?action=download',
+        'binaries_osx': 'https://osf.io/ceg8p/?action=download'
+    }
     tmp_file = 'tmp.data.zip'
 
     # Get parser info
     parser = get_parser()
     arguments = parser.parse(args)
     data_name = arguments['-d']
-    if '-v' in arguments:
-        verbose = int(arguments['-v'])
+    verbose = int(arguments['-v'])
+    dest_folder = arguments.get('-o', os.curdir)
 
     # Download data
     url = dict_url[data_name]
     try:
-        download_from_url(url, tmp_file)
-    except(KeyboardInterrupt):
+        # download_from_url(url, tmp_file)
+        tmp_file = download_data(url, verbose)
+    except (KeyboardInterrupt):
         printv('\nERROR: User canceled process.', 1, 'error')
-    # try:
-    #     printv('\nDownload data from: '+url, verbose)
-    #     urlretrieve(url, tmp_file)
-    #     # Allow time for data to download/save:
-    #     print "hola1"
-    #     time.sleep(0.5)
-    #     print "hola2"
-    # except:
-    #     printv("ERROR: Download Failed.", verbose, 'error')
 
-    # Check if folder already exists
-    printv('Check if folder already exists...', verbose)
-    if path.isdir(data_name):
-        printv('.. WARNING: Folder '+data_name+' already exists. Removing it...', 1, 'warning')
-        run('rm -rf '+data_name, 0)
+    unzip(tmp_file, dest_folder, verbose)
 
-    # unzip
-    printv('Unzip dataset...', verbose)
-    try:
-        zf = zipfile.ZipFile(tmp_file)
-        zf.extractall()
-    except (zipfile.BadZipfile):
-        printv('\nERROR: ZIP package corrupted. Please try downloading again.', verbose, 'error')
-
-    # if downloaded from GitHub, need to remove the "-master" suffix
-    if 'master.zip' in url:
-        printv('Rename folder...', verbose)
-        rename(data_name+'-master', data_name)
-
-    # remove zip file
     printv('Remove temporary file...', verbose)
-    remove(tmp_file)
+    os.remove(tmp_file)
 
-    # display stuff
-    printv('Done! Folder created: '+data_name+'\n', verbose, 'info')
+    printv('Done! Folder created: ' + dest_folder + '\n', verbose, 'info')
 
+
+def unzip(compressed, dest_folder, verbose):
+    """Extract compressed file to the dest_folder"""
+    printv('Unzip dataset...', verbose)
+    if compressed.endswith('zip'):
+        try:
+            zf = zipfile.ZipFile(compressed)
+            zf.extractall(dest_folder)
+            return
+        except (zipfile.BadZipfile):
+            printv(
+                'ERROR: ZIP package corrupted. Please try downloading again.',
+                verbose, 'error')
+    elif compressed.endswith('tar.gz'):
+        try:
+            tar = tarfile.open(compressed)
+            tar.extractall(path=dest_folder)
+            return
+        except tarfile.TarError:
+            printv('ERROR: ZIP package corrupted. Please try again.',
+                   verbose, 'error')
+    else:
+        printv('ERROR: The file %s is of wrong format' % compressed, verbose,
+               'error')
+
+
+def download_data(url, verbose):
+    """Download the binaries from a URL and return the destination filename"""
+    response = requests.get(url, stream=True)
+    import re
+    import tempfile
+
+    filename = re.findall('filename="?([\w\.]+)"?',
+                          response.headers['Content-Disposition'])
+    tmp_path = os.path.join(tempfile.mkdtemp(), filename[0])
+
+    with open(tmp_path, 'wb') as tmp_file:
+        for chunk in response.iter_content(chunk_size=1024):
+            if chunk:
+                tmp_file.write(chunk)
+
+    printv('Download complete %s' % filename, verbose=verbose)
+    return tmp_path
 
 
 def download_from_url(url, local):
@@ -122,7 +153,7 @@ def download_from_url(url, local):
     i_trial = 1
     max_trials = 3
 
-    print 'Reaching URL: '+url
+    print 'Reaching URL: ' + url
     while keep_connecting:
         try:
             u = urllib2.urlopen(url)
@@ -132,11 +163,12 @@ def download_from_url(url, local):
             printv('\nURLError = ' + str(e.reason), 1, 'error')
         except httplib.HTTPException, e:
             printv('\nHTTPException', 1, 'error')
-        except(KeyboardInterrupt):
+        except (KeyboardInterrupt):
             printv('\nERROR: User canceled process.', 1, 'error')
         except Exception:
             import traceback
-            printv('\nERROR: Cannot open URL: ' + traceback.format_exc(), 1, 'error')
+            printv('\nERROR: Cannot open URL: ' + traceback.format_exc(), 1,
+                   'error')
         h = u.info()
         try:
             totalSize = int(h["Content-Length"])
@@ -144,32 +176,38 @@ def download_from_url(url, local):
         except:
             # if URL was badly reached (issue #895):
             # send warning message
-            printv('\nWARNING: URL cannot be reached. Trying again (maximum trials: '+str(max_trials)+').', 1, 'warning')
+            printv(
+                '\nWARNING: URL cannot be reached. Trying again (maximum trials: '
+                + str(max_trials) + ').', 1, 'warning')
             # pause for 0.5s
             time.sleep(0.5)
             # iterate i_trial and try again
             i_trial += 1
             # if i_trial exceeds max_trials, exit with error
             if i_trial > max_trials:
-                printv('\nERROR: Maximum number of trials reached. Try again later.', 1, 'error')
+                printv(
+                    '\nERROR: Maximum number of trials reached. Try again later.',
+                    1, 'error')
                 keep_connecting = False
 
     print "Downloading %s bytes..." % totalSize,
     fp = open(local, 'wb')
 
-    blockSize = 8192 #100000 # urllib.urlretrieve uses 8192
+    blockSize = 8192
     count = 0
     while True:
         chunk = u.read(blockSize)
-        if not chunk: break
+        if not chunk:
+            break
         fp.write(chunk)
         count += 1
         if totalSize > 0:
             percent = int(count * blockSize * 100 / totalSize)
-            if percent > 100: percent = 100
+            if percent > 100:
+                percent = 100
             print "%2d%%" % percent,
             if percent < 100:
-                print "\b\b\b\b\b",  # Erase "NN% "
+                print "\b\b\b\b\b",
             else:
                 print "Done."
 
@@ -179,9 +217,5 @@ def download_from_url(url, local):
         print
 
 
-
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
-    # call main function
     main()


### PR DESCRIPTION
In some installations, CURL might not be updated, and might not have wget,
downloading from OSF will fail. Instead of using CURL or wget, we will use
the python request module with the security option to download the binaries.

The installation still depends on CURL or wget to download conda, if the
installation of conda fails, we have no other option then to recommend the
user to update their system.

Fixes #1107