### PR TITLE
Fix the handling of the path of the QC report.

### DIFF
--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -54,9 +54,10 @@ if __name__ == "__main__":
                ' This is not a proper QC folder', type='error')
         sys.exit(-1)
 
-    os.chdir(qc_path)
+    qc_path = os.path.realpath(qc_path)
     _copy_assets(qc_path)
 
+    os.chdir(qc_path)
     httpd = HTTPServer(('', 8888), SimpleHTTPRequestHandler)
     printv('QC viewer started on:')
     printv('http://127.0.0.1:8888', type='info')


### PR DESCRIPTION
Changing the path before copying the assets was calculating the path
incorrectly.

Fixes #1278