### PR TITLE
Generation of centerline as ROI

### DIFF
--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -31,6 +31,13 @@ def run_main():
                       example="My_Output_Folder/",
                       default_value="")
 
+    parser.add_option(name="-roi",
+                      type_value="multiple_choice",
+                      description="outputs a ROI file, compatible with JIM software.",
+                      mandatory=False,
+                      example=['0', '1'],
+                      default_value='0')
+
     parser.add_option(name="-r",
                       type_value="multiple_choice",
                       description="remove temporary files.",
@@ -66,6 +73,11 @@ def run_main():
     if "-r" in arguments:
         remove_temp_files = bool(arguments["-r"])
 
+    # Outputs a ROI file
+    output_roi = False
+    if "-roi" in arguments:
+        output_roi = bool(arguments["-roi"])
+
     # Verbosity
     verbose = 0
     if "-v" in arguments:
@@ -80,9 +92,13 @@ def run_main():
                                    '{}_model'.format(contrast_type))
 
     # Execute OptiC binary
-    _, optic_filename = optic.detect_centerline(fname_data, contrast_type, 
-                                                optic_models_path, folder_output,
-                                                remove_temp_files, verbose)
+    _, optic_filename = optic.detect_centerline(image_fname=fname_data,
+                                                contrast_type=contrast_type,
+                                                optic_models_path=optic_models_path,
+                                                folder_output=folder_output,
+                                                remove_temp_files=remove_temp_files,
+                                                output_roi=output_roi,
+                                                verbose=verbose)
 
     sct.printv('\nDone! To view results, type:', verbose)
     sct.printv("fslview " + fname_input_data + " " + optic_filename + " -l Red -b 0,1 -t 0.7 &\n",

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -598,7 +598,7 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
     f = open('centerline.roi', "w")
     sct.printv('\nWrite ROI file...', verbose)
     for i in range(min_z_index, max_z_index + 1):
-        coord_phys_center = im_seg.transfo_pix2phys([[(nx-1)/ 2.0, (ny-1) / 2.0, int(i)]])[0]
+        coord_phys_center = im_seg.transfo_pix2phys([[(nx-1) / 2.0, (ny-1) / 2.0, int(i)]])[0]
         coord_phys = im_seg.transfo_pix2phys([[x_centerline_voxel[i - min_z_index], y_centerline_voxel[i - min_z_index], int(i)]])[0]
         f.write(common_text_start)
         # JIM coordinate system is centered at the center of the image (per slice) and X and Y are inversed

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -595,25 +595,6 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
                                                 folder_output='./',
                                                 verbose=verbose)
 
-    """
-    from datetime import datetime
-    date_now = datetime.now()
-    common_text_start = 'Begin Marker ROI\n  Build version="7.0_33"\n  Annotation=""\n  Colour=0\n  Image source="' + fname_segmentation + '"\n  Created  "' + date_now.strftime("%d %B %Y %H:%M:%S.%f %Z") + '" by Operator ID="SCT"\n'
-    common_text_end = 'End Marker ROI\n'
-
-    f = open('centerline.roi', "w")
-    sct.printv('\nWrite ROI file...', verbose)
-    for i in range(min_z_index, max_z_index + 1):
-        coord_phys_center = im_seg.transfo_pix2phys([[(nx-1) / 2.0, (ny-1) / 2.0, int(i)]])[0]
-        coord_phys = im_seg.transfo_pix2phys([[x_centerline_voxel[i - min_z_index], y_centerline_voxel[i - min_z_index], int(i)]])[0]
-        f.write(common_text_start)
-        # JIM coordinate system is centered at the center of the image (per slice) and X and Y are inversed
-        text = '  Slice=' + str(int(i+1)) + '\n  Begin Shape\n    X=' + str(coord_phys_center[0] - coord_phys[0]) + '; Y=' + str(coord_phys_center[1] - coord_phys[1]) + '\n  End Shape\n'
-        f.write(text)
-        f.write(common_text_end)
-    f.close()
-    """
-
     # come back to parent folder
     os.chdir('..')
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -589,6 +589,24 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
         file_results.write(str(int(i)) + ' ' + str(x_centerline_voxel[i - min_z_index]) + ' ' + str(y_centerline_voxel[i - min_z_index]) + '\n')
     file_results.close()
 
