### PR TITLE
Added the dependency psutil in the conda requirements

### DIFF
--- a/install/requirements/requirementsConda.txt
+++ b/install/requirements/requirementsConda.txt
@@ -10,3 +10,4 @@ pip==9.0.1
 requests==2.12.4
 cryptography==1.6
 mpi4py==2.0.0
+psutil==5.2.2


### PR DESCRIPTION
In some systems, the pip version of psutil is not properly installed. So far,
conda's version is the most stable.
