### PR TITLE
Introducing spinal cord shape symmetry

### DIFF
--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -276,7 +276,8 @@ def compute_shape(fname_segmentation, remove_temp_files, output_folder, overwrit
                      'equivalent_diameter',
                      'ratio_minor_major',
                      'eccentricity',
-                     'solidity']
+                     'solidity',
+                     'symmetry']
 
     property_list, shape_properties = msct_shape.compute_properties_along_centerline(fname_seg_image=fname_segmentation,
                                                                                      property_list=property_list,


### PR DESCRIPTION
The spinal cord shape symmetry feature is available as part of `sct_process_segmentation -p shape`. As represented on the image below, the shape symmetry is computed by flipping the right half of the spinal cord segmentation on the left half and computing their dice coefficient (values between 0 and 1, 1 representing perfect symmetry), while taking into account the spinal cord rotation.

![assymetry](https://cloud.githubusercontent.com/assets/7757117/26130401/83e90e40-3a62-11e7-91e2-36d861b447c4.png)
Credit: Allan R. Martin

Related to issue #1030.