+    # create a .roi file
+    from datetime import datetime
+    date_now = datetime.now()
+    common_text_start = 'Begin Marker ROI\n  Build version="7.0_33"\n  Annotation=""\n  Colour=0\n  Image source="' + fname_segmentation + '"\n  Created  "' + date_now.strftime("%d %B %Y %H:%M:%S.%f %Z") + '" by Operator ID="SCT"\n'
+    common_text_end = 'End Marker ROI\n'
+
+    f = open('centerline.roi', "w")
+    sct.printv('\nWrite ROI file...', verbose)
+    for i in range(min_z_index, max_z_index + 1):
+        coord_phys_center = im_seg.transfo_pix2phys([[(nx-1)/ 2.0, (ny-1) / 2.0, int(i)]])[0]
+        coord_phys = im_seg.transfo_pix2phys([[x_centerline_voxel[i - min_z_index], y_centerline_voxel[i - min_z_index], int(i)]])[0]
+        f.write(common_text_start)
+        # JIM coordinate system is centered at the center of the image (per slice) and X and Y are inversed
+        text = '  Slice=' + str(int(i+1)) + '\n  Begin Shape\n    X=' + str(coord_phys_center[0] - coord_phys[0]) + '; Y=' + str(coord_phys_center[1] - coord_phys[1]) + '\n  End Shape\n'
+        f.write(text)
+        f.write(common_text_end)
+    f.close()
+
     # come back to parent folder
     os.chdir('..')
 
@@ -596,6 +614,7 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
     sct.printv('\nGenerate output files...', verbose)
     sct.generate_output_file(path_tmp + 'centerline.nii.gz', file_data + '_centerline.nii.gz')
     sct.generate_output_file(path_tmp + 'centerline.txt', file_data + '_centerline.txt')
+    sct.generate_output_file(path_tmp + 'centerline.roi', file_data + '_centerline.roi')
 
     # Remove temporary files
     if remove_temp_files:

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -31,6 +31,7 @@ from msct_parser import Parser
 import msct_shape
 import pandas as pd
 from msct_types import Centerline
+from spinalcordtoolbox.centerline import optic
 
 
 class Param:
@@ -590,6 +591,11 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
     file_results.close()
 
     # create a .roi file
+    fname_roi_centerline = optic.centerline2roi(fname_image='centerline_RPI.nii.gz',
+                                                folder_output='./',
+                                                verbose=verbose)
+
+    """
     from datetime import datetime
     date_now = datetime.now()
     common_text_start = 'Begin Marker ROI\n  Build version="7.0_33"\n  Annotation=""\n  Colour=0\n  Image source="' + fname_segmentation + '"\n  Created  "' + date_now.strftime("%d %B %Y %H:%M:%S.%f %Z") + '" by Operator ID="SCT"\n'
@@ -606,6 +612,7 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
         f.write(text)
         f.write(common_text_end)
     f.close()
+    """
 
     # come back to parent folder
     os.chdir('..')
@@ -614,7 +621,7 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
     sct.printv('\nGenerate output files...', verbose)
     sct.generate_output_file(path_tmp + 'centerline.nii.gz', file_data + '_centerline.nii.gz')
     sct.generate_output_file(path_tmp + 'centerline.txt', file_data + '_centerline.txt')
-    sct.generate_output_file(path_tmp + 'centerline.roi', file_data + '_centerline.roi')
+    sct.generate_output_file(path_tmp + fname_roi_centerline, file_data + '_centerline.roi')
 
     # Remove temporary files
     if remove_temp_files:

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -11,6 +11,58 @@ from datetime import datetime
 from string import Template
 
 
+def centerline2roi(fname_image, folder_output='./', verbose=0):
+    """
+    Tis method converts a binary centerline image to a .roi centerline file
+
+    Args:
+        fname_image: filename of the binary centerline image, in RPI orientation
+        folder_output: path to output folder where to copy .roi centerline
+        verbose: adjusts the verbosity of the logging.
+
+    Returns: filename of the .roi centerline that has been created
+
+    """
+    path_data, file_data, ext_data = sct.extract_fname(fname_image)
+    fname_output = file_data + '.roi'
+
+    date_now = datetime.now()
+    ROI_TEMPLATE = 'Begin Marker ROI\n' \
+                   '  Build version="7.0_33"\n' \
+                   '  Annotation=""\n' \
+                   '  Colour=0\n' \
+                   '  Image source="{fname_segmentation}"\n' \
+                   '  Created  "{creation_date}" by Operator ID="SCT"\n' \
+                   '  Slice={slice_num}\n' \
+                   '  Begin Shape\n' \
+                   '    X={position_x}; Y={position_y}\n' \
+                   '  End Shape\n' \
+                   'End Marker ROI\n'
+
+    im = Image(fname_image)
+    nx, ny, nz, nt, px, py, pz, pt = im.dim
+    coord_phys_center = im.transfo_pix2phys([[(nx - 1) / 2.0, (ny - 1) / 2.0, (nz - 1) / 2.0]])[0]
+    coordinates_centerline = im.getNonZeroCoordinates(sorting='z')
+
+    f = open(fname_output, "w")
+    sct.printv('\nWriting ROI file...', verbose)
+
+    for coord in coordinates_centerline:
+        coord_phys = im.transfo_pix2phys([[coord.x, coord.y, coord.z]])[0]
+        f.write(ROI_TEMPLATE.format(fname_segmentation=fname_image,
+                                    creation_date=date_now.strftime("%d %B %Y %H:%M:%S.%f %Z"),
+                                    slice_num=coord.z + 1,
+                                    position_x=coord_phys_center[0] - coord_phys[0],
+                                    position_y=coord_phys_center[1] - coord_phys[1]))
+
+    f.close()
+
+    if os.path.abspath(folder_output) != os.getcwd():
+        shutil.copy(fname_output, folder_output)
+
+    return fname_output
+
+
 def detect_centerline(image_fname, contrast_type,
                       optic_models_path, folder_output,
                       remove_temp_files=False, init_option=None, output_roi=False, verbose=0):
