### PR TITLE
Use a pythonic way to compare a variable as  None

### DIFF
--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -269,7 +269,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
     from msct_nurbs import NURBS
 
     twodim = False
-    if z == None:
+    if z is None:
         twodim = True
 
     """x.reverse()


### PR DESCRIPTION
in msct_smooth, l272, change `if z == None ` by `if z is None` as `z` can be a list of coordinates, creating an error during the straightening. 

Error observed when calling `sct_register_to_template` : 
![capture d ecran 2017-06-16 12 02 51](https://user-images.githubusercontent.com/5857909/27234771-2fe64ca8-528c-11e7-8a4d-f44f9db34aec.png)

