### PR TITLE
DEV: fixed bug on centerline when referencing to the PMJ

### DIFF
--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -569,7 +569,7 @@ class SpinalCordStraightener(object):
                         relative_position = centerline.dist_points[index]
                     else:
                         relative_position = centerline.dist_points_rel[index]
-                    idx_closest = centerline_straight.get_closest_to_absolute_position(disk_label, relative_position, mode=alignment_mode)
+                    idx_closest = centerline_straight.get_closest_to_absolute_position(disk_label, relative_position, backup_index=index, backup_centerline=centerline_straight, mode=alignment_mode)
                     if idx_closest is not None:
                         lookup_curved2straight[index] = idx_closest
                     else:
@@ -594,7 +594,7 @@ class SpinalCordStraightener(object):
                         relative_position = centerline_straight.dist_points[index]
                     else:
                         relative_position = centerline_straight.dist_points_rel[index]
-                    idx_closest = centerline.get_closest_to_absolute_position(disk_label, relative_position, mode=alignment_mode)
+                    idx_closest = centerline.get_closest_to_absolute_position(disk_label, relative_position, backup_index=index, backup_centerline=centerline_straight, mode=alignment_mode)
                     if idx_closest is not None:
                         lookup_straight2curved[index] = idx_closest
             for p in range(0, len(lookup_straight2curved)/2):


### PR DESCRIPTION
### Description of the Change

The registration of two images using the straightening and the vertebral levels failed when the disks labels did not contained the PMJ. The PMJ was used as a reference.

Now, an adaptative reference is selected (first or last label) when it is not found in one of the two images.

### Steps and Constraints

Running the template generation (https://github.com/neuropoly/template) produced the error when the PMJ label was not included into the input images.

