### PR TITLE
BUG: fix bug when slice is empty

### DIFF
--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -485,8 +485,8 @@ def extract_metric(method, data, labels, indiv_labels_ids, clusters_labels='', a
         metric_in_labels, metric_std_in_labels = np.divide(metric_in_labels, metric_norm_label), np.divide(metric_std_in_labels, metric_std_norm_label)
 
     if combined_labels_id_group:
-        metric_in_labels = metric_in_labels[0]
-        metric_std_in_labels = metric_std_in_labels[0]
+        metric_in_labels = np.asarray([metric_in_labels[0]])
+        metric_std_in_labels = np.asarray([metric_std_in_labels[0]])
 
     # compute fractional volume for each label
     fract_vol_per_label = np.zeros(metric_in_labels.size, dtype=float)


### PR DESCRIPTION
### Requirements
A bug was happening when extracting metric from an empty slice: 
```Traceback (most recent call last):
File "/Users/saradupont/Neuropoly/code/spinalcordtoolbox/scripts/sct_extract_metric.py", line 1315, in <module>
main(fname_data, path_label, method, slices_of_interest, vertebral_levels, fname_output, labels_user, overwrite, fname_normalizing_label, normalization_method, label_to_fix, adv_param_user, fname_output_metric_map, fname_mask_weight)
File "/Users/saradupont/Neuropoly/code/spinalcordtoolbox/scripts/sct_extract_metric.py", line 391, in main
combined_labels_value[i_combined_labels], combined_labels_std[i_combined_labels], combined_labels_fract_vol[i_combined_labels] = extract_metric(method, data, labels, indiv_labels_ids, clusters_all_labels, adv_param, normalizing_label, normalization_method, im_weight=im_weight, combined_labels_id_group=combined_labels_groups_all_IDs[i_combined_labels])
File "/Users/saradupont/Neuropoly/code/spinalcordtoolbox/scripts/sct_extract_metric.py", line 492, in extract_metric
fract_vol_per_label = np.zeros(metric_in_labels.size, dtype=float)
AttributeError: 'int' object has no attribute 'size'

/Users/saradupont/Neuropoly/code/spinalcordtoolbox/scripts/sct_utils.pyNone
```

### Description of the Change

Quick fix: when slice is empty ant the return value is only `0` --> consider the `0` as a numpy array to be in the same format as when the slice is not empty and values are output (so that `metric_in_labels.size` doesn't raise an error)
