### PR TITLE
OPT: display mean and std instead of mean twice

### DIFF
--- a/scripts/isct_test_function.py
+++ b/scripts/isct_test_function.py
@@ -405,7 +405,7 @@ if __name__ == "__main__":
         # results_display = results_display.append(results_mean, ignore_index=True)
 
         # std
-        results_std = results_subset.query('status != 200 & status != 201').mean(numeric_only=True)
+        results_std = results_subset.query('status != 200 & status != 201').std(numeric_only=True)
         results_std['subject'] = 'STD'
         results_std.set_value('status', float('NaN'))  # set status to NaN
         # results_display = results_display.append(results_std, ignore_index=True)


### PR DESCRIPTION
In the results display at the end of `isct_test_function` the mean was shown a second time instead of the standard deviation.