### PR TITLE
Fixed global dependency in sct_process_segmentation call

### DIFF
--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -42,7 +42,6 @@ class Param:
         self.remove_temp_files = 1
         self.smoothing_param = 0  # window size (in mm) for smoothing CSA along z. 0 for no smoothing.
         self.slices = ''
-        self.vertebral_levels = ''
         self.type_window = 'hanning'  # for smooth_centerline @sct_straighten_spinalcord
         self.window_length = 50  # for smooth_centerline @sct_straighten_spinalcord
         self.algo_fitting = 'hanning'  # nurbs, hanning
@@ -179,21 +178,17 @@ def main(args):
 
     parser = get_parser()
     arguments = parser.parse(args)
+    param = Param()
 
     # Initialization
     path_script = os.path.dirname(__file__)
     fsloutput = 'export FSLOUTPUTTYPE=NIFTI; '  # for faster processing, all outputs are in NIFTI
     processes = ['centerline', 'csa', 'length', 'shape']
     start_time = time.time()
-    if "-v" in arguments:
-        verbose = int(arguments["-v"])
-    if "-r" in arguments:
-        remove_temp_files = int(arguments["-r"])
     # spline_smoothing = param.spline_smoothing
     step = param.step
     smoothing_param = param.smoothing_param
     slices = param.slices
-    vert_lev = param.vertebral_levels
     angle_correction = True
     use_phys_coord = True
 
@@ -208,6 +203,8 @@ def main(args):
         overwrite = arguments['-overwrite']
     if '-vert' in arguments:
         vert_lev = arguments['-vert']
+    else:
+        vert_lev = ''
     if '-r' in arguments:
         remove_temp_files = arguments['-r']
     if '-size' in arguments:
@@ -899,11 +896,11 @@ def compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_te
         sct.run('rm -rf ' + path_tmp, error_exit='warning')
 
     # Sum up the output file names
-    sct.printv('\nOutput a nifti file of CSA values along the segmentation: ' + output_folder + 'csa_image.nii.gz', param.verbose, 'info')
-    sct.printv('Output result text file of CSA per slice: ' + output_folder + 'csa_per_slice.txt', param.verbose, 'info')
+    sct.printv('\nOutput a nifti file of CSA values along the segmentation: ' + output_folder + 'csa_image.nii.gz', verbose, 'info')
+    sct.printv('Output result text file of CSA per slice: ' + output_folder + 'csa_per_slice.txt', verbose, 'info')
     if slices or vert_levels:
-        sct.printv('Output result files of the mean CSA across the selected slices: \n\t\t' + output_folder + 'csa_mean.txt\n\t\t' + output_folder + 'csa_mean.xls\n\t\t' + output_folder + 'csa_mean.pickle', param.verbose, 'info')
-        sct.printv('Output result files of the volume in between the selected slices: \n\t\t' + output_folder + 'csa_volume.txt\n\t\t' + output_folder + 'csa_volume.xls\n\t\t' + output_folder + 'csa_volume.pickle', param.verbose, 'info')
+        sct.printv('Output result files of the mean CSA across the selected slices: \n\t\t' + output_folder + 'csa_mean.txt\n\t\t' + output_folder + 'csa_mean.xls\n\t\t' + output_folder + 'csa_mean.pickle', verbose, 'info')
+        sct.printv('Output result files of the volume in between the selected slices: \n\t\t' + output_folder + 'csa_volume.txt\n\t\t' + output_folder + 'csa_volume.xls\n\t\t' + output_folder + 'csa_volume.pickle', verbose, 'info')
 
 
 def label_vert(fname_seg, fname_label, verbose=1):

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -185,9 +185,11 @@ def main(args):
     path_script = os.path.dirname(__file__)
     fsloutput = 'export FSLOUTPUTTYPE=NIFTI; '  # for faster processing, all outputs are in NIFTI
     processes = ['centerline', 'csa', 'length', 'shape']
-    verbose = param.verbose
     start_time = time.time()
-    remove_temp_files = param.remove_temp_files
+    if "-v" in arguments:
+        verbose = int(arguments["-v"])
+    if "-r" in arguments:
+        remove_temp_files = int(arguments["-r"])
     # spline_smoothing = param.spline_smoothing
     step = param.step
     smoothing_param = param.smoothing_param

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -649,31 +649,33 @@ def compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_te
     X, Y, Z = (data_seg > 0).nonzero()
     min_z_index, max_z_index = min(Z), max(Z)
 
-    if use_phys_coord:
-        # fit centerline, smooth it and return the first derivative (in physical space)
-        x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=3000, phys_coordinates=True, verbose=verbose, all_slices=False)
-        centerline = Centerline(x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv)
+    # if angle correction is required, get segmentation centerline
+    if angle_correction:
+        if use_phys_coord:
+            # fit centerline, smooth it and return the first derivative (in physical space)
+            x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=3000, phys_coordinates=True, verbose=verbose, all_slices=False)
+            centerline = Centerline(x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv)
 
