### PR TITLE
Adding minimal Dockerfile for SCT.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y wget unzip git bzip2
+RUN wget https://github.com/neuropoly/spinalcordtoolbox/archive/master.zip
+RUN unzip master.zip
+WORKDIR spinalcordtoolbox-master
+RUN yes | ./install_sct
+RUN echo "export PATH=/root/sct_dev/bin:$PATH" >>~/.bashrc

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,10 @@
+# Minimal SCT Docker file w/ Ubuntu 16.04
+
+This directory contains a minimal Dockerfile to install spinalcoordtoolbox.
+
+## Instructions
+
+Inside this directory, run:
+
+    docker build -t dockersct .
+    docker run --name sctcontainer -i -t dockersct


### PR DESCRIPTION
## Minimal Dockerfile for SCT w/ Ubuntu 16.04

This is just a minimal Dockerfile for SCT w/ Ubuntu 16.04. I made for myself but it might be useful for other people when they cannot run SCT on their platform.