### PR TITLE
Now possible to input single label at disc (instead of mid-body)

### DIFF
--- a/scripts/sct_convert.py
+++ b/scripts/sct_convert.py
@@ -80,7 +80,7 @@ def main(args = None):
 
     # Building the command, do sanity checks
     parser = get_parser()
-    arguments = parser.parse(sys.argv[1:])
+    arguments = parser.parse(args)
     fname_in = arguments["-i"]
     fname_out = arguments["-o"]
     squeeze_data = bool(int(arguments['-squeeze']))

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -299,6 +299,7 @@ class ProcessLabels(object):
 
         return image_output
 
+
     def cubic_to_point(self):
         """
         Calculate the center of mass of each group of labels and returns a file of same size with only a
@@ -333,6 +334,7 @@ class ProcessLabels(object):
 
         return output_image
 
+
     def increment_z_inverse(self):
         """
         Take all non-zero values, sort them along the inverse z direction, and attributes the values 1,
@@ -347,6 +349,7 @@ class ProcessLabels(object):
             image_output.data[int(coord.x), int(coord.y), int(coord.z)] = i + 1
 
         return image_output
+
 
     def labelize_from_disks(self):
         """
@@ -368,6 +371,7 @@ class ProcessLabels(object):
 
         return image_output
 
+
     def label_vertebrae(self, levels_user=None):
         """
         Find the center of mass of vertebral levels specified by the user.
@@ -388,6 +392,7 @@ class ProcessLabels(object):
                 image_cubic2point.data[int(list_coordinates[i_label].x), int(list_coordinates[i_label].y), int(list_coordinates[i_label].z)] = 0
         # list all labels
         return image_cubic2point
+
 
     # FUNCTION BELOW REMOVED BY JULIEN ON 2016-07-04 BECAUSE SEEMS NOT TO BE USED (AND DUPLICATION WITH ABOVE)
     # def label_vertebrae_from_disks(self, levels_user):
@@ -412,7 +417,7 @@ class ProcessLabels(object):
     #
     #     return image_cubic2point
 
-    # BELOW: UNFINISHED BUSINESS (JULIEN)
+
     # def label_disc(self, levels_user=None):
     #     """
     #     Find the edge of vertebral labeling file and assign value corresponding to middle coordinate between two levels.

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -92,6 +92,8 @@ class ProcessLabels(object):
             self.output_image = self.create_label()
         if type_process == 'create-add':
             self.output_image = self.create_label(add=True)
+        if type_process == 'create-seg':
+            self.output_image = self.create_label_along_segmentation()
         if type_process == 'display-voxel':
             self.display_voxel()
             self.fname_output = None
@@ -163,8 +165,43 @@ class ProcessLabels(object):
             elif len(image_output.data.shape) == 2:
                 assert str(coord.z) == '0', "ERROR: 2D coordinates should have a Z value of 0. Z coordinate is :" + str(coord.z)
                 image_output.data[int(coord.x), int(coord.y)] = coord.value
-
         return image_output
