### PR TITLE
Fixed unassigned variable in case -z or -vert is not used

### DIFF
--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -370,7 +370,7 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
         if fname_mask_weight:  # if the flag -mask-weighted was specified,
             im_weight.data, slices_list = remove_slices(im_weight.data, slices_of_interest)
     else:
-        slices_list = range(0, nz)
+        slices_list = np.arange(nz).tolist()
 
     # parse clusters used for a priori (map method)
     clusters_all_labels = parse_label_ID_groups(ml_clusters)

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -369,6 +369,8 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
             normalizing_label[0], slices_list = remove_slices(normalizing_label[0], slices_of_interest)
         if fname_mask_weight:  # if the flag -mask-weighted was specified,
             im_weight.data, slices_list = remove_slices(im_weight.data, slices_of_interest)
+    else:
+        slices_list = range(0, nz)
 
     # parse clusters used for a priori (map method)
     clusters_all_labels = parse_label_ID_groups(ml_clusters)


### PR DESCRIPTION
### Description of the Change

Default assignment is a list with all slices. 

### Steps and Constraints

data on **/Volumes/folder_shared/sct_issues/20170608_issue1241**
command:
~~~
sct_extract_metric -i Dh_reg.nii -f atlas/ -method map -overwrite 1 -output-map test.nii.gz
~~~

### Applicable Issues

Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/1241
