### PR TITLE
BUG: sct_fmri_compute_tsnr does not compute tSNR

### DIFF
--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -86,12 +86,12 @@ if __name__ == '__main__':
     else:
         param_default = Param()
 
-        parser = get_parser()
-        arguments = parser.parse(sys.argv[1:])
-        input_fmri = arguments['-i']
+    parser = get_parser()
+    arguments = parser.parse(sys.argv[1:])
+    input_fmri = arguments['-i']
 
-        if '-v' in arguments:
-            param.verbose = int(arguments['-v'])
+    if '-v' in arguments:
+        param.verbose = int(arguments['-v'])
 
-        tsnr = Tsnr(param=param, fmri=input_fmri)
-        tsnr.compute()
+    tsnr = Tsnr(param=param, fmri=input_fmri)
+    tsnr.compute()


### PR DESCRIPTION
### Description of the Change

Some of the code was indented too far and wasn't executing. This was corrected.

### Applicable Issues

https://github.com/neuropoly/spinalcordtoolbox/issues/1521
