### PR TITLE
Improve robustness of segmentation fitting 

### DIFF
--- a/scripts/msct_nurbs.py
+++ b/scripts/msct_nurbs.py
@@ -204,7 +204,7 @@ class NURBS():
                 list_param_that_worked_sorted = sorted(list_param_that_worked, key=lambda list_param_that_worked: list_param_that_worked[2])
                 nbControle_that_last_worked = list_param_that_worked_sorted[0][0]
                 pointsControle_that_last_worked = list_param_that_worked_sorted[0][1]
-                error_curve_that_last_worked = list_param_that_worked_sorted[0][2]
+                self.error_curve_that_last_worked = list_param_that_worked_sorted[0][2]
                 if not twodim:
                     self.courbe3D, self.courbe3D_deriv = self.construct3D_uniform(pointsControle_that_last_worked, self.degre, self.precision)  # generate curve with hig resolution
                 else:
@@ -213,7 +213,7 @@ class NURBS():
 
                 if verbose >= 1:
                     if self.nbControle != nbControle_that_last_worked:
-                        print 'The fitting of the curve was done using ', nbControle_that_last_worked, ' control points: the number that gave the best results. \nError on approximation = ' + str(round(error_curve_that_last_worked, 2)) + ' mm'
+                        print 'The fitting of the curve was done using ', nbControle_that_last_worked, ' control points: the number that gave the best results. \nError on approximation = ' + str(round(self.error_curve_that_last_worked, 2)) + ' mm'
                     else:
                         print 'Number of control points of the optimal NURBS = ' + str(self.nbControle)
             else:

--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -366,9 +366,9 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.show()
 
     if not twodim:
-        return x_fit, y_fit, z_fit, x_deriv, y_deriv, z_deriv
+        return x_fit, y_fit, z_fit, x_deriv, y_deriv, z_deriv, nurbs.error_curve_that_last_worked
     else:
-        return x_fit, y_fit, x_deriv, y_deriv
+        return x_fit, y_fit, x_deriv, y_deriv, nurbs.error_curve_that_last_worked
 
 
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -513,34 +513,35 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
         data[X[k], Y[k], Z[k]] = 0
 
     # extract centerline and smooth it
-    x_centerline_fit, y_centerline_fit, z_centerline_fit, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', type_window = type_window, window_length = window_length, algo_fitting = algo_fitting, verbose = verbose)
+    x_centerline_fit, y_centerline_fit, z_centerline_fit, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', type_window=type_window, window_length=window_length, algo_fitting=algo_fitting, all_slices=True, verbose=verbose)
+
 
     if verbose == 2:
-            import matplotlib.pyplot as plt
+        import matplotlib.pyplot as plt
 
-            #Creation of a vector x that takes into account the distance between the labels
-            nz_nonz = len(z_centerline)
-            x_display = [0 for i in range(x_centerline_fit.shape[0])]
-            y_display = [0 for i in range(y_centerline_fit.shape[0])]
-            for i in range(0, nz_nonz, 1):
-                x_display[int(z_centerline[i]-z_centerline[0])] = x_centerline[i]
-                y_display[int(z_centerline[i]-z_centerline[0])] = y_centerline[i]
+        #Creation of a vector x that takes into account the distance between the labels
+        nz_nonz = len(z_centerline)
+        x_display = [0 for i in range(x_centerline_fit.shape[0])]
+        y_display = [0 for i in range(y_centerline_fit.shape[0])]
+        for i in range(0, nz_nonz, 1):
+            x_display[int(z_centerline[i]-z_centerline[0])] = x_centerline[i]
+            y_display[int(z_centerline[i]-z_centerline[0])] = y_centerline[i]
 
-            plt.figure(1)
-            plt.subplot(2,1,1)
-            plt.plot(z_centerline_fit, x_display, 'ro')
-            plt.plot(z_centerline_fit, x_centerline_fit)
-            plt.xlabel("Z")
-            plt.ylabel("X")
-            plt.title("x and x_fit coordinates")
+        plt.figure(1)
+        plt.subplot(2,1,1)
+        plt.plot(z_centerline_fit, x_display, 'ro')
+        plt.plot(z_centerline_fit, x_centerline_fit)
+        plt.xlabel("Z")
+        plt.ylabel("X")
+        plt.title("x and x_fit coordinates")
 
-            plt.subplot(2,1,2)
-            plt.plot(z_centerline_fit, y_display, 'ro')
-            plt.plot(z_centerline_fit, y_centerline_fit)
-            plt.xlabel("Z")
-            plt.ylabel("Y")
-            plt.title("y and y_fit coordinates")
-            plt.show()
+        plt.subplot(2,1,2)
+        plt.plot(z_centerline_fit, y_display, 'ro')
+        plt.plot(z_centerline_fit, y_centerline_fit)
+        plt.xlabel("Z")
+        plt.ylabel("Y")
+        plt.title("y and y_fit coordinates")
+        plt.show()
 
     # Create an image with the centerline
     min_z_index, max_z_index = int(round(min(z_centerline_fit))), int(round(max(z_centerline_fit)))

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -154,8 +154,19 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
         # simple way to do it: go from one end and remove point if the distance from mean is higher than 2 * std
 
         x_centerline_fit, y_centerline_fit, z_centerline_fit, x_centerline_deriv, y_centerline_deriv,\
-            z_centerline_deriv = b_spline_nurbs(x_centerline, y_centerline, z_centerline, nbControl=None,
+            z_centerline_deriv, mse = b_spline_nurbs(x_centerline, y_centerline, z_centerline, nbControl=None,
                                                 point_number=nurbs_pts_number, verbose=verbose, all_slices=all_slices)
+
+        # Checking accuracy of fitting. If NURBS fitting is not accurate enough, do not smooth segmentation
+        if mse >= 5.0:
+            x_centerline_fit = x_centerline
+            y_centerline_fit = y_centerline
+            z_centerline_fit = z_centerline
+            # get derivative
+            x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = evaluate_derivative_3D(x_centerline_fit,
+                                                                                                y_centerline_fit,
+                                                                                                z_centerline_fit,
+                                                                                                px, py, pz)
 
     else:
         sct.printv("ERROR: wrong algorithm for fitting", 1, "error")


### PR DESCRIPTION
I added some checking for accuracy on centreline fitting, particularly for NURBS fitting. When the fitting is not accurate enough (threshold arbitrarily set to 5 mm (or pixel)), the segmentation is not fitted (the derivative is computed directly on the segmentation center of mass per slices.

Note that this is a convenient fix for issue #1118 but all functions related to fitting, centerline and smoothing should be refactored as many temporary rules have added in the code over time.