-        # average centerline coordinates over slices of the image
-        x_centerline_fit_rescorr, y_centerline_fit_rescorr, z_centerline_rescorr, x_centerline_deriv_rescorr, y_centerline_deriv_rescorr, z_centerline_deriv_rescorr = centerline.average_coordinates_over_slices(im_seg)
+            # average centerline coordinates over slices of the image
+            x_centerline_fit_rescorr, y_centerline_fit_rescorr, z_centerline_rescorr, x_centerline_deriv_rescorr, y_centerline_deriv_rescorr, z_centerline_deriv_rescorr = centerline.average_coordinates_over_slices(im_seg)
 
-        # compute Z axis of the image, in physical coordinate
-        axis_X, axis_Y, axis_Z = im_seg.get_directions()
+            # compute Z axis of the image, in physical coordinate
+            axis_X, axis_Y, axis_Z = im_seg.get_directions()
 
-        # compute z_centerline in image coordinates for usage in vertebrae mapping
-        z_centerline_voxel = [coord[2] for coord in im_seg.transfo_phys2pix([[x_centerline_fit_rescorr[i], y_centerline_fit_rescorr[i], z_centerline_rescorr[i]] for i in range(len(z_centerline_rescorr))])]
+            # compute z_centerline in image coordinates for usage in vertebrae mapping
+            z_centerline_voxel = [coord[2] for coord in im_seg.transfo_phys2pix([[x_centerline_fit_rescorr[i], y_centerline_fit_rescorr[i], z_centerline_rescorr[i]] for i in range(len(z_centerline_rescorr))])]
 
-    else:
-        # fit centerline, smooth it and return the first derivative (in voxel space but FITTED coordinates)
-        x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=3000, phys_coordinates=False, verbose=verbose, all_slices=True)
+        else:
+            # fit centerline, smooth it and return the first derivative (in voxel space but FITTED coordinates)
+            x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=3000, phys_coordinates=False, verbose=verbose, all_slices=True)
 
-        # correct centerline fitted coordinates according to the data resolution
-        x_centerline_fit_rescorr, y_centerline_fit_rescorr, z_centerline_rescorr, x_centerline_deriv_rescorr, y_centerline_deriv_rescorr, z_centerline_deriv_rescorr = x_centerline_fit * px, y_centerline_fit * py, z_centerline * pz, x_centerline_deriv * px, y_centerline_deriv * py, z_centerline_deriv * pz
+            # correct centerline fitted coordinates according to the data resolution
+            x_centerline_fit_rescorr, y_centerline_fit_rescorr, z_centerline_rescorr, x_centerline_deriv_rescorr, y_centerline_deriv_rescorr, z_centerline_deriv_rescorr = x_centerline_fit * px, y_centerline_fit * py, z_centerline * pz, x_centerline_deriv * px, y_centerline_deriv * py, z_centerline_deriv * pz
 
-        axis_Z = [0.0, 0.0, 1.0]
+            axis_Z = [0.0, 0.0, 1.0]
 
-        # compute z_centerline in image coordinates for usage in vertebrae mapping
-        z_centerline_voxel = z_centerline
+            # compute z_centerline in image coordinates for usage in vertebrae mapping
+            z_centerline_voxel = z_centerline
 
     # Compute CSA
     sct.printv('\nCompute CSA...', verbose)

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -41,7 +41,6 @@ class Param:
         self.step = 1  # step of discretized plane in mm default is min(x_scale,py)
         self.remove_temp_files = 1
         self.smoothing_param = 0  # window size (in mm) for smoothing CSA along z. 0 for no smoothing.
-        self.figure_fit = 0
         self.slices = ''
         self.vertebral_levels = ''
         self.type_window = 'hanning'  # for smooth_centerline @sct_straighten_spinalcord
@@ -193,7 +192,6 @@ def main(args):
     # spline_smoothing = param.spline_smoothing
     step = param.step
     smoothing_param = param.smoothing_param
-    figure_fit = param.figure_fit
     slices = param.slices
     vert_lev = param.vertebral_levels
     angle_correction = True
@@ -249,7 +247,7 @@ def main(args):
         sct.printv('fslview ' + fname_segmentation + ' ' + output_folder + fname_output + ' -l Red &\n', param.verbose, 'info')
 
     if name_process == 'csa':
-        compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_temp_files, step, smoothing_param, figure_fit, slices, vert_lev, fname_vertebral_labeling, algo_fitting=param.algo_fitting, type_window=param.type_window, window_length=param.window_length, angle_correction=angle_correction, use_phys_coord=use_phys_coord)
+        compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_temp_files, step, smoothing_param, slices, vert_lev, fname_vertebral_labeling, algo_fitting=param.algo_fitting, type_window=param.type_window, window_length=param.window_length, angle_correction=angle_correction, use_phys_coord=use_phys_coord)
 
     if name_process == 'label-vert':
         if '-discfile' in arguments:
