### PR TITLE
crashes if apply transfo on 4d images issue#640

### DIFF
--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -180,7 +180,7 @@ class Transform:
             # convert to nifti into temp folder
             sct.printv('\nCopying input data to tmp folder and convert to nii...', verbose)
             from sct_convert import convert
-            convert(fname_src, path_tmp + 'data.nii')
+            convert(fname_src, path_tmp + 'data.nii', squeeze_data=False)
             sct.run('cp ' + fname_dest + ' ' + path_tmp + file_dest + ext_dest)
             fname_warp_list_tmp = []
             for fname_warp in fname_warp_list:
@@ -216,7 +216,8 @@ class Transform:
             fname_list = glob.glob('data_reg_T*.nii')
             im_out = concat_data(fname_list, 3, im_header['pixdim'])
             im_out.setFileName(name_out + ext_out)
-            im_out.save()
+            im_out.save(squeeze_data=False)
+
             os.chdir('..')
             sct.generate_output_file(path_tmp + name_out + ext_out, fname_out)
             # Delete temporary folder if specified


### PR DESCRIPTION
### Requirements

* Is there a issue open describing the motivation for this pull request ?
https://github.com/neuropoly/spinalcordtoolbox/issues/640

* Does the pull request need an update of the documentation ?
No Need

* Does the pull request need additional test(s) ?
Tanguy & Harris

### Description of the Change
For 4D images, we do not want to squeeze data along 4th dim --> squeeze_data=False