### PR TITLE
Force numpy 1.12.1 on osx and linux

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -398,12 +398,8 @@ else
             and verify your internet connection before reinstalling"
     exit $e_status
   fi
-  # reinstall numpy at the end to prevent a conda bug
-  if [[ $OS == linux ]]; then
-    # Fix Intel MKL FATAL ERROR: Cannot load libmkl_avx2.so or libmkl_def.so.
-    # on certain linux distribution
-    conda install -fy numpy
-  fi
+  # reinstall numpy at the end to prevent some bugs
+  conda install -fy numpy=1.12.1
 
 fi
 


### PR DESCRIPTION
new numpy 1.13.0, crashes the sct.



