### PR TITLE
Change import path of resample

### DIFF
--- a/install/requirements/requirementsPip.txt
+++ b/install/requirements/requirementsPip.txt
@@ -1,4 +1,4 @@
-nipy==0.4.0
+nipy==0.4.1
 nibabel==2.1.0
 dipy==0.11.0
 distribute2mpi==0.3.0

--- a/scripts/sct_resample.py
+++ b/scripts/sct_resample.py
@@ -56,7 +56,7 @@ def resample():
     :return:
     """
     import nipy
-    from nipy.algorithms.registration import resample
+    from nipy.algorithms.registration.resample import resample
     import numpy as np
 
     verbose = param.verbose


### PR DESCRIPTION
The current import resample from the `__init__` module instead of `resample` module. This should prevent from importing `scripting` module that imports `matplotlib`

Fixes #1374 