@@ -615,7 +613,7 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
 
 # compute_csa
 # ==========================================================================================
-def compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_temp_files, step, smoothing_param, figure_fit, slices, vert_levels, fname_vertebral_labeling='', algo_fitting='hanning', type_window='hanning', window_length=80, angle_correction=True, use_phys_coord=True):
+def compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_temp_files, step, smoothing_param, slices, vert_levels, fname_vertebral_labeling='', algo_fitting='hanning', type_window='hanning', window_length=80, angle_correction=True, use_phys_coord=True):
 
     from math import degrees
     import pandas as pd

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -213,7 +213,7 @@ class ParamSeg:
 
         self.type_seg = 'prob'  # 'prob' or 'bin'
         self.thr_bin = 0.5
-        self.ratio = '0'  # '0', 'slice' or 'level'
+        self.ratio = 'slice'  # '0', 'slice' or 'level'
 
         self.qc = True
 
@@ -632,8 +632,8 @@ class SegmentGM:
             fname_gmseg = im_res_gmseg.absolutepath
             fname_wmseg = im_res_wmseg.absolutepath
 
-        sct_process_segmentation.main(['-i', fname_gmseg, '-p', 'csa', '-ofolder', 'gm_csa'])
-        sct_process_segmentation.main(['-i', fname_wmseg, '-p', 'csa', '-ofolder', 'wm_csa'])
+        sct_process_segmentation.main(['-i', fname_gmseg, '-p', 'csa', '-ofolder', 'gm_csa', '-no-angle', '1'])
+        sct_process_segmentation.main(['-i', fname_wmseg, '-p', 'csa', '-ofolder', 'wm_csa', '-no-angle', '1'])
 
         gm_csa = open('gm_csa/csa_per_slice.txt', 'r')
         wm_csa = open('wm_csa/csa_per_slice.txt', 'r')

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -82,9 +82,12 @@ def get_parser():
                       description="Spinal cord segmentation",
                       mandatory=True,
                       example='sc_seg.nii.gz')
+
+    parser.usage.addSection('SEGMENTATION OPTIONS')
+
     parser.add_option(name="-vertfile",
                       type_value="str",
-                      description='Labels of vertebral levels. This could either be an image (e.g., label/template/PAM50_levels.nii.gz) or a text file that specifies "slice,level" at each line. Example:\n'
+                      description='Labels of vertebral levels used as prior for the segmentation. This could either be an image (e.g., label/template/PAM50_levels.nii.gz) or a text file that specifies "slice,level" at each line. Example:\n'
                       "0,3\n"
                       "1,3\n"
                       "2,4\n"
@@ -99,7 +102,6 @@ def get_parser():
                       mandatory=False,
                       deprecated_by='-vertfile')
 
-    parser.usage.addSection('SEGMENTATION OPTIONS')
     parser.add_option(name="-denoising",
                       type_value='multiple_choice',
                       description="1: Adaptative denoising from F. Coupe algorithm, 0: no  WARNING: It affects the model you should use (if denoising is applied to the target, the model should have been computed with denoising too)",
@@ -141,7 +143,9 @@ def get_parser():
                       description="Path to the computed model",
                       mandatory=False,
                       example='/home/jdoe/gm_seg_model/')
-    parser.usage.addSection('\nOUTPUT OTIONS')
+
+    parser.usage.addSection('\nOUTPUT OPTIONS')
+
     parser.add_option(name="-res-type",
                       type_value='multiple_choice',
                       description="Type of result segmentation : binary or probabilistic",
@@ -154,18 +158,22 @@ def get_parser():
                       mandatory=False,
                       default_value=ParamSeg().ratio,
                       example=['0', 'slice', 'level'])
-    parser.add_option(name="-ref",
-                      type_value="file",
-                      description="Reference segmentation of the gray matter for segmentation validation --> output Dice coefficient and Hausdorff's and median distances)",
-                      mandatory=False,
-                      example='manual_gm_seg.nii.gz')
     parser.add_option(name="-ofolder",
                       type_value="folder_creation",
                       description="Output folder",
                       mandatory=False,
                       default_value=ParamSeg().path_results,
                       example='gm_segmentation_results/')
-    parser.usage.addSection('MISC')
+
+    parser.usage.addSection('\nQC OPTIONS')
+
+    parser.add_option(name="-ref",
+                      type_value="file",
+                      description="Compute DICE coefficient, Hausdorff's and median distances between output segmentation and gold-standard segmentation specified here",
+                      mandatory=False,
+                      example='manual_gm_seg.nii.gz')
+
+    parser.usage.addSection('\nMISC')
     parser.add_option(name='-qc',
                       type_value='multiple_choice',
                       description='Output images for quality control.',


### PR DESCRIPTION
### Description of the Change

Global variable `param` was used in the main of `sct_process_segmentation`, which created bugs when this function was called as a module (instead of using sct.run() as we used to do).

### Applicable Issues

Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/1479
