### PR TITLE
The init-mask accepts "viewer" as a value

### DIFF
--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -255,7 +255,8 @@ If the segmentation fails at some location (e.g. due to poor contrast between sp
     parser.add_option(name="-init-mask",
                       type_value="image_nifti",
                       description="mask containing three center of the spinal cord, used to initiate the propagation.\nReplace filename by 'viewer' to use interactive viewer for providing mask. Ex: -init-mask viewer",
-                      mandatory=False)
+                      mandatory=False,
+                      list_no_image=['viewer'])
     parser.add_option(name="-mask-correction",
                       type_value="image_nifti",
                       description="mask containing binary pixels at edges of the spinal cord on which the segmentation algorithm will be forced to register the surface. Can be used in case of poor/missing contrast between spinal cord and CSF or in the presence of artefacts/pathologies.",


### PR DESCRIPTION

### Requirements
See issue #1323 

### Description of the Change
At the creation of the option `-init-mask` in `sct_propseg`'s parser, add `viewer` to the list of the possible inputs that shouldn't be considered as an image. 

Fixes #1323 

### Additional information
With that fix, the option `-init-mask` of `sct_propseg` works but the position of the slices displayed by the viewer is not adapted to the use of `-init-mask` in `sct_propseg` (the viewer displays only three slices from the top of SC).
