### PR TITLE
Rework for the remaining time display (pull-request #1299)

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -160,6 +160,8 @@ def download_data(url, verbose):
                     dl_chunk = len(chunk)
                     tqdm_bar.update(dl_chunk)
 
+        tqdm_bar.close()
+
     sct.printv('\nDownload complete', verbose=verbose)
     return tmp_path
 


### PR DESCRIPTION
This is a rework of the PR #1299, ref. issue #1298.
Fixed the issue with the "download complete" message appearing before `tqdm` flush buffers.