### PR TITLE
Adapt concat and apply transfo to work on 2d images

### DIFF
--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -167,7 +167,11 @@ class Transform:
             # Apply transformation
             sct.printv('\nApply transformation...', verbose)
             # print 'HOLA1'
-            sct.run('isct_antsApplyTransforms -d 3 -i ' + fname_src + ' -o ' + fname_out + ' -t ' + ' '.join(fname_warp_list_invert) + ' -r ' + fname_dest + interp, verbose)
+            if nz in [0, 1]:
+                dim = '2'
+            else:
+                dim = '3'
+            sct.run('isct_antsApplyTransforms -d '+dim+' -i ' + fname_src + ' -o ' + fname_out + ' -t ' + ' '.join(fname_warp_list_invert) + ' -r ' + fname_dest + interp, verbose)
 
         # if 4d, loop across the T dimension
         else:

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -20,6 +20,7 @@ import getopt
 from commands import getstatusoutput
 import sct_utils as sct
 from msct_parser import Parser
+from msct_image import Image
 
 # DEFAULT PARAMETERS
 
@@ -86,11 +87,17 @@ def main():
     else:
         path_out, file_out, ext_out = sct.extract_fname(fname_warp_final)
 
+    # Check dimension of data (cf. issue #1419)
+    dimensionality = '3'
+    im_warp = Image(fname_warp_list[0])
+    if im_warp.data.shape[2] in (0, 1):
+        dimensionality = '2'
+
     # Concatenate warping fields
     sct.printv('\nConcatenate warping fields...', verbose)
     # N.B. Here we take the inverse of the warp list
     fname_warp_list_invert.reverse()
-    cmd = 'isct_ComposeMultiTransform 3 warp_final' + ext_out + ' -R ' + fname_dest + ' ' + ' '.join(fname_warp_list_invert)
+    cmd = 'isct_ComposeMultiTransform '+dimensionality+' warp_final' + ext_out + ' -R ' + fname_dest + ' ' + ' '.join(fname_warp_list_invert)
     sct.printv('>> ' + cmd, verbose)
     status, output = getstatusoutput(cmd)  # here cannot use sct.run() because of wrong output status in isct_ComposeMultiTransform
 

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -89,9 +89,11 @@ def main():
 
     # Check dimension of data (cf. issue #1419)
     dimensionality = '3'
-    im_warp = Image(fname_warp_list[0])
-    if im_warp.data.shape[2] in (0, 1):
-        dimensionality = '2'
+    path, file, ext = sct.extract_fname(fname_warp_list[0])
+    if 'nii' in ext:
+        im_warp = Image(fname_warp_list[0])
+        if im_warp.data.shape[2] in (0, 1):
+            dimensionality = '2'
 
     # Concatenate warping fields
     sct.printv('\nConcatenate warping fields...', verbose)


### PR DESCRIPTION
### Requirements
Allow `sct_concat_transfo` to work on 2D warping fields

### Description of the Change
When warping field is 2D, use `isct_ComposeMultiTransform` with dimensionality at 2 instead of 3. 
Only the first warping field of the list is check because we assume all the warping fields are in the same dimensionality (i.e. 2D or 3D) to avoid opening them all. 

### Applicable Issues

Fixes #1419 
