### PR TITLE
Ignore using user packages when install with conda and pip

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -349,6 +349,11 @@ cmd="./update_bin.sh"; echo ">> "$cmd; $cmd  # N.B. This script needs to be run 
 # Copy binaries
 
 ## INSTALL PYTHON
+# We make sure that there is no conflict with local python install by unsetting PYTHONPATH
+# and forcing PYTHONNOUSERSITE
+unset PYTHONPATH
+export PYTHONNOUSERSITE=1
+
 if [ ${NO_CONDA_INSTALL} ]; then
   echo "python/ will not be (re)-install"
   # activate miniconda
@@ -382,8 +387,6 @@ else
 
   # Install Python dependencies
   echo -e "\nInstalling Python dependencies..."
-  # N.B. the flag --ignore-installed is required because locally install
-  # package are skip
   conda install --yes --file ${SCT_SOURCE}/install/requirements/requirementsConda.txt
   e_status=$?
   if [ ${e_status} != 0 ] ; then
@@ -391,7 +394,7 @@ else
             and verify your internet connection before reinstalling"
     exit $e_status
   fi
-  pip install --ignore-installed  -r ${SCT_SOURCE}/install/requirements/requirementsPip.txt
+  pip install  -r ${SCT_SOURCE}/install/requirements/requirementsPip.txt
   e_status=$?
   if [ ${e_status} != 0 ] ; then
     echo "pip install error with exit status $e_status. Check logs for more details


### PR DESCRIPTION

### Description of the Change

unset PYTHONPATH and set PYTHONNOUSERSITE=1 at install time 

All that to make sure local python install is not meddling with the sct


### Applicable Issues

Fixes #1373 and #1381 (might be a conflict to merge manually here)
