### PR TITLE
Fixed z-regularization for slicereg

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -72,9 +72,9 @@ def main(args=None):
         'MNI-Poly-AMU': 'https://osf.io/sh6h4/?action=download',
         'gm_model': 'https://osf.io/ugscu/?action=download',
         'optic_models': 'https://osf.io/g4fwn/?action=download',
-        'binaries_debian': 'https://osf.io/a83jr/?action=download',
-        'binaries_centos': 'https://osf.io/sgy6x/?action=download',
-        'binaries_osx': 'https://osf.io/rtzey/?action=download',
+        'binaries_debian': 'https://osf.io/2egh5/?action=download',
+        'binaries_centos': 'https://osf.io/qngj2/?action=download',
+        'binaries_osx': 'https://osf.io/hsa5r/?action=download',
         'course_hawaii17': 'https://osf.io/6exht/?action=download'
     }
 


### PR DESCRIPTION
### Description of the Change

current version of isct_antsSliceRegularizedRegistration does not regularize along Z. Bug was introduced with new version of isct_antsSliceRegularizedRegistration, which accounts for z-rotation. This fix goes back to the previous version with only TxTy

### Applicable Issues

Implements or Fixes #1464 
