### PR TITLE
Improvements of viewer with sct_propseg

### DIFF
--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -61,7 +61,6 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, thresho
     # extraction of centerline provided by isct_propseg and computation of center of mass for each slice
     # the centerline is defined as the center of the tubular mesh outputed by propseg.
     centerline, key_centerline = {}, []
-    z_centerline = []
     for i in range(nz):
         slice = im_centerline.data[:, :, i]
         if np.any(slice):
@@ -72,7 +71,6 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, thresho
     minz_centerline = np.min(key_centerline)
     maxz_centerline = np.max(key_centerline)
     mid_slice = int((maxz_centerline - minz_centerline) / 2)
-    nb_slices = maxz_centerline - minz_centerline + 1
 
     # for each slice of the segmentation, check if only one object is present. If not, remove the slice from segmentation.
     # If only one object (the spinal cord) is present in the slice, check if its center of mass is close to the centerline of isct_propseg.

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -298,7 +298,8 @@ if __name__ == "__main__":
     parser = get_parser()
     arguments = parser.parse(sys.argv[1:])
 
-    fname_data = os.path.abspath(arguments["-i"])
+    fname_input_data = arguments["-i"]
+    fname_data = os.path.abspath(fname_input_data)
     contrast_type = arguments["-c"]
 
     # Building the command
@@ -469,4 +470,4 @@ if __name__ == "__main__":
             shutil.rmtree(path_tmp_viewer, ignore_errors=True)
 
     sct.printv('\nDone! To view results, type:', verbose)
-    sct.printv("fslview "+fname_data+" "+fname_seg+" -l Red -b 0,1 -t 0.7 &\n", verbose, 'info')
+    sct.printv("fslview " + fname_input_data + " " + fname_seg + " -l Red -b 0,1 -t 0.7 &\n", verbose, 'info')

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -61,6 +61,7 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, thresho
     # extraction of centerline provided by isct_propseg and computation of center of mass for each slice
     # the centerline is defined as the center of the tubular mesh outputed by propseg.
     centerline, key_centerline = {}, []
+    z_centerline = []
     for i in range(nz):
         slice = im_centerline.data[:, :, i]
         if np.any(slice):
@@ -68,10 +69,15 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, thresho
             centerline[str(i)] = [x_centerline, y_centerline]
             key_centerline.append(i)
 
+    minz_centerline = np.min(key_centerline)
+    maxz_centerline = np.max(key_centerline)
+    mid_slice = int((maxz_centerline - minz_centerline) / 2)
+    nb_slices = maxz_centerline - minz_centerline + 1
+
     # for each slice of the segmentation, check if only one object is present. If not, remove the slice from segmentation.
     # If only one object (the spinal cord) is present in the slice, check if its center of mass is close to the centerline of isct_propseg.
     slices_to_remove = [False] * nz  # flag that decides if the slice must be removed
-    for i in range(nz):
+    for i in range(minz_centerline, maxz_centerline+1):
         # extraction of slice
         slice = im_seg.data[:, :, i]
         distance = -1
@@ -93,21 +99,21 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, thresho
     # Method:
     # starting from mid-centerline (in both directions), the first True encountered is applied to all following slices
     slice_to_change = False
-    for i in range(nz / 2, nz):
+    for i in range(mid_slice, maxz_centerline):
         if slice_to_change:
             slices_to_remove[i] = True
         elif slices_to_remove[i]:
             slices_to_remove[i] = True
             slice_to_change = True
     slice_to_change = False
-    for i in range(nz / 2, -1, -1):
+    for i in range(mid_slice, minz_centerline-1, -1):
         if slice_to_change:
             slices_to_remove[i] = True
         elif slices_to_remove[i]:
             slices_to_remove[i] = True
             slice_to_change = True
 
-    for i in range(nz):
+    for i in range(mid_slice, maxz_centerline):
         # remove the slice
         if slices_to_remove[i]:
             im_seg.data[:, :, i] *= 0
@@ -411,13 +417,25 @@ if __name__ == "__main__":
         viewer = ClickViewer(image_input_reoriented)
         viewer.help_url = 'https://sourceforge.net/p/spinalcordtoolbox/wiki/correction_PropSeg/attachment/propseg_viewer.png'
         if use_viewer == "mask":
