### PR TITLE
[BUG] Fixing the TensorFlow installation for some old platforms.

### DIFF
--- a/install/tf_distro_check.py
+++ b/install/tf_distro_check.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+# Check if the platform requires conda tensorflow.
+#
+# Author: Christian S. Perone
+
+import platform
+
+
+# This is the list of distros that will require
+# Tensorflow to be installed using conda.
+# The format is:
+#
+#     (distro name, distro version, distro id)
+#
+DISTRO_MATCH = [
+    ('centos', '6.8'),
+    ('debian',)
+]
+
+
+def run_main():
+    sysplatform = platform.dist()
+
+    for spec in DISTRO_MATCH:
+        match = 0
+        for spec_value, sys_value in zip(spec, sysplatform):
+            if spec_value == sys_value:
+                match += 1
+        if match == len(spec):
+            print '1'
+            return
+
+    print '0'
+
+
+if __name__ == '__main__':
+    run_main()

--- a/install/tf_distro_check.py
+++ b/install/tf_distro_check.py
@@ -29,10 +29,10 @@ def run_main():
             if spec_value == sys_value:
                 match += 1
         if match == len(spec):
-            print '1'
+            print('1')
             return
 
-    print '0'
+    print('0')
 
 
 if __name__ == '__main__':

--- a/install_sct
+++ b/install_sct
@@ -474,8 +474,12 @@ else
     exit $e_status
   fi
 
-  # Install tensorflow for Debian
-  if python -c "import platform; print platform.dist()" | grep -qi 'debian'; then
+  # This varible will be 1 if the Tensorflow should be installed
+  # using Conda and 0 otherwise.
+  TF_DISTRO_CHECK=$(python ${SCT_SOURCE}/install/tf_distro_check.py)
+
+  # Install tensorflow with Conda for some distributions
+  if [ $TF_DISTRO_CHECK = "1" ]; then
     conda install -c defaults --yes tensorflow==1.3.0
   fi
 


### PR DESCRIPTION
This is a fix for the issue #1645, where SCT installation fails on some distributions.

Since we're starting to have more than one distribution with these issues, I added a new installation check file that would make it easier to add a new distribution later (by adding the distribution name and optionally the version or id).