### PR TITLE
Fixes Optic is used by default if -init-mask is used with external file provided

### DIFF
--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -396,6 +396,7 @@ if __name__ == "__main__":
             use_viewer = "mask"
         else:
             cmd += " -init-mask " + str(arguments["-init-mask"])
+            use_optic = False
     if "-mask-correction" in arguments:
         cmd += " -mask-correction " + str(arguments["-mask-correction"])
     if "-radius" in arguments:


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/1484