@@ -83,47 +135,19 @@ def detect_centerline(image_fname, contrast_type,
     sct.run(cmd_reorient, verbose=0)
 
     # copy centerline to parent folder
+    folder_output_from_temp = folder_output
+    if not os.path.isabs(folder_output):
+        folder_output_from_temp = '../' + folder_output
+
     sct.printv('Copy output to ' + folder_output, verbose=0)
-    if os.path.isabs(folder_output):
-        shutil.copy(centerline_optic_filename, folder_output)
-    else:
-        shutil.copy(centerline_optic_filename, '../' + folder_output)
+    shutil.copy(centerline_optic_filename, folder_output_from_temp)
 
     if output_roi:
-        date_now = datetime.now()
-        ROI_TEMPLATE = 'Begin Marker ROI\n' \
-                       '  Build version="7.0_33"\n' \
-                       '  Annotation=""\n' \
-                       '  Colour=0\n' \
-                       '  Image source="{fname_segmentation}"\n' \
-                       '  Created  "{creation_date}" by Operator ID="SCT"\n' \
-                       '  Slice={slice_num}\n' \
-                       '  Begin Shape\n' \
-                       '    X={position_x}; Y={position_y}\n' \
-                       '  End Shape\n' \
-                       'End Marker ROI\n'
+        fname_roi_centerline = centerline2roi(fname_image=centerline_optic_RPI_filename,
+                                              folder_output=folder_output_from_temp,
+                                              verbose=verbose)
 
-        im = Image(centerline_optic_RPI_filename)
-        nx, ny, nz, nt, px, py, pz, pt = im.dim
-        coord_phys_center = im.transfo_pix2phys([[(nx - 1) / 2.0, (ny - 1) / 2.0, (nz - 1) / 2.0]])[0]
-        coordinates_centerline = im.getNonZeroCoordinates(sorting='z')
-
-        centerline_optic_filename_roi = file_data + '_centerline_optic.roi'
-        f = open(centerline_optic_filename_roi, "w")
-        sct.printv('\nWriting ROI file...', verbose)
-
-        for coord in coordinates_centerline:
-            coord_phys = im.transfo_pix2phys([[coord.x, coord.y, coord.z]])[0]
-            f.write(ROI_TEMPLATE.format(fname_segmentation=image_fname,
-                                        creation_date=date_now.strftime("%d %B %Y %H:%M:%S.%f %Z"),
-                                        slice_num=coord.z + 1,
-                                        position_x=coord_phys_center[0] - coord_phys[0],
-                                        position_y=coord_phys_center[1] - coord_phys[1]))
-
-        f.close()
-
-        shutil.copy(reoriented_image_filename_nii, '../' + folder_output)
-        shutil.copy(centerline_optic_filename_roi, '../' + folder_output)
+        shutil.copy(reoriented_image_filename_nii, folder_output_from_temp)
 
     # return to initial folder
     temp_folder.chdir_undo()
@@ -132,5 +156,4 @@ def detect_centerline(image_fname, contrast_type,
     if remove_temp_files:
         temp_folder.cleanup()
 
-    return init_option, os.path.join(folder_output,
-                                     centerline_optic_filename)
+    return init_option, os.path.join(folder_output, centerline_optic_filename)

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -7,10 +7,13 @@ import sct_utils as sct
 from sct_image import orientation
 from msct_image import Image
 
+from datetime import datetime
+from string import Template
+
 
 def detect_centerline(image_fname, contrast_type,
                       optic_models_path, folder_output,
-                      remove_temp_files=False, init_option=None, verbose=0):
+                      remove_temp_files=False, init_option=None, output_roi=False, verbose=0):
     """This method will use the OptiC to detect the centerline.
 
     :param image_fname: The input image filename.
@@ -72,8 +75,7 @@ def detect_centerline(image_fname, contrast_type,
     nib.save(img, centerline_optic_RPI_filename)
 
     # reorient the output image to initial orientation
-    centerline_optic_filename = sct.add_suffix(file_data + ext_data,
-                                               "_centerline_optic")
+    centerline_optic_filename = sct.add_suffix(file_data + ext_data, "_centerline_optic")
     cmd_reorient = 'sct_image -i "%s" -o "%s" -setorient "%s" -v 0' % \
                    (centerline_optic_RPI_filename,
                     centerline_optic_filename,
@@ -85,9 +87,44 @@ def detect_centerline(image_fname, contrast_type,
     if os.path.isabs(folder_output):
         shutil.copy(centerline_optic_filename, folder_output)
     else:
-        dst_path = os.path.join("../", folder_output)
-        shutil.copy(centerline_optic_filename,
-                    '../' + folder_output)
+        shutil.copy(centerline_optic_filename, '../' + folder_output)
+
+    if output_roi:
+        print 'test'
+        date_now = datetime.now()
+        ROI_TEMPLATE = 'Begin Marker ROI\n' \
+                       '  Build version="7.0_33"\n' \
+                       '  Annotation=""\n' \
+                       '  Colour=0\n' \
+                       '  Image source="{fname_segmentation}"\n' \
+                       '  Created  "{creation_date}" by Operator ID="SCT"\n' \
+                       '  Slice={slice_num}\n' \
+                       '  Begin Shape\n' \
+                       '    X={position_x}; Y={position_y}\n' \
+                       '  End Shape\n' \
+                       'End Marker ROI\n'
+
+        im = Image(centerline_optic_RPI_filename)
+        nx, ny, nz, nt, px, py, pz, pt = im.dim
+        coord_phys_center = im.transfo_pix2phys([[(nx - 1) / 2.0, (ny - 1) / 2.0, (nz - 1) / 2.0]])[0]
+        coordinates_centerline = im.getNonZeroCoordinates(sorting='z')
+
+        centerline_optic_filename_roi = file_data + '_centerline_optic.roi'
+        f = open(centerline_optic_filename_roi, "w")
+        sct.printv('\nWriting ROI file...', verbose)
+
+        for coord in coordinates_centerline:
+            coord_phys = im.transfo_pix2phys([[coord.x, coord.y, coord.z]])[0]
+            f.write(ROI_TEMPLATE.format(fname_segmentation=image_fname,
+                                        creation_date=date_now.strftime("%d %B %Y %H:%M:%S.%f %Z"),
+                                        slice_num=coord.z + 1,
+                                        position_x=coord_phys_center[0] - coord_phys[0],
+                                        position_y=coord_phys_center[1] - coord_phys[1]))
+
+        f.close()
+
+        shutil.copy(reoriented_image_filename_nii, '../' + folder_output)
+        shutil.copy(centerline_optic_filename_roi, '../' + folder_output)
 
     # return to initial folder
     temp_folder.chdir_undo()

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -90,7 +90,6 @@ def detect_centerline(image_fname, contrast_type,
         shutil.copy(centerline_optic_filename, '../' + folder_output)
 
     if output_roi:
-        print 'test'
         date_now = datetime.now()
         ROI_TEMPLATE = 'Begin Marker ROI\n' \
                        '  Build version="7.0_33"\n' \

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -147,6 +147,8 @@ def detect_centerline(image_fname, contrast_type,
                                               folder_output=folder_output_from_temp,
                                               verbose=verbose)
 
+        # Note: the .roi file is defined in RPI orientation. To be used, it must be applied on the original image with
+        # a RPI orientation. For this reason, this script also outputs the input image in RPI orientation
         shutil.copy(reoriented_image_filename_nii, folder_output_from_temp)
 
     # return to initial folder


### PR DESCRIPTION
### Description of the Change

This pull request introduces the generation of centerline as ROI, readable by JIM (http://www.xinapse.com/Manual/index.html) so that we can automatize the CordFinder tool (spinal cord segmentation method developed by Horsfield et al.).

For now, only `sct_process_segmentation` allow to generate a ROI based on a segmentation or a centerline, using the following command:
```
sct_process_segmentation -i my_segmentation.nii.gz -p centerline
```

`sct_get_centerline` should also integrate this option.
