### PR TITLE
Set “MeanSquares” the default metric for sct_fmri_moco

### DIFF
--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -49,7 +49,7 @@ class Param:
         self.poly = '2'  # degree of polynomial function for moco
         self.smooth = '2'  # smoothing sigma in mm
         self.gradStep = '1'  # gradientStep for searching algorithm
-        self.metric = 'MI'  # metric: MI, MeanSquares, CC
+        self.metric = 'MeanSquares'  # metric: MI, MeanSquares, CC
         self.sampling = '0.2'  # sampling rate used for registration metric
         self.interp = 'spline'  # nn, linear, spline
         self.run_eddy = 0


### PR DESCRIPTION
### Description of the Change

Previously, metric was MI, which is suboptimal (more prone to error and longer). "MeanSquares" makes more sense for fMRI time series because images have exactly the same contrast.

### Applicable Issues

Fixes #1468