+
+    def create_label_along_segmentation(self):
+        """
+        Create an image with labels defined along the spinal cord segmentation (or centerline)
+        Example:
+        object_define=ProcessLabels(fname_segmentation, coordinates=[coord_1, coord_2, coord_i]), where coord_i='z,value'. If z=-1, then use z=nz/2 (i.e. center of FOV in superior-inferior direction)
+        Returns
+        -------
+        image_output: Image object with labels.
+        """
+        # copy input Image object (will use the same header)
+        image_output = self.image_input.copy()
+        # set all voxels to 0
+        image_output.data *= 0
+        # loop across labels
+        for i, coord in enumerate(self.coordinates):
+            # split coord string
+            list_coord = coord.split(',')
+            # convert to int() and assign to variable
+            z, value = [int(i) for i in list_coord]
+            # if z=-1, replace with nz/2
+            if z == -1:
+                z = int(round(image_output.dim[2]/2.0))
+            # get center of mass of segmentation at given z
+            x, y = ndimage.measurements.center_of_mass(np.array(self.image_input.data[:, :, z]))
+            # round values to make indices
+            x, y = int(round(x)), int(round(y))
+            # display info
+            sct.printv('Label #' + str(i) + ': ' + str(x) + ',' + str(y) + ',' + str(z) + ' --> ' + str(value), 1)
+            if len(image_output.data.shape) == 3:
+                image_output.data[x, y, z] = value
+            elif len(image_output.data.shape) == 2:
+                assert str(z) == '0', "ERROR: 2D coordinates should have a Z value of 0. Z coordinate is :" + str(z)
+                image_output.data[x, y] = value
+        return image_output
+
 
     def cross(self):
         """
@@ -732,7 +769,7 @@ def get_parser():
     parser.usage.set_description('Utility function for label image.')
     parser.add_option(name="-i",
                       type_value="file",
-                      description="Label image.",
+                      description="Input image.",
                       mandatory=True,
                       example="t2_labels.nii.gz")
     parser.add_option(name="-o",
@@ -752,8 +789,12 @@ def get_parser():
                       mandatory=False)
     parser.add_option(name='-create-add',
                       type_value=[[':'], 'Coordinate'],
-                      description='Same as create, but add labels to input image instead of creating a new one.',
+                      description='Same as "-create", but add labels to the input image instead of creating a new image.',
                       example='12,34,32,1:12,35,33,2',
+                      mandatory=False)
+    parser.add_option(name='-create-seg',
+                      type_value=[[':'], 'str'],
+                      description='Create labels along cord segmentation (or centerline) defined by "-i". First value is "z", second is the value of the label. Separate labels with ":". Example: 5,1:14,2:23,3. To select the mid-point in the superior-inferior direction, set z to "-1". For example if you know that C2-C3 disc is centered in the S-I direction, then enter: -1,3',
                       mandatory=False)
     parser.add_option(name='-cross',
                       type_value='int',
@@ -839,6 +880,9 @@ def main(args=None):
     elif '-create-add' in arguments:
         process_type = 'create-add'
         input_coordinates = arguments['-create-add']
+    elif '-create-seg' in arguments:
+        process_type = 'create-seg'
+        input_coordinates = arguments['-create-seg']
     elif '-cross' in arguments:
         process_type = 'cross'
         input_cross_radius = arguments['-cross']

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import time
 import sct_utils as sct
+import sct_label_utils
 from sct_utils import add_suffix
 from sct_register_multimodal import Paramreg, ParamregMultiStep, register
 from msct_parser import Parser
@@ -281,7 +282,11 @@ def main(args=None):
 
     # Generate labels from template vertebral labeling
     sct.printv('\nGenerate labels from template vertebral labeling', verbose)
-    sct.run('sct_label_utils -i ' + fname_template_vertebral_labeling + ' -vert-body 0 -o ' + ftmp_template_label)
+    sct_label_utils.main(args=[
+        '-i', fname_template_vertebral_labeling,
+        '-vert-body', '0',
+        '-o', ftmp_template_label])
+    # sct.run('sct_label_utils -i ' + fname_template_vertebral_labeling + ' -vert-body 0 -o ' + ftmp_template_label)
 
     # check if provided labels are available in the template
     sct.printv('\nCheck if provided labels are available in the template', verbose)


### PR DESCRIPTION
### Description of the Change

* [x] *sct_register_to_template*: Made it possible to accept single labeled file at the level of the disc. New flag: ```-ldisc```
* [x] *sct_label_utils*: New feature to create a single label centered in the cord segmentation and along I-S. This is useful for people who always acquire data with e.g. FOV centered at C2-C3 disc.

### Convention for labeling disc: 

![45f05b66-0803-11e7-864f-d9448150b33c](https://user-images.githubusercontent.com/2482071/30251155-294ed9e8-9628-11e7-9002-ecec0ab97571.png)

Note: Please note that in this figure, points are located at the posterior tip of discs, whereas in practice, they should be centered in the cord, although this does not have large impact for sct_register_to_template (because there is a realignment based on the cord centerline).

### Applicable Issues

Implements #574 
