### PR TITLE
Catch the OSError exception thrown when the git command is missing

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -292,14 +292,14 @@ class QcReport(object):
 
         Parameters
         ----------
-        description : str
-            quick description of current usage of the process
+        dimension : (int, int)
+            The dimension of the image frame
         """
         # get path of the toolbox
         try:
             cmd = 'git rev-parse --short HEAD'.split()
             git_hash = subprocess.check_output(cmd).strip('"')
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, OSError):
             git_hash = "N/A"
 
         output = {


### PR DESCRIPTION
Fixes #1277 