+            viewer.input_type = 'mask'
             viewer.number_of_slices = 3
             viewer.gap_inter_slice = int(10 / pz)
             if viewer.gap_inter_slice == 0:
                 viewer.gap_inter_slice = 1
-            viewer.calculate_list_slices()
-        #else:
-        #    viewer.gap_inter_slice = 3
+
+            if '-init' in arguments:
+                starting_slice = arguments['-init']
+
+                # starting_slice can be provided as a ratio of the number of slices
+                # we assume slice number/ratio is in RPI orientation, which is the inverse of the one used in viewer (SAL)
+                if 0 < starting_slice < 1:
+                    starting_slice = int((1.0 - starting_slice) * image_input_reoriented.data.shape[0])
+                else:
+                    starting_slice = image_input_reoriented.data.shape[0] - starting_slice
+
+                viewer.calculate_list_slices(starting_slice=starting_slice)
+            else:
+                viewer.calculate_list_slices()
 
         # start the viewer that ask the user to enter a few points along the spinal cord
         mask_points = viewer.start()

--- a/scripts/sct_viewer.py
+++ b/scripts/sct_viewer.py
@@ -488,7 +488,7 @@ class ClickViewer(Viewer):
     Assumes SAL orientation
     orientation_subplot: list of two views that will be plotted next to each other. The first view is the main one (right) and the second view is the smaller one (left). Orientations are: ax, sag, cor.
     """
-    def __init__(self, list_images, visualization_parameters=None, orientation_subplot=['ax', 'sag'], title=''):
+    def __init__(self, list_images, visualization_parameters=None, orientation_subplot=['ax', 'sag'], title='', input_type='centerline'):
         self.orientation = {'ax': 1, 'cor': 2, 'sag': 3}
         if isinstance(list_images, Image):
             list_images = [list_images]
@@ -563,11 +563,18 @@ class ClickViewer(Viewer):
         self.fig.canvas.mpl_connect('close_event', self.close_window)
         self.closed = False
 
-    def calculate_list_slices(self):
+        self.input_type = input_type
+
+    def calculate_list_slices(self, starting_slice=-1):
         if self.number_of_slices != 0 and self.gap_inter_slice != 0:  # mode multiple points with fixed gap
-            central_slice = int(self.image_dim[self.orientation[self.primary_subplot]-1] / 2)
-            first_slice = central_slice - (self.number_of_slices / 2) * self.gap_inter_slice
-            last_slice = central_slice + (self.number_of_slices / 2) * self.gap_inter_slice
+
+            # if starting slice is not provided, middle slice is used
+            # starting slice must be an integer, in the range of the image [0, #slices]
+            if starting_slice == -1:
+                starting_slice = int(self.image_dim[self.orientation[self.primary_subplot]-1] / 2)
+
+            first_slice = starting_slice - (self.number_of_slices / 2) * self.gap_inter_slice
+            last_slice = starting_slice + (self.number_of_slices / 2) * self.gap_inter_slice
             if first_slice < 0:
                 first_slice = 0
             if last_slice >= self.image_dim[self.orientation[self.primary_subplot]-1]:
@@ -697,7 +704,8 @@ class ClickViewer(Viewer):
             if not is_in_axes:
                 return
 
-            self.enable_custom_points = True
+            if self.input_type == 'centerline':
+                self.enable_custom_points = True
 
             title_obj = self.windows[0].axes.set_title('Automatic sliding disabled\nPlease click on spinal cord center\nand close the window once finished\n(# points = ' + str(len(self.list_points)) + ')')
             plt.setp(title_obj, color='k')


### PR DESCRIPTION
This Pull Request made improvements on `sct_viewer` and `sct_propseg`.

1. The viewer when initializing `sct_propseg` with a three-point mask not allows to select the central slice with the `-init` option. The number of the mid-slice is assumed in the RPI orientation, even though the visualization is made in SLA orientation. That means that the slice "20" is the 20th slice from the bottom of the image (direction inferior --> superior).
This fixes issue #1125 

2. fixed a bug on the function `check_and_correct_segmentation` called at the end of `sct_propseg`. It now allows the correction on the real centerline, even if it has a small coverage of the image.
This fixes issue #1166 