### PR TITLE
Fixing stdout issue on sct_testing

### DIFF
--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -159,6 +159,8 @@ def test(path_data='', parameters=''):
     # write log file
     write_to_log_file(fname_log, output, mode='r+', prepend=True)
 
+    sys.stdout = stdout_orig
+
     return status, output, results
 
 


### PR DESCRIPTION
### Description of the Change

This Pull Request fixes a small bug in SCT testing. `test_sct_register_to_template` was changing the standard stdout during the testing and never changed it back, resulting in the loss of display.

Fixes #1428.