### PR TITLE
Correct type of list output 

### DIFF
--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -159,9 +159,9 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
 
         # Checking accuracy of fitting. If NURBS fitting is not accurate enough, do not smooth segmentation
         if mse >= 2.0:
-            x_centerline_fit = x_centerline
-            y_centerline_fit = y_centerline
-            z_centerline_fit = z_centerline
+            x_centerline_fit = np.asarray(x_centerline)
+            y_centerline_fit = np.asarray(y_centerline)
+            z_centerline_fit = np.asarray(z_centerline)
             # get derivative
             x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = evaluate_derivative_3D(x_centerline_fit,
                                                                                                 y_centerline_fit,


### PR DESCRIPTION
Bug appeared in `sct_process_segmentation` using `-p csa`: 
![capture d ecran 2017-02-06 09 31 06](https://cloud.githubusercontent.com/assets/5857909/22650897/05042f3a-ec4f-11e6-80dd-698278540408.png)

--> Due to the nurbs fitting of centerline in `sct_straighten_spinalcord`: when the nurbs fitting is not accurate enough (MSE too high), the fitting results are not used and the original centerline coordinates are kept as a list instead of a numpy array. 
--> This caused `sct_process_segmentation` to fail when using the centerline coordinates as a numpy array. 
