### PR TITLE
Incorrect variable when installing SCT in a different directory

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -426,7 +426,7 @@ fi
 
 
 ## Install the spinalcordtoolbox into conda
-pip install -e ${SCT_DIR}
+pip install -e ${SCT_SOURCE}
 
 
 ## Install binaries


### PR DESCRIPTION
The variable SCT_SOURCE is the path of the spinalcordtoolbox while SCT_DIR
is the destination directory.

Fixes #1288