### PR TITLE
Properly exit the installation process if error occurs

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -37,17 +37,21 @@ DATA_DIR="data"
 PYTHON_DIR="python"
 BIN_DIR="bin"
 
-
 # Force a clean exit
 finish ()
 {
-  # Get back to starting point
-  cd ${SCT_SOURCE}
-  # remove installation tmp files
-#  rm -Rf ${TMP_DIR}
+    # Catch the last return code
+    value=$?
+    # Get back to starting point
+    cd ${SCT_SOURCE}
+    if [ ${value} -eq 0 ]; then
+        echo "Installation finished successfully"
+    else
+        echo "Installation failed"
+    fi
+    exit ${value}
 }
 trap finish EXIT
-
 
 # Force bashrc loading
 force_bashrc_loading ()


### PR DESCRIPTION
### Description of the Change

There is two changes done. First, properly catch the errors when downloading data and the second in the installation script, trap the return value when exiting and re-send it.

Fixes #1365
