### PR TITLE
Uniformize use of Quick Check and refactor call sites

### DIFF
--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -37,7 +37,7 @@ def register_slicewise(fname_src,
                         warp_inverse_out='step0InverseWarp.nii.gz',
                         paramreg=None,
                         ants_registration_params=None,
-                        path_qc='./',
+                        qc_path='./',
                         remove_temp_files=1,
                         verbose=0):
 
@@ -58,13 +58,13 @@ def register_slicewise(fname_src,
     # Calculate displacement
     if paramreg.algo == 'centermass':
         # translation of center of mass between source and destination in voxel space
-        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=0, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose)
+        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=0, poly=int(paramreg.poly), qc_path=qc_path, verbose=verbose)
     elif paramreg.algo == 'centermassrot':
         # translation of center of mass and rotation based on source and destination first eigenvectors from PCA.
-        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose, pca_eigenratio_th=float(paramreg.pca_eigenratio_th))
+        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), qc_path=qc_path, verbose=verbose, pca_eigenratio_th=float(paramreg.pca_eigenratio_th))
     elif paramreg.algo == 'columnwise':
         # scaling R-L, then column-wise center of mass alignment and scaling
-        register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, path_qc=path_qc, smoothWarpXY=int(paramreg.smoothWarpXY))
+        register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, qc_path=qc_path, smoothWarpXY=int(paramreg.smoothWarpXY))
     else:
         # convert SCT flags into ANTs-compatible flags
         algo_dic = {'translation': 'Translation', 'rigid': 'Rigid', 'affine': 'Affine', 'syn': 'SyN', 'bsplinesyn': 'BSplineSyN', 'centermass': 'centermass'}
@@ -83,7 +83,7 @@ def register_slicewise(fname_src,
         sct.rmtree(path_tmp, verbose=verbose)
 
 
-def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', rot=1, poly=0, path_qc='./', verbose=0, pca_eigenratio_th=1.6):
+def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', rot=1, poly=0, qc_path='./', verbose=0, pca_eigenratio_th=1.6):
     """
     Rotate the source image to match the orientation of the destination image, using the first and second eigenvector
     of the PCA. This function should be used on segmentations (not images).
@@ -182,7 +182,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
             plt.grid()
             plt.xlabel('z')
             plt.ylabel('Angle (deg)')
-            plt.savefig(os.path.join(path_qc, 'register2d_centermassrot_regularize_rotation.png'))
+            plt.savefig(os.path.join(qc_path, 'register2d_centermassrot_regularize_rotation.png'))
             plt.close()
         # update variable
         angle_src_dest[z_nonzero] = angle_src_dest_regularized
@@ -265,7 +265,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
                     # sct.printv('WARNING: '+str(e), 1, 'warning')
 
                     # plt.axis('equal')
-            plt.savefig(os.path.join(path_qc, 'register2d_centermassrot_pca_z' + str(iz) + '.png'))
+            plt.savefig(os.path.join(qc_path, 'register2d_centermassrot_pca_z' + str(iz) + '.png'))
             plt.close()
 
         # construct 3D warping matrix
@@ -281,7 +281,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
     generate_warping_field(fname_src, warp_inv_x, warp_inv_y, fname_warp_inv, verbose)
 
 
-def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', verbose=0, path_qc='./', smoothWarpXY=1):
+def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', verbose=0, qc_path='./', smoothWarpXY=1):
     """
     Column-wise non-linear registration of segmentations. Based on an idea from Allan Martin.
     - Assumes src/dest are segmentations (not necessarily binary), and already registered by center of mass
@@ -517,7 +517,7 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
                 plt.ylim(mean_dest_y - 15, mean_dest_y + 15)
                 ax.grid(True, color='w')
                 # save figure
-                plt.savefig(os.path.join(path_qc, 'register2d_columnwise_image_z' + str(iz) + '.png'))
+                plt.savefig(os.path.join(qc_path, 'register2d_columnwise_image_z' + str(iz) + '.png'))
                 plt.close()
 
             # ============================================================

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -37,7 +37,7 @@ def register_slicewise(fname_src,
                         warp_inverse_out='step0InverseWarp.nii.gz',
                         paramreg=None,
                         ants_registration_params=None,
-                        qc_path='./',
+                        path_qc='./',
                         remove_temp_files=1,
                         verbose=0):
 
@@ -58,13 +58,13 @@ def register_slicewise(fname_src,
     # Calculate displacement
     if paramreg.algo == 'centermass':
         # translation of center of mass between source and destination in voxel space
-        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=0, poly=int(paramreg.poly), qc_path=qc_path, verbose=verbose)
+        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=0, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose)
     elif paramreg.algo == 'centermassrot':
         # translation of center of mass and rotation based on source and destination first eigenvectors from PCA.
-        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), qc_path=qc_path, verbose=verbose, pca_eigenratio_th=float(paramreg.pca_eigenratio_th))
+        register2d_centermassrot('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, rot=1, poly=int(paramreg.poly), path_qc=path_qc, verbose=verbose, pca_eigenratio_th=float(paramreg.pca_eigenratio_th))
     elif paramreg.algo == 'columnwise':
         # scaling R-L, then column-wise center of mass alignment and scaling
-        register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, qc_path=qc_path, smoothWarpXY=int(paramreg.smoothWarpXY))
+        register2d_columnwise('src.nii', 'dest.nii', fname_warp=warp_forward_out, fname_warp_inv=warp_inverse_out, verbose=verbose, path_qc=path_qc, smoothWarpXY=int(paramreg.smoothWarpXY))
     else:
         # convert SCT flags into ANTs-compatible flags
         algo_dic = {'translation': 'Translation', 'rigid': 'Rigid', 'affine': 'Affine', 'syn': 'SyN', 'bsplinesyn': 'BSplineSyN', 'centermass': 'centermass'}
@@ -83,7 +83,7 @@ def register_slicewise(fname_src,
         sct.rmtree(path_tmp, verbose=verbose)
 
 
-def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', rot=1, poly=0, qc_path='./', verbose=0, pca_eigenratio_th=1.6):
+def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', rot=1, poly=0, path_qc='./', verbose=0, pca_eigenratio_th=1.6):
     """
     Rotate the source image to match the orientation of the destination image, using the first and second eigenvector
     of the PCA. This function should be used on segmentations (not images).
@@ -182,7 +182,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
             plt.grid()
             plt.xlabel('z')
             plt.ylabel('Angle (deg)')
-            plt.savefig(os.path.join(qc_path, 'register2d_centermassrot_regularize_rotation.png'))
+            plt.savefig(os.path.join(path_qc, 'register2d_centermassrot_regularize_rotation.png'))
             plt.close()
         # update variable
         angle_src_dest[z_nonzero] = angle_src_dest_regularized
@@ -265,7 +265,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
                     # sct.printv('WARNING: '+str(e), 1, 'warning')
 
                     # plt.axis('equal')
-            plt.savefig(os.path.join(qc_path, 'register2d_centermassrot_pca_z' + str(iz) + '.png'))
+            plt.savefig(os.path.join(path_qc, 'register2d_centermassrot_pca_z' + str(iz) + '.png'))
             plt.close()
 
         # construct 3D warping matrix
@@ -281,7 +281,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
     generate_warping_field(fname_src, warp_inv_x, warp_inv_y, fname_warp_inv, verbose)
 
 
-def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', verbose=0, qc_path='./', smoothWarpXY=1):
+def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz', fname_warp_inv='warp_inverse.nii.gz', verbose=0, path_qc='./', smoothWarpXY=1):
     """
     Column-wise non-linear registration of segmentations. Based on an idea from Allan Martin.
     - Assumes src/dest are segmentations (not necessarily binary), and already registered by center of mass
@@ -517,7 +517,7 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
                 plt.ylim(mean_dest_y - 15, mean_dest_y + 15)
                 ax.grid(True, color='w')
                 # save figure
-                plt.savefig(os.path.join(qc_path, 'register2d_columnwise_image_z' + str(iz) + '.png'))
+                plt.savefig(os.path.join(path_qc, 'register2d_columnwise_image_z' + str(iz) + '.png'))
                 plt.close()
 
             # ============================================================

--- a/scripts/msct_register_landmarks.py
+++ b/scripts/msct_register_landmarks.py
@@ -39,7 +39,7 @@ ini_param_trans_y = -150.0  # pix
 initial_step = 2
 
 
-def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, path_qc='./'):
+def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, qc_path='./'):
     """
     Register two NIFTI volumes containing landmarks
     :param fname_src: fname of source landmarks
@@ -82,8 +82,8 @@ def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', ve
 
     # estimate transformation
     # N.B. points_src and points_dest are inverted below, because ITK uses inverted transformation matrices, i.e., src->dest is defined in dest instead of src.
-    # (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_dest, points_src, constraints=dof, verbose=verbose, path_qc=path_qc)
-    (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_src, points_dest, constraints=dof, verbose=verbose, path_qc=path_qc)
+    # (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_dest, points_src, constraints=dof, verbose=verbose, qc_path=qc_path)
+    (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_src, points_dest, constraints=dof, verbose=verbose, qc_path=qc_path)
     # writing rigid transformation file
     # N.B. x and y dimensions have a negative sign to ensure compatibility between Python and ITK transfo
     text_file = open(fname_affine, 'w')
@@ -287,7 +287,7 @@ def getRigidTransformFromImages(img_dest, img_src, constraints='none', metric = 
     return rotation_matrix, translation_array
 
 
-def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, path_qc='./'):
+def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, qc_path='./'):
     """
     Compute affine transformation to register landmarks
     :param points_src:
@@ -342,7 +342,9 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
     sct.printv('Center:\n' + str(points_src_barycenter))
     sct.printv('Translation:\n' + str(translation_array))
 
-    if verbose == 2:
+    if qc_path is not None:
+        sct.create_folder(qc_path)
+
         import matplotlib
         # use Agg to prevent display
         matplotlib.use('Agg')
@@ -371,14 +373,14 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
         ax.set_aspect('auto')
         plt.legend()
         # plt.show()
-        plt.savefig(os.path.join(path_qc, 'getRigidTransformFromLandmarks_plot.png'))
+        plt.savefig(os.path.join(qc_path, 'getRigidTransformFromLandmarks_plot.png'))
 
         fig2 = plt.figure()
         plt.plot(sse_results)
         plt.grid()
         plt.title('#Iterations: ' + str(res.nit) + ', #FuncEval: ' + str(res.nfev) + ', Error: ' + str(res.fun))
         plt.show()
-        plt.savefig(os.path.join(path_qc, 'getRigidTransformFromLandmarks_iterations.png'))
+        plt.savefig(os.path.join(qc_path, 'getRigidTransformFromLandmarks_iterations.png'))
 
     # transform numpy matrix to list structure because it is easier to handle
     points_src_reg = points_src_reg.tolist()

--- a/scripts/msct_register_landmarks.py
+++ b/scripts/msct_register_landmarks.py
@@ -39,7 +39,7 @@ ini_param_trans_y = -150.0  # pix
 initial_step = 2
 
 
-def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, qc_path='./'):
+def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, path_qc='./'):
     """
     Register two NIFTI volumes containing landmarks
     :param fname_src: fname of source landmarks
@@ -82,8 +82,8 @@ def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', ve
 
     # estimate transformation
     # N.B. points_src and points_dest are inverted below, because ITK uses inverted transformation matrices, i.e., src->dest is defined in dest instead of src.
-    # (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_dest, points_src, constraints=dof, verbose=verbose, qc_path=qc_path)
-    (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_src, points_dest, constraints=dof, verbose=verbose, qc_path=qc_path)
+    # (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_dest, points_src, constraints=dof, verbose=verbose, path_qc=path_qc)
+    (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_src, points_dest, constraints=dof, verbose=verbose, path_qc=path_qc)
     # writing rigid transformation file
     # N.B. x and y dimensions have a negative sign to ensure compatibility between Python and ITK transfo
     text_file = open(fname_affine, 'w')
@@ -287,7 +287,7 @@ def getRigidTransformFromImages(img_dest, img_src, constraints='none', metric = 
     return rotation_matrix, translation_array
 
 
-def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, qc_path='./'):
+def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, path_qc='./'):
     """
     Compute affine transformation to register landmarks
     :param points_src:
@@ -342,8 +342,8 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
     sct.printv('Center:\n' + str(points_src_barycenter))
     sct.printv('Translation:\n' + str(translation_array))
 
-    if qc_path is not None:
-        sct.create_folder(qc_path)
+    if path_qc is not None:
+        sct.create_folder(path_qc)
 
         import matplotlib
         # use Agg to prevent display
@@ -373,14 +373,14 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
         ax.set_aspect('auto')
         plt.legend()
         # plt.show()
-        plt.savefig(os.path.join(qc_path, 'getRigidTransformFromLandmarks_plot.png'))
+        plt.savefig(os.path.join(path_qc, 'getRigidTransformFromLandmarks_plot.png'))
 
         fig2 = plt.figure()
         plt.plot(sse_results)
         plt.grid()
         plt.title('#Iterations: ' + str(res.nit) + ', #FuncEval: ' + str(res.nfev) + ', Error: ' + str(res.fun))
         plt.show()
-        plt.savefig(os.path.join(qc_path, 'getRigidTransformFromLandmarks_iterations.png'))
+        plt.savefig(os.path.join(path_qc, 'getRigidTransformFromLandmarks_iterations.png'))
 
     # transform numpy matrix to list structure because it is easier to handle
     points_src_reg = points_src_reg.tolist()

--- a/scripts/msct_register_landmarks.py
+++ b/scripts/msct_register_landmarks.py
@@ -39,7 +39,7 @@ ini_param_trans_y = -150.0  # pix
 initial_step = 2
 
 
-def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, path_qc='./'):
+def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, path_qc=None):
     """
     Register two NIFTI volumes containing landmarks
     :param fname_src: fname of source landmarks
@@ -287,7 +287,7 @@ def getRigidTransformFromImages(img_dest, img_src, constraints='none', metric = 
     return rotation_matrix, translation_array
 
 
-def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, path_qc='./'):
+def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, path_qc=None):
     """
     Compute affine transformation to register landmarks
     :param points_src:

--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -265,7 +265,7 @@ def Univariate_Spline(x, y, w=None, bbox=[None, None], k=3, s=None) :
 #=======================================================================================================================
 # 3D B-Spline function, sct_nurbs
 #=======================================================================================================================
-def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, nbControl=-1, verbose=1, all_slices=True, qc_path='.'):
+def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, nbControl=-1, verbose=1, all_slices=True, path_qc='.'):
 
     from math import log
     from msct_nurbs import NURBS
@@ -362,7 +362,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.xlabel('y')
             plt.ylabel('x')
             plt.show()
-        plt.savefig(os.path.join(qc_path, 'b_spline_nurbs.png'))
+        plt.savefig(os.path.join(path_qc, 'b_spline_nurbs.png'))
         plt.close()
 
     if not twodim:

--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -265,7 +265,7 @@ def Univariate_Spline(x, y, w=None, bbox=[None, None], k=3, s=None) :
 #=======================================================================================================================
 # 3D B-Spline function, sct_nurbs
 #=======================================================================================================================
-def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, nbControl=-1, verbose=1, all_slices=True, path_qc='.'):
+def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, nbControl=-1, verbose=1, all_slices=True, qc_path='.'):
 
     from math import log
     from msct_nurbs import NURBS
@@ -322,6 +322,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
     z_deriv = x_fit[::-1]"""
 
     if verbose == 2:
+        # TODO qc
         PC = nurbs.getControle()
         PC_x = [p[0] for p in PC]
         PC_y = [p[1] for p in PC]
@@ -361,7 +362,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.xlabel('y')
             plt.ylabel('x')
             plt.show()
-        plt.savefig(os.path.join(path_qc, 'b_spline_nurbs.png'))
+        plt.savefig(os.path.join(qc_path, 'b_spline_nurbs.png'))
         plt.close()
 
     if not twodim:

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -59,7 +59,7 @@ def get_parser():
     return parser
 
 
-def quick_check(fn_in, fn_seg, args, qc_path):
+def quick_check(fn_in, fn_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """
@@ -72,7 +72,7 @@ def quick_check(fn_in, fn_seg, args, qc_path):
      src=fn_in,
      process="sct_deepseg_gm",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane='Axial',
      qcslice=qcslice.Axial([Image(fn_in), Image(fn_seg)]),
      qcslice_operations=[qc.QcImage.listed_seg],
@@ -97,9 +97,9 @@ def run_main():
     out_fname = deepseg_gm.segment_file(input_filename, output_filename,
                                         model_name, int(verbose))
 
-    qc_path = arguments.get("-qc", None)
-    if qc_path is not None:
-        quick_check(input_filename, out_fname, sys.argv[1:], os.path.abspath(qc_path))
+    path_qc = arguments.get("-qc", None)
+    if path_qc is not None:
+        quick_check(input_filename, out_fname, sys.argv[1:], os.path.abspath(path_qc))
 
 
     sct.display_viewer_syntax([input_filename, format(out_fname)],

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -59,7 +59,7 @@ def get_parser():
     return parser
 
 
-def quick_check(fn_in, fn_seg, args, path_qc):
+def generate_qc(fn_in, fn_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """
@@ -99,7 +99,7 @@ def run_main():
 
     path_qc = arguments.get("-qc", None)
     if path_qc is not None:
-        quick_check(input_filename, out_fname, sys.argv[1:], os.path.abspath(path_qc))
+        generate_qc(input_filename, out_fname, sys.argv[1:], os.path.abspath(path_qc))
 
 
     sct.display_viewer_syntax([input_filename, format(out_fname)],

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -235,12 +235,12 @@ def main():
      remove_temp_files=remove_temp_files, verbose=verbose)
 
     if path_qc is not None:
-        quick_check(fname_image, fname_seg, args, os.path.abspath(path_qc))
+        generate_qc(fname_image, fname_seg, args, os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_image, os.path.join(output_folder, fname_seg)], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
-def quick_check(fn_in, fn_seg, args, path_qc):
+def generate_qc(fn_in, fn_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -229,18 +229,18 @@ def main():
     if '-v' in arguments:
         verbose = arguments['-v']
 
-    qc_path = arguments.get("-qc", None)
+    path_qc = arguments.get("-qc", None)
 
     fname_seg = deep_segmentation_spinalcord(fname_image, contrast_type, output_folder,
      remove_temp_files=remove_temp_files, verbose=verbose)
 
-    if qc_path is not None:
-        quick_check(fname_image, fname_seg, args, os.path.abspath(qc_path))
+    if path_qc is not None:
+        quick_check(fname_image, fname_seg, args, os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_image, os.path.join(output_folder, fname_seg)], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
-def quick_check(fn_in, fn_seg, args, qc_path):
+def quick_check(fn_in, fn_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """
@@ -252,7 +252,7 @@ def quick_check(fn_in, fn_seg, args, qc_path):
      src=fn_in,
      process="sct_deepseg_sc",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane='Axial',
      qcslice=qcslice.Axial([Image(fn_in), Image(fn_seg)]),
      qcslice_operations=[qc.QcImage.listed_seg],

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -52,12 +52,10 @@ def get_parser():
                         description="Output folder",
                         mandatory=False,
                         example="My_Output_Folder/")
-    parser.add_option(name="-qc",
-                        type_value="multiple_choice",
-                        description="Output png image for quality control.",
-                        mandatory=False,
-                        example=["0", "1"],
-                        default_value="0")
+    parser.add_option(name='-qc',
+                      type_value='folder_creation',
+                      description='The path where the quality control generated content will be saved',
+                      default_value=None)
     parser.add_option(name="-igt",
                       type_value="image_nifti",
                       description="File name of ground-truth PMJ (single voxel).",
@@ -79,7 +77,7 @@ def get_parser():
 
 
 class DetectPMJ:
-    def __init__(self, fname_im, contrast, fname_seg, path_out, quality_control, verbose):
+    def __init__(self, fname_im, contrast, fname_seg, path_out, verbose):
 
         self.fname_im = fname_im
         self.contrast = contrast
@@ -87,8 +85,6 @@ class DetectPMJ:
         self.fname_seg = fname_seg
 
         self.path_out = path_out
-
-        self.quality_control = quality_control
 
         self.verbose = verbose
 
@@ -136,35 +132,9 @@ class DetectPMJ:
             sct.copy(os.path.abspath(os.path.join(self.tmp_dir, self.fname_out)),
                         os.path.abspath(os.path.join(self.path_out, self.fname_out)))
 
-            if self.quality_control:
-                sct.copy(os.path.abspath(os.path.join(self.tmp_dir, self.fname_qc)),
-                                os.path.abspath(os.path.join(self.path_out, self.fname_qc)))
-
             return os.path.join(self.path_out, self.fname_out)
         else:
             return None
-
-    def save_qc(self, slice_arr, coord_lst):
-        """Output a QC PNG image with a green bounding box around the detected PMJ."""
-        sct.printv('\nSave quality control image...', self.verbose, 'normal')
-
-        import matplotlib.pyplot as plt
-        import matplotlib.patches as patches
-
-        fig, ax = plt.subplots(1)
-        ax.imshow(np.rot90(slice_arr), cmap='gray')
-
-        rect = patches.Rectangle((coord_lst[0] - 10, slice_arr.shape[1] - coord_lst[1] - 10),
-                                    20, 20,
-                                    linewidth=2,
-                                    edgecolor='lime',
-                                    facecolor='none')
-        ax.add_patch(rect)
-
-        plt.axis('off')
-        fig.savefig(self.fname_qc, bbox_inches='tight')
-
-        sct.printv('\nQC output image: ' + self.fname_qc, self.verbose, 'info')
 
     def generate_mask_pmj(self):
         """Output the PMJ mask."""
@@ -174,9 +144,6 @@ class DetectPMJ:
             im_mask.data *= 0  # empty mask
 
             im_mask.data[self.pa_coord, self.is_coord, self.rl_coord] = 50  # voxel with value = 50
-
-            if self.quality_control:  # output QC image
-                self.save_qc(im.data[:, :, self.rl_coord], [self.pa_coord, self.is_coord])
 
             im_mask.setFileName(self.fname_out)
 
@@ -303,29 +270,19 @@ def main(args=None):
     else:
         path_results = '.'
 
-    if '-qc' in arguments:
-        qc = bool(int(arguments['-qc']))
-    else:
-        qc = False
+    qc_path = arguments.get("-qc", None)
 
     # Remove temp folder
-    if '-r' in arguments:
-        rm_tmp = bool(int(arguments['-r']))
-    else:
-        rm_tmp = True
+    rm_tmp = bool(int(arguments.get("-r", 1)))
 
     # Verbosity
-    if '-v' in arguments:
-        verbose = int(arguments['-v'])
-    else:
-        verbose = '1'
+    verbose = int(arguments.get("-v", 1))
 
     # Initialize DetectPMJ
     detector = DetectPMJ(fname_im=fname_in,
                             contrast=contrast,
                             fname_seg=fname_seg,
                             path_out=path_results,
-                            quality_control=qc,
                             verbose=verbose)
 
     # run the extraction
@@ -337,7 +294,54 @@ def main(args=None):
 
     # View results
     if fname_out is not None:
+        if qc_path is not None:
+            quick_check(fname_in, fname_out, args, os.path.abspath(qc_path))
+
         sct.display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'])
+
+
+def quick_check(fname_in, fname_out, args, qc_path):
+    """
+    Generate a QC entry allowing to quickly review the PMJ position
+    """
+
+    import spinalcordtoolbox.reports.qc as qc
+    import spinalcordtoolbox.reports.slice as qcslice
+
+    def highlight_pmj(self, mask):
+        """
+        Hook to show a rectangle where PMJ is on the slice
+        """
+
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as patches
+
+        y, x = np.where(mask == 50)
+
+        ax = plt.gca()
+        img = np.full_like(mask, np.nan)
+        ax.imshow(img, cmap='gray', alpha=0)
+
+        rect = patches.Rectangle((x - 10, y - 10),
+                                    20, 20,
+                                    linewidth=2,
+                                    edgecolor='lime',
+                                    facecolor='none')
+
+        ax.add_patch(rect)
+        ax.get_xaxis().set_visible(False)
+        ax.get_yaxis().set_visible(False)
+
+    qc.add_entry(
+     src=fname_in,
+     process="sct_detect_pmj",
+     args=args,
+     qc_path=qc_path,
+     plane="Sagittal",
+     qcslice=qcslice.Sagittal([Image(fname_in), Image(fname_out)]),
+     qcslice_operations=[highlight_pmj],
+     qcslice_layout=lambda x: x.single(),
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -295,12 +295,12 @@ def main(args=None):
     # View results
     if fname_out is not None:
         if path_qc is not None:
-            quick_check(fname_in, fname_out, args, os.path.abspath(path_qc))
+            generate_qc(fname_in, fname_out, args, os.path.abspath(path_qc))
 
         sct.display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'])
 
 
-def quick_check(fname_in, fname_out, args, path_qc):
+def generate_qc(fname_in, fname_out, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the PMJ position
     """

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -270,7 +270,7 @@ def main(args=None):
     else:
         path_results = '.'
 
-    qc_path = arguments.get("-qc", None)
+    path_qc = arguments.get("-qc", None)
 
     # Remove temp folder
     rm_tmp = bool(int(arguments.get("-r", 1)))
@@ -294,13 +294,13 @@ def main(args=None):
 
     # View results
     if fname_out is not None:
-        if qc_path is not None:
-            quick_check(fname_in, fname_out, args, os.path.abspath(qc_path))
+        if path_qc is not None:
+            quick_check(fname_in, fname_out, args, os.path.abspath(path_qc))
 
         sct.display_viewer_syntax([fname_in, fname_out], colormaps=['gray', 'red'])
 
 
-def quick_check(fname_in, fname_out, args, qc_path):
+def quick_check(fname_in, fname_out, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the PMJ position
     """
@@ -336,7 +336,7 @@ def quick_check(fname_in, fname_out, args, qc_path):
      src=fname_in,
      process="sct_detect_pmj",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane="Sagittal",
      qcslice=qcslice.Sagittal([Image(fname_in), Image(fname_out)]),
      qcslice_operations=[highlight_pmj],

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -262,7 +262,7 @@ def main(args=None):
         sct.run(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
     else:
         cmd = ['sct_straighten_spinalcord', '-i', 'data.nii', '-s', 'segmentation.nii.gz', '-r', str(remove_temp_files)]
-        if param.path_qc is not None:
+        if param.path_qc is not None and os.environ.get("SCT_RECURSIVE_QC", None) == "1":
             cmd += ['-qc', param.path_qc]
         sct.run(cmd)
 
@@ -672,7 +672,6 @@ def create_label_z(fname_seg, z, value):
     orientation_origin = nii.change_orientation('RPI')  # change orientation to RPI
     nx, ny, nz, nt, px, py, pz, pt = nii.dim  # Get dimensions
     # find x and y coordinates of the centerline at z using center of mass
-    from scipy.ndimage.measurements import center_of_mass
     x, y = center_of_mass(nii.data[:, :, z])
     x, y = int(round(x)), int(round(y))
     nii.data[:, :, :] = 0
@@ -696,7 +695,6 @@ def get_z_and_disc_values_from_label(fname_label):
     """
     nii = Image(fname_label)
     # get center of mass of label
-    from scipy.ndimage.measurements import center_of_mass
     x_label, y_label, z_label = center_of_mass(nii.data)
     x_label, y_label, z_label = int(round(x_label)), int(round(y_label)), int(round(z_label))
     # get label value

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -48,6 +48,7 @@ class Param:
         self.shift_AP_visu = 15  # 0#15  # shift AP for displaying disc values
         self.smooth_factor = [3, 1, 1]  # [3, 1, 1]
         self.gaussian_std = 1.0  # STD of the Gaussian function, centered at the most rostral point of the image, and used to weight C2-C3 disk location finding towards the rostral portion of the FOV. Values to set between 0.1 (strong weighting) and 999 (no weighting).
+        self.qc_path = None
 
     # update constructor with user's parameters
     def update(self, param_user):
@@ -162,7 +163,7 @@ sct_label_vertebrae -i t2.nii.gz -s t2_seg_manual.nii.gz  "$(< init_label_verteb
     parser.add_option(name='-qc',
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
-                      default_value=None)
+                      default_value=param_default.qc_path)
     return parser
 
 
@@ -195,6 +196,8 @@ def main(args=None):
         path_output = arguments['-ofolder']
     else:
         path_output = os.curdir
+    param.qc_path = arguments.get("-qc", None)
+
     if '-initz' in arguments:
         initz = arguments['-initz']
     if '-initcenter' in arguments:
@@ -258,7 +261,10 @@ def main(args=None):
         # apply straightening
         sct.run(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
     else:
-        sct.run(['sct_straighten_spinalcord', '-i', 'data.nii', '-s', 'segmentation.nii.gz', '-r', str(remove_temp_files), '-qc', '0'])
+        cmd = ['sct_straighten_spinalcord', '-i', 'data.nii', '-s', 'segmentation.nii.gz', '-r', str(remove_temp_files)]
+        if param.qc_path is not None:
+            cmd += ['-qc', param.qc_path]
+        sct.run(cmd)
 
     # resample to 0.5mm isotropic to match template resolution
     sct.printv('\nResample to 0.5mm isotropic...', verbose)
@@ -329,30 +335,31 @@ def main(args=None):
         sct.rmtree(path_tmp)
 
     # Generate QC report
-    try:
-        if '-qc' in arguments:
-            qc_path = os.path.abspath(arguments['-qc'])
-
-            import spinalcordtoolbox.reports.qc as qc
-            import spinalcordtoolbox.reports.slice as qcslice
-
-            qc_param = qc.Params(fname_in, 'sct_label_vertebrae', args, 'Sagittal', qc_path)
-            report = qc.QcReport(qc_param, '')
-
-            @qc.QcImage(report, 'none', [qc.QcImage.label_vertebrae, ])
-            def test(qslice):
-                return qslice.single()
-
-            labeled_seg_file = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-            test(qcslice.Sagittal(Image(fname_in), Image(labeled_seg_file)))
-            sct.printv('Sucessfully generated the QC results in %s' % qc_param.qc_results)
-            sct.printv('Use the following command to see the results in a browser:')
-            sct.printv('open file "{}/index.html"'.format(qc_path), type='info')
-    except Exception as err:
-        sct.printv(err, verbose, 'warning')
-        sct.printv('WARNING: Cannot generate report.', verbose, 'warning')
+    if param.qc_path is not None:
+        qc_path = os.path.abspath(param.qc_path)
+        labeled_seg_file = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
+        quick_check(fname_in, labeled_seg_file, args, qc_path)
 
     sct.display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'random'], opacities=['1', '0.5'])
+
+
+def quick_check(fn_in, fn_labeled, args, qc_path):
+    """
+    Generate a quick visualization of vertex labeling
+    """
+    import spinalcordtoolbox.reports.qc as qc
+    import spinalcordtoolbox.reports.slice as qcslice
+
+    qc.add_entry(
+     src=fn_in,
+     process='sct_label_vertebrae',
+     args=args,
+     qc_path=qc_path,
+     plane='Sagittal',
+     qcslice=qcslice.Sagittal([Image(fn_in), Image(fn_labeled)]),
+     qcslice_operations=[qc.QcImage.label_vertebrae],
+     qcslice_layout=lambda x: x.single(),
+    )
 
 
 # Detect vertebral levels

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -345,7 +345,7 @@ def main(args=None):
 
 def generate_qc(fn_in, fn_labeled, args, path_qc):
     """
-    Generate a quick visualization of vertex labeling
+    Generate a quick visualization of vertebral labeling
     """
     import spinalcordtoolbox.reports.qc as qc
     import spinalcordtoolbox.reports.slice as qcslice

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -338,12 +338,12 @@ def main(args=None):
     if param.path_qc is not None:
         path_qc = os.path.abspath(param.path_qc)
         labeled_seg_file = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-        quick_check(fname_in, labeled_seg_file, args, path_qc)
+        generate_qc(fname_in, labeled_seg_file, args, path_qc)
 
     sct.display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'random'], opacities=['1', '0.5'])
 
 
-def quick_check(fn_in, fn_labeled, args, path_qc):
+def generate_qc(fn_in, fn_labeled, args, path_qc):
     """
     Generate a quick visualization of vertex labeling
     """

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -350,6 +350,39 @@ def quick_check(fn_in, fn_labeled, args, qc_path):
     import spinalcordtoolbox.reports.qc as qc
     import spinalcordtoolbox.reports.slice as qcslice
 
+    def label_vertebrae(self, mask):
+        """
+        Draw vertebrae areas, then add text showing the vertebrae names.
+        """
+
+        import matplotlib.pyplot as plt
+        import scipy.ndimage
+
+        self.listed_seg(mask)
+
+        ax = plt.gca()
+        a = [0.0]
+        data = mask
+        for index, val in np.ndenumerate(data):
+            if val not in a:
+                a.append(val)
+                index = int(val)
+                if index in self._labels_regions.values():
+                    color = self._labels_color[index]
+                    y, x = scipy.ndimage.measurements.center_of_mass(np.where(data == val, data, 0))
+
+                    # Draw text with a shadow
+
+                    x += 10
+
+                    label = list(self._labels_regions.keys())[list(self._labels_regions.values()).index(index)]
+                    ax.text(x, y, label, color='black', clip_on=True)
+
+                    x -= 0.5
+                    y -= 0.5
+
+                    ax.text(x, y, label, color=color, clip_on=True)
+
     qc.add_entry(
      src=fn_in,
      process='sct_label_vertebrae',
@@ -357,7 +390,7 @@ def quick_check(fn_in, fn_labeled, args, qc_path):
      qc_path=qc_path,
      plane='Sagittal',
      qcslice=qcslice.Sagittal([Image(fn_in), Image(fn_labeled)]),
-     qcslice_operations=[qc.QcImage.label_vertebrae],
+     qcslice_operations=[label_vertebrae],
      qcslice_layout=lambda x: x.single(),
     )
 

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -48,7 +48,7 @@ class Param:
         self.shift_AP_visu = 15  # 0#15  # shift AP for displaying disc values
         self.smooth_factor = [3, 1, 1]  # [3, 1, 1]
         self.gaussian_std = 1.0  # STD of the Gaussian function, centered at the most rostral point of the image, and used to weight C2-C3 disk location finding towards the rostral portion of the FOV. Values to set between 0.1 (strong weighting) and 999 (no weighting).
-        self.qc_path = None
+        self.path_qc = None
 
     # update constructor with user's parameters
     def update(self, param_user):
@@ -163,7 +163,7 @@ sct_label_vertebrae -i t2.nii.gz -s t2_seg_manual.nii.gz  "$(< init_label_verteb
     parser.add_option(name='-qc',
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
-                      default_value=param_default.qc_path)
+                      default_value=param_default.path_qc)
     return parser
 
 
@@ -196,7 +196,7 @@ def main(args=None):
         path_output = arguments['-ofolder']
     else:
         path_output = os.curdir
-    param.qc_path = arguments.get("-qc", None)
+    param.path_qc = arguments.get("-qc", None)
 
     if '-initz' in arguments:
         initz = arguments['-initz']
@@ -262,8 +262,8 @@ def main(args=None):
         sct.run(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
     else:
         cmd = ['sct_straighten_spinalcord', '-i', 'data.nii', '-s', 'segmentation.nii.gz', '-r', str(remove_temp_files)]
-        if param.qc_path is not None:
-            cmd += ['-qc', param.qc_path]
+        if param.path_qc is not None:
+            cmd += ['-qc', param.path_qc]
         sct.run(cmd)
 
     # resample to 0.5mm isotropic to match template resolution
@@ -335,15 +335,15 @@ def main(args=None):
         sct.rmtree(path_tmp)
 
     # Generate QC report
-    if param.qc_path is not None:
-        qc_path = os.path.abspath(param.qc_path)
+    if param.path_qc is not None:
+        path_qc = os.path.abspath(param.path_qc)
         labeled_seg_file = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-        quick_check(fname_in, labeled_seg_file, args, qc_path)
+        quick_check(fname_in, labeled_seg_file, args, path_qc)
 
     sct.display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'random'], opacities=['1', '0.5'])
 
 
-def quick_check(fn_in, fn_labeled, args, qc_path):
+def quick_check(fn_in, fn_labeled, args, path_qc):
     """
     Generate a quick visualization of vertex labeling
     """
@@ -387,7 +387,7 @@ def quick_check(fn_in, fn_labeled, args, qc_path):
      src=fn_in,
      process='sct_label_vertebrae',
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane='Sagittal',
      qcslice=qcslice.Sagittal([Image(fn_in), Image(fn_labeled)]),
      qcslice_operations=[label_vertebrae],

--- a/scripts/sct_make_ground_truth.py
+++ b/scripts/sct_make_ground_truth.py
@@ -13,7 +13,7 @@
 # TODO: for -ref subject, crop data, otherwise registration is too long
 # TODO: testing script for all cases
 
-import sys, io, os, shutil, time
+import sys, io, os, time
 
 import numpy as np
 
@@ -424,7 +424,7 @@ def main():
             sct.run(['sct_apply_transfo', '-i', ftmp_seg, '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', add_suffix(ftmp_seg, '_straight')])
         else:
             cmd = ['sct_straighten_spinalcord', '-i', ftmp_seg, '-s', ftmp_seg, '-o', add_suffix(ftmp_seg, '_straight'), '-r', str(remove_temp_files), '-v', str(verbose)]
-            if param.path_qc is not None:
+            if param.path_qc is not None and os.environ.get("SCT_RECURSIVE_QC", None) == "1":
                 cmd += ["-qc", param.path_qc]
             sct.run(cmd, verbose)
         # N.B. DO NOT UPDATE VARIABLE ftmp_seg BECAUSE TEMPORARY USED LATER

--- a/scripts/sct_make_ground_truth.py
+++ b/scripts/sct_make_ground_truth.py
@@ -38,7 +38,7 @@ class Param:
         self.padding = 10  # this field is needed in the function register@sct_register_multimodal
         self.verbose = 1  # verbose
         self.path_template = os.path.join(path_sct, 'data', 'PAM50')
-        self.qc_path = None
+        self.path_qc = None
         self.zsubsample = '0.25'
         self.param_straighten = ''
 
@@ -180,7 +180,7 @@ def write_paramaters(arguments,param,ref,verbose):
     if '-param-straighten' in arguments:
         param.param_straighten = arguments['-param-straighten']
 
-    param.qc_path = arguments.get("-qc", None)
+    param.path_qc = arguments.get("-qc", None)
 
     """
     if '-cpu-nb' in arguments:
@@ -424,8 +424,8 @@ def main():
             sct.run(['sct_apply_transfo', '-i', ftmp_seg, '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', add_suffix(ftmp_seg, '_straight')])
         else:
             cmd = ['sct_straighten_spinalcord', '-i', ftmp_seg, '-s', ftmp_seg, '-o', add_suffix(ftmp_seg, '_straight'), '-r', str(remove_temp_files), '-v', str(verbose)]
-            if param.qc_path is not None:
-                cmd += ["-qc", param.qc_path]
+            if param.path_qc is not None:
+                cmd += ["-qc", param.path_qc]
             sct.run(cmd, verbose)
         # N.B. DO NOT UPDATE VARIABLE ftmp_seg BECAUSE TEMPORARY USED LATER
         # re-define warping field using non-cropped space (to avoid issue #367)
@@ -586,7 +586,7 @@ def main():
         warp_forward = ['template2subjectAffine.txt']
         warp_inverse = ['-template2subjectAffine.txt']
         try:
-            register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, qc_path=param.qc_path)
+            register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, path_qc=param.path_qc)
         except Exception:
             sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/', verbose=verbose, type='error')
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -320,7 +320,7 @@ If the segmentation fails at some location (e.g. due to poor contrast between sp
     return parser
 
 
-def quick_check(fn_in, fn_seg, args, path_qc):
+def generate_qc(fn_in, fn_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """
@@ -536,6 +536,6 @@ if __name__ == "__main__":
         os.remove(tmp_output_file.absolutepath)
 
     if path_qc is not None:
-        quick_check(fname_input_data, fname_seg, args, os.path.abspath(path_qc))
+        generate_qc(fname_input_data, fname_seg, args, os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -320,7 +320,7 @@ If the segmentation fails at some location (e.g. due to poor contrast between sp
     return parser
 
 
-def quick_check(fn_in, fn_seg, args, qc_path):
+def quick_check(fn_in, fn_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """
@@ -332,7 +332,7 @@ def quick_check(fn_in, fn_seg, args, qc_path):
      src=fn_in,
      process="sct_propseg",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane='Axial',
      qcslice=qcslice.Axial([Image(fn_in), Image(fn_seg)]),
      qcslice_operations=[qc.QcImage.listed_seg],
@@ -375,7 +375,7 @@ if __name__ == "__main__":
     if "-r" in arguments:
         remove_temp_files = int(arguments["-r"])
 
-    qc_path = arguments.get("-qc", None)
+    path_qc = arguments.get("-qc", None)
 
     verbose = 0
     if "-v" in arguments:
@@ -535,7 +535,7 @@ if __name__ == "__main__":
         sct.log.info("Remove temporary files...")
         os.remove(tmp_output_file.absolutepath)
 
-    if qc_path is not None:
-        quick_check(fname_input_data, fname_seg, args, os.path.abspath(qc_path))
+    if path_qc is not None:
+        quick_check(fname_input_data, fname_seg, args, os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])

--- a/scripts/sct_register_graymatter.py
+++ b/scripts/sct_register_graymatter.py
@@ -34,7 +34,7 @@ class Param:
         self.output_folder = '.'
         self.verbose = 1
         self.remove_tmp = 1
-        self.qc = 1
+        self.qc_path = None
 
 
 class MultiLabelRegistration:
@@ -188,7 +188,8 @@ class MultiLabelRegistration:
         if self.fname_warp_target2template is not None:
             sct.generate_output_file(os.path.join(tmp_dir, self.fname_warp_gm2template), os.path.join(self.param.output_folder, self.fname_warp_gm2template))
 
-        if self.param.qc:
+        if self.param.qc_path is not None:
+            # TODO move to qc
             fname_grid_warped = visualize_warp(os.path.join(tmp_dir, fname_warp_multilabel_template2auto), rm_tmp=self.param.remove_tmp)
             path_grid_warped, file_grid_warped, ext_grid_warped = sct.extract_fname(fname_grid_warped)
             sct.generate_output_file(fname_grid_warped, os.path.join(self.param.output_folder, file_grid_warped + ext_grid_warped))
@@ -208,7 +209,11 @@ class MultiLabelRegistration:
         curdir = os.getcwd()
         os.chdir(tmp_dir)
 
-        sct.run(['sct_warp_template', '-d', fname_manual_gmseg, '-w', self.fname_warp_template2gm, '-qc', '0', '-a', '0'])
+        cmd = ['sct_warp_template', '-d', fname_manual_gmseg, '-w', self.fname_warp_template2gm, '-a', '0']
+        if self.param.qc_path is not None:
+            cmd += ["-qc", self.param.qc_path]
+
+        sct.run(cmd)
         if 'MNI-Poly-AMU_GM.nii.gz' in os.listdir(os.path.join('label', 'template')):
             im_new_template_gm = Image(os.path.join('label', 'template', 'MNI-Poly-AMU_GM.nii.gz'))
             im_new_template_wm = Image(os.path.join('label', 'template', 'MNI-Poly-AMU_WM.nii.gz'))
@@ -571,8 +576,9 @@ if __name__ == "__main__":
         fname_template_dest = arguments['-template-original']
     if '-ofolder' in arguments:
         ml_param.output_folder = arguments['-ofolder']
-    if '-qc' in arguments:
-        ml_param.qc = int(arguments['-qc'])
+
+    ml_param.qc_path = arguments.get("-qc", None)
+
     if '-r' in arguments:
         ml_param.remove_tmp = int(arguments['-r'])
     if '-v' in arguments:

--- a/scripts/sct_register_graymatter.py
+++ b/scripts/sct_register_graymatter.py
@@ -34,7 +34,7 @@ class Param:
         self.output_folder = '.'
         self.verbose = 1
         self.remove_tmp = 1
-        self.qc_path = None
+        self.path_qc = None
 
 
 class MultiLabelRegistration:
@@ -188,7 +188,7 @@ class MultiLabelRegistration:
         if self.fname_warp_target2template is not None:
             sct.generate_output_file(os.path.join(tmp_dir, self.fname_warp_gm2template), os.path.join(self.param.output_folder, self.fname_warp_gm2template))
 
-        if self.param.qc_path is not None:
+        if self.param.path_qc is not None:
             # TODO move to qc
             fname_grid_warped = visualize_warp(os.path.join(tmp_dir, fname_warp_multilabel_template2auto), rm_tmp=self.param.remove_tmp)
             path_grid_warped, file_grid_warped, ext_grid_warped = sct.extract_fname(fname_grid_warped)
@@ -210,8 +210,8 @@ class MultiLabelRegistration:
         os.chdir(tmp_dir)
 
         cmd = ['sct_warp_template', '-d', fname_manual_gmseg, '-w', self.fname_warp_template2gm, '-a', '0']
-        if self.param.qc_path is not None:
-            cmd += ["-qc", self.param.qc_path]
+        if self.param.path_qc is not None:
+            cmd += ["-qc", self.param.path_qc]
 
         sct.run(cmd)
         if 'MNI-Poly-AMU_GM.nii.gz' in os.listdir(os.path.join('label', 'template')):
@@ -577,7 +577,7 @@ if __name__ == "__main__":
     if '-ofolder' in arguments:
         ml_param.output_folder = arguments['-ofolder']
 
-    ml_param.qc_path = arguments.get("-qc", None)
+    ml_param.path_qc = arguments.get("-qc", None)
 
     if '-r' in arguments:
         ml_param.remove_tmp = int(arguments['-r'])

--- a/scripts/sct_register_graymatter.py
+++ b/scripts/sct_register_graymatter.py
@@ -210,7 +210,7 @@ class MultiLabelRegistration:
         os.chdir(tmp_dir)
 
         cmd = ['sct_warp_template', '-d', fname_manual_gmseg, '-w', self.fname_warp_template2gm, '-a', '0']
-        if self.param.path_qc is not None:
+        if self.param.path_qc is not None and os.environ.get("SCT_RECURSIVE_QC", None) == "1":
             cmd += ["-qc", self.param.path_qc]
 
         sct.run(cmd)

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -189,7 +189,7 @@ class Param:
         self.debug = 0
         self.outSuffix  = "_reg"
         self.padding = 5
-        self.path_qc = os.path.join(os.path.abspath(os.curdir), "qc")
+        self.qc_path = os.path.join(os.path.abspath(os.curdir), "qc")
 
 # Parameters for registration
 
@@ -384,7 +384,7 @@ def main(args=None):
         file_out_inv = file_out + '_inv'
 
     # create QC folder
-    sct.create_folder(param.path_qc)
+    sct.create_folder(param.qc_path)
 
     # create temporary folder
     path_tmp = sct.tmp_create()
@@ -679,7 +679,7 @@ def register(src, dest, paramreg, param, i_step_str):
                                warp_forward_out=warp_forward_out,
                                warp_inverse_out=warp_inverse_out,
                                ants_registration_params=ants_registration_params,
-                               path_qc=param.path_qc,
+                               qc_path=param.qc_path,
                                remove_temp_files=param.remove_temp_files,
                                verbose=param.verbose)
 
@@ -711,7 +711,7 @@ def register(src, dest, paramreg, param, i_step_str):
                            warp_forward_out=warp_forward_out,
                            warp_inverse_out=warp_inverse_out,
                            ants_registration_params=ants_registration_params,
-                           path_qc=param.path_qc,
+                           qc_path=param.qc_path,
                            remove_temp_files=param.remove_temp_files,
                            verbose=param.verbose)
 
@@ -730,7 +730,7 @@ def register(src, dest, paramreg, param, i_step_str):
                            paramreg.steps[i_step_str].dof,
                            fname_affine=warp_forward_out,
                            verbose=param.verbose,
-                           path_qc=param.path_qc)
+                           qc_path=param.qc_path)
 
     if not os.path.isfile(warp_forward_out):
         # no forward warping field for rigid and affine

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -189,7 +189,7 @@ class Param:
         self.debug = 0
         self.outSuffix  = "_reg"
         self.padding = 5
-        self.qc_path = os.path.join(os.path.abspath(os.curdir), "qc")
+        self.path_qc = os.path.join(os.path.abspath(os.curdir), "qc")
 
 # Parameters for registration
 
@@ -384,7 +384,7 @@ def main(args=None):
         file_out_inv = file_out + '_inv'
 
     # create QC folder
-    sct.create_folder(param.qc_path)
+    sct.create_folder(param.path_qc)
 
     # create temporary folder
     path_tmp = sct.tmp_create()
@@ -679,7 +679,7 @@ def register(src, dest, paramreg, param, i_step_str):
                                warp_forward_out=warp_forward_out,
                                warp_inverse_out=warp_inverse_out,
                                ants_registration_params=ants_registration_params,
-                               qc_path=param.qc_path,
+                               path_qc=param.path_qc,
                                remove_temp_files=param.remove_temp_files,
                                verbose=param.verbose)
 
@@ -711,7 +711,7 @@ def register(src, dest, paramreg, param, i_step_str):
                            warp_forward_out=warp_forward_out,
                            warp_inverse_out=warp_inverse_out,
                            ants_registration_params=ants_registration_params,
-                           qc_path=param.qc_path,
+                           path_qc=param.path_qc,
                            remove_temp_files=param.remove_temp_files,
                            verbose=param.verbose)
 
@@ -730,7 +730,7 @@ def register(src, dest, paramreg, param, i_step_str):
                            paramreg.steps[i_step_str].dof,
                            fname_affine=warp_forward_out,
                            verbose=param.verbose,
-                           qc_path=param.qc_path)
+                           path_qc=param.path_qc)
 
     if not os.path.isfile(warp_forward_out):
         # no forward warping field for rigid and affine

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -40,7 +40,7 @@ class Param:
         self.padding = 10  # this field is needed in the function register@sct_register_multimodal
         self.verbose = 1  # verbose
         self.path_template = os.path.join(path_sct, 'data', 'PAM50')
-        self.qc_path = None
+        self.path_qc = None
         self.zsubsample = '0.25'
         self.param_straighten = ''
 
@@ -131,7 +131,7 @@ def get_parser():
     parser.add_option(name='-qc',
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
-                      default_value=param.qc_path)
+                      default_value=param.path_qc)
     parser.add_option(name="-igt",
                       type_value="image_nifti",
                       description="File name of ground-truth template cord segmentation (binary nifti).",
@@ -181,7 +181,7 @@ def main(args=None):
     else:
         path_output = ''
 
-    param.qc_path = arguments.get("-qc", None)
+    param.path_qc = arguments.get("-qc", None)
 
     path_template = arguments['-t']
     contrast_template = arguments['-c']
@@ -529,7 +529,7 @@ def main(args=None):
         warp_forward = ['template2subjectAffine.txt']
         warp_inverse = ['-template2subjectAffine.txt']
         try:
-            register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, qc_path=param.qc_path)
+            register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, path_qc=param.path_qc)
         except Exception:
             sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/', verbose=verbose, type='error')
 
@@ -592,14 +592,14 @@ def main(args=None):
     elapsed_time = time.time() - start_time
     sct.printv('\nFinished! Elapsed time: ' + str(int(round(elapsed_time))) + 's', verbose)
 
-    if param.qc_path is not None:
-        quick_check(fname_data, fname_template2anat, fname_seg, args, os.path.abspath(param.qc_path))
+    if param.path_qc is not None:
+        quick_check(fname_data, fname_template2anat, fname_seg, args, os.path.abspath(param.path_qc))
 
     sct.display_viewer_syntax([fname_data, fname_template2anat], verbose=verbose)
     sct.display_viewer_syntax([fname_template, fname_anat2template], verbose=verbose)
 
 
-def quick_check(fname_data, fname_template2anat, fname_seg, args, qc_path):
+def quick_check(fname_data, fname_template2anat, fname_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the straightening process.
     """
@@ -611,7 +611,7 @@ def quick_check(fname_data, fname_template2anat, fname_seg, args, qc_path):
      src=fname_data,
      process="sct_register_to_template",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane="Axial",
      qcslice=qcslice.Axial([Image(fname_data), Image(fname_template2anat), Image(fname_seg)]),
      qcslice_operations=[qc.QcImage.no_seg_seg],

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -40,7 +40,7 @@ class Param:
         self.padding = 10  # this field is needed in the function register@sct_register_multimodal
         self.verbose = 1  # verbose
         self.path_template = os.path.join(path_sct, 'data', 'PAM50')
-        self.path_qc = None
+        self.qc_path = None
         self.zsubsample = '0.25'
         self.param_straighten = ''
 
@@ -131,7 +131,7 @@ def get_parser():
     parser.add_option(name='-qc',
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
-                      default_value=param.path_qc)
+                      default_value=param.qc_path)
     parser.add_option(name="-igt",
                       type_value="image_nifti",
                       description="File name of ground-truth template cord segmentation (binary nifti).",
@@ -180,8 +180,8 @@ def main(args=None):
         path_output = arguments['-ofolder']
     else:
         path_output = ''
-    if '-qc' in arguments:
-        param.path_qc = arguments['-qc']
+
+    param.qc_path = arguments.get("-qc", None)
 
     path_template = arguments['-t']
     contrast_template = arguments['-c']
@@ -245,10 +245,6 @@ def main(args=None):
     sct.printv('  Segmentation:         ' + fname_seg, verbose)
     sct.printv('  Path template:        ' + path_template, verbose)
     sct.printv('  Remove temp files:    ' + str(remove_temp_files), verbose)
-
-    if param.path_qc is not None:
-        # create QC folder
-        sct.create_folder(param.path_qc)
 
     # check if data, segmentation and landmarks are in the same space
     # JULIEN 2017-04-25: removed because of issue #1168
@@ -533,7 +529,7 @@ def main(args=None):
         warp_forward = ['template2subjectAffine.txt']
         warp_inverse = ['-template2subjectAffine.txt']
         try:
-            register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, path_qc=param.path_qc)
+            register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, qc_path=param.qc_path)
         except Exception:
             sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/', verbose=verbose, type='error')
 
@@ -596,30 +592,31 @@ def main(args=None):
     elapsed_time = time.time() - start_time
     sct.printv('\nFinished! Elapsed time: ' + str(int(round(elapsed_time))) + 's', verbose)
 
-    if param.path_qc is not None:
-        qc_path = os.path.abspath(param.path_qc)
-
-        import spinalcordtoolbox.reports.qc as qc
-        import spinalcordtoolbox.reports.slice as qcslice
-
-        qc_param = qc.Params(fname_data, 'sct_register_to_template', args, 'Axial', qc_path)
-        report = qc.QcReport(qc_param, '')
-
-        @qc.QcImage(report, 'none', [qc.QcImage.no_seg_seg])
-        def test(qslice):
-            return qslice.mosaic()
-
-        fname_template2anat = os.path.join(path_output, "template2anat" + ext_data)
-        try:
-            test(qcslice.AxialTemplate2Anat(Image(fname_data), Image(fname_template2anat), Image(fname_seg)))
-            sct.printv('Sucessfully generate the QC results in %s' % qc_param.qc_results)
-            sct.printv('Use the following command to see the results in a browser')
-            sct.printv('open file "{}/index.html"'.format(qc_path), type='info')
-        except:
-            sct.log.warning('Issue when creating QC report.')
+    if param.qc_path is not None:
+        quick_check(fname_data, fname_template2anat, fname_seg, args, os.path.abspath(param.qc_path))
 
     sct.display_viewer_syntax([fname_data, fname_template2anat], verbose=verbose)
     sct.display_viewer_syntax([fname_template, fname_anat2template], verbose=verbose)
+
+
+def quick_check(fname_data, fname_template2anat, fname_seg, args, qc_path):
+    """
+    Generate a QC entry allowing to quickly review the straightening process.
+    """
+
+    import spinalcordtoolbox.reports.qc as qc
+    import spinalcordtoolbox.reports.slice as qcslice
+
+    qc.add_entry(
+     src=fname_data,
+     process="sct_register_to_template",
+     args=args,
+     qc_path=qc_path,
+     plane="Axial",
+     qcslice=qcslice.Axial([Image(fname_data), Image(fname_template2anat), Image(fname_seg)]),
+     qcslice_operations=[qc.QcImage.no_seg_seg],
+     qcslice_layout=lambda x: x.mosaic()[:2],
+    )
 
 
 # Resample labels

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -593,13 +593,13 @@ def main(args=None):
     sct.printv('\nFinished! Elapsed time: ' + str(int(round(elapsed_time))) + 's', verbose)
 
     if param.path_qc is not None:
-        quick_check(fname_data, fname_template2anat, fname_seg, args, os.path.abspath(param.path_qc))
+        generate_qc(fname_data, fname_template2anat, fname_seg, args, os.path.abspath(param.path_qc))
 
     sct.display_viewer_syntax([fname_data, fname_template2anat], verbose=verbose)
     sct.display_viewer_syntax([fname_template, fname_anat2template], verbose=verbose)
 
 
-def quick_check(fname_data, fname_template2anat, fname_seg, args, path_qc):
+def generate_qc(fname_data, fname_template2anat, fname_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the straightening process.
     """

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -724,8 +724,9 @@ def main(args=None):
         param_seg.fname_manual_gmseg = arguments['-ref']
     if '-ofolder' in arguments:
         param_seg.path_results = os.path.abspath(arguments['-ofolder'])
-    if '-qc' in arguments:
-        param_seg.qc = os.path.abspath(arguments['-qc'])
+
+    param_seg.qc = arguments.get("-qc", None)
+
     if '-r' in arguments:
         param.rm_tmp = bool(int(arguments['-r']))
     if '-v' in arguments:
@@ -747,53 +748,56 @@ def main(args=None):
         gm_col = 'red-yellow'
         b = '0.4,1'
 
-    if param_seg.qc:
-        qc_path = param_seg.qc
-        # output QC image
-        printv('\nSave quality control images...', param.verbose, 'normal')
+    if param_seg.qc is not None:
+        quick_check(param_seg.fname_im_original, seg_gm.fname_res_gmseg,
+         seg_gm.fname_res_wmseg, param_seg, args, os.path.abspath(param_seg.qc))
 
-        import spinalcordtoolbox.reports.qc as qc
-        import spinalcordtoolbox.reports.slice as qcslice
-
-        qc_param = qc.Params(param_seg.fname_im, 'sct_segment_graymatter', args, 'Axial', qc_path)
-        report = qc.QcReport(qc_param, '')
-
-        @qc.QcImage(report, 'none', [qc.QcImage.listed_seg])
-        def test(qslice):
-            return qslice.mosaic()
-
-        im_org = Image(param_seg.fname_im_original)
-        im_gm = Image(seg_gm.fname_res_gmseg)
-        im_wm = Image(seg_gm.fname_res_wmseg)
-
-        # create simple compound segmentation image for QC purposes
-
-        if param_seg.type_seg == 'bin':
-            im_wm.data[im_wm.data == 1] = 1
-            im_gm.data[im_gm.data == 1] = 2
-        else:
-            # binarize anyway
-            im_wm.data[im_wm.data >= param_seg.thr_bin] = 1
-            im_wm.data[im_wm.data < param_seg.thr_bin] = 0
-            im_gm.data[im_gm.data >= param_seg.thr_bin] = 2
-            im_gm.data[im_gm.data < param_seg.thr_bin] = 0
-
-        im_seg = im_gm
-        im_seg.data += im_wm.data
-
-        try:
-            test(qcslice.Axial(im_org, im_seg))
-            sct.printv('Sucessfully generate the QC results in %s' % qc_param.qc_results)
-            sct.printv('Use the following command to see the results in a browser')
-            sct.printv('open file "{}/index.html"'.format(qc_path), type='info')
-        except:
-            sct.log.warning('Issue when creating QC report.')
 
     if param.rm_tmp:
         # remove tmp_dir
         sct.rmtree(seg_gm.tmp_dir)
 
     sct.display_viewer_syntax([param_seg.fname_im_original, seg_gm.fname_res_gmseg, seg_gm.fname_res_wmseg], colormaps=['gray', gm_col, wm_col], minmax=['', b, b], opacities=['1', '0.7', '0.7'], verbose=param.verbose)
+
+def quick_check(fname_in, fname_gm, fname_wm, param_seg, args, qc_path):
+    """
+    Generate a QC entry allowing to quickly review the segmentation process.
+    """
+
+    import spinalcordtoolbox.reports.qc as qc
+    import spinalcordtoolbox.reports.slice as qcslice
+
+    im_org = Image(fname_in)
+    im_gm = Image(fname_gm)
+    im_wm = Image(fname_wm)
+
+    # create simple compound segmentation image for QC purposes
+
+    if param_seg.type_seg == 'bin':
+        im_wm.data[im_wm.data == 1] = 1
+        im_gm.data[im_gm.data == 1] = 2
+    else:
+        # binarize anyway
+        im_wm.data[im_wm.data >= param_seg.thr_bin] = 1
+        im_wm.data[im_wm.data < param_seg.thr_bin] = 0
+        im_gm.data[im_gm.data >= param_seg.thr_bin] = 2
+        im_gm.data[im_gm.data < param_seg.thr_bin] = 0
+
+    im_seg = im_gm
+    im_seg.data += im_wm.data
+
+    s = qcslice.Axial([im_org, im_seg])
+
+    qc.add_entry(
+     src=fname_in,
+     process="sct_segment_graymatter",
+     args=args,
+     qc_path=qc_path,
+     plane='Axial',
+     qcslice=s,
+     qcslice_operations=[qc.QcImage.listed_seg],
+     qcslice_layout=lambda x: x.mosaic(),
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -749,7 +749,7 @@ def main(args=None):
         b = '0.4,1'
 
     if param_seg.qc is not None:
-        quick_check(param_seg.fname_im_original, seg_gm.fname_res_gmseg,
+        generate_qc(param_seg.fname_im_original, seg_gm.fname_res_gmseg,
          seg_gm.fname_res_wmseg, param_seg, args, os.path.abspath(param_seg.qc))
 
 
@@ -759,7 +759,7 @@ def main(args=None):
 
     sct.display_viewer_syntax([param_seg.fname_im_original, seg_gm.fname_res_gmseg, seg_gm.fname_res_wmseg], colormaps=['gray', gm_col, wm_col], minmax=['', b, b], opacities=['1', '0.7', '0.7'], verbose=param.verbose)
 
-def quick_check(fname_in, fname_gm, fname_wm, param_seg, args, path_qc):
+def generate_qc(fname_in, fname_gm, fname_wm, param_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -759,7 +759,7 @@ def main(args=None):
 
     sct.display_viewer_syntax([param_seg.fname_im_original, seg_gm.fname_res_gmseg, seg_gm.fname_res_wmseg], colormaps=['gray', gm_col, wm_col], minmax=['', b, b], opacities=['1', '0.7', '0.7'], verbose=param.verbose)
 
-def quick_check(fname_in, fname_gm, fname_wm, param_seg, args, qc_path):
+def quick_check(fname_in, fname_gm, fname_wm, param_seg, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the segmentation process.
     """
@@ -792,7 +792,7 @@ def quick_check(fname_in, fname_gm, fname_wm, param_seg, args, qc_path):
      src=fname_in,
      process="sct_segment_graymatter",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane='Axial',
      qcslice=s,
      qcslice_operations=[qc.QcImage.listed_seg],

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -156,7 +156,7 @@ def main(args=None):
         # apply straightening
         sct.run(['sct_apply_transfo', '-i', 'anat_rpi.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'anat_rpi_straight.nii', '-x', 'spline'], verbose)
     else:
-        sct.run(['sct_straighten_spinalcord', '-i', 'anat_rpi.nii', '-s', 'centerline_rpi.nii', '-qc', '0', '-x', 'spline'], verbose)
+        sct.run(['sct_straighten_spinalcord', '-i', 'anat_rpi.nii', '-s', 'centerline_rpi.nii', '-x', 'spline'], verbose)
 
     # Smooth the straightened image along z
     sct.printv('\nSmooth the straightened image along z...')

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -174,7 +174,7 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
             x_centerline_deriv, y_centerline_deriv, z_centerline_deriv
 
 
-def quick_check(fn_input, fn_centerline, fn_output, args, path_qc):
+def generate_qc(fn_input, fn_centerline, fn_output, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the straightening process.
     """
@@ -1026,7 +1026,7 @@ def main(args=None):
     if sc_straight.curved2straight:
 
         if path_qc is not None:
-           quick_check(input_filename, centerline_file,
+           generate_qc(input_filename, centerline_file,
             fname_straight, args, os.path.abspath(path_qc))
 
         sct.display_viewer_syntax([fname_straight], verbose=verbose)

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -154,7 +154,7 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
         curdir = os.getcwd()
 
         x_centerline_fit, y_centerline_fit, z_centerline_fit, x_centerline_deriv, y_centerline_deriv,\
-            z_centerline_deriv, mse = b_spline_nurbs(x_centerline, y_centerline, z_centerline, nbControl=None, qc_path=curdir, point_number=nurbs_pts_number, verbose=verbose, all_slices=all_slices)
+            z_centerline_deriv, mse = b_spline_nurbs(x_centerline, y_centerline, z_centerline, nbControl=None, path_qc=curdir, point_number=nurbs_pts_number, verbose=verbose, all_slices=all_slices)
 
         # Checking accuracy of fitting. If NURBS fitting is not accurate enough, do not smooth segmentation
         if mse >= 2.0:
@@ -174,7 +174,7 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
             x_centerline_deriv, y_centerline_deriv, z_centerline_deriv
 
 
-def quick_check(fn_input, fn_centerline, fn_output, args, qc_path):
+def quick_check(fn_input, fn_centerline, fn_output, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the straightening process.
     """
@@ -190,7 +190,7 @@ def quick_check(fn_input, fn_centerline, fn_output, args, qc_path):
      src=fn_input,
      process="sct_straighten_spinalcord",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane="Sagittal",
      foreground=foreground,
     )
@@ -239,7 +239,7 @@ class SpinalCordStraightener(object):
 
         self.template_orientation = 0
 
-        self.qc_path = None
+        self.path_qc = None
 
     def straighten(self):
         # Initialization
@@ -992,7 +992,7 @@ def main(args=None):
     # if "-cpu-nb" in arguments:
     #     sc_straight.cpu_number = int(arguments["-cpu-nb"])
 
-    qc_path = arguments.get("-qc", None)
+    path_qc = arguments.get("-qc", None)
 
     if '-disable-straight2curved' in arguments:
         sc_straight.straight2curved = False
@@ -1025,9 +1025,9 @@ def main(args=None):
 
     if sc_straight.curved2straight:
 
-        if qc_path is not None:
+        if path_qc is not None:
            quick_check(input_filename, centerline_file,
-            fname_straight, args, os.path.abspath(qc_path))
+            fname_straight, args, os.path.abspath(path_qc))
 
         sct.display_viewer_syntax([fname_straight], verbose=verbose)
 

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -19,6 +19,7 @@ import numpy as np
 from nibabel import Nifti1Image, save
 from scipy import ndimage
 
+from msct_image import Image
 from msct_parser import Parser
 from sct_apply_transfo import Transform
 import sct_utils as sct
@@ -38,7 +39,6 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
     sct.printv('\nSmooth centerline/segmentation...', verbose)
 
     # get dimensions (again!)
-    from msct_image import Image
     file_image = None
     if isinstance(fname_centerline, str):
         file_image = Image(fname_centerline)
@@ -154,7 +154,7 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
         curdir = os.getcwd()
 
         x_centerline_fit, y_centerline_fit, z_centerline_fit, x_centerline_deriv, y_centerline_deriv,\
-            z_centerline_deriv, mse = b_spline_nurbs(x_centerline, y_centerline, z_centerline, nbControl=None, path_qc=curdir, point_number=nurbs_pts_number, verbose=verbose, all_slices=all_slices)
+            z_centerline_deriv, mse = b_spline_nurbs(x_centerline, y_centerline, z_centerline, nbControl=None, qc_path=curdir, point_number=nurbs_pts_number, verbose=verbose, all_slices=all_slices)
 
         # Checking accuracy of fitting. If NURBS fitting is not accurate enough, do not smooth segmentation
         if mse >= 2.0:
@@ -172,6 +172,28 @@ def smooth_centerline(fname_centerline, algo_fitting='hanning', type_window='han
 
     return x_centerline_fit, y_centerline_fit, z_centerline_fit, \
             x_centerline_deriv, y_centerline_deriv, z_centerline_deriv
+
+
+def quick_check(fn_input, fn_centerline, fn_output, args, qc_path):
+    """
+    Generate a QC entry allowing to quickly review the straightening process.
+    """
+
+    import spinalcordtoolbox.reports.qc as qc
+    import spinalcordtoolbox.reports.slice as qcslice
+
+    # Just display the straightened spinal cord
+    img_out = Image(fn_output)
+    foreground = qcslice.Sagittal([img_out]).single()[0]
+
+    qc.add_entry(
+     src=fn_input,
+     process="sct_straighten_spinalcord",
+     args=args,
+     qc_path=qc_path,
+     plane="Sagittal",
+     foreground=foreground,
+    )
 
 
 class SpinalCordStraightener(object):
@@ -217,6 +239,8 @@ class SpinalCordStraightener(object):
 
         self.template_orientation = 0
 
+        self.qc_path = None
+
     def straighten(self):
         # Initialization
         fname_anat = self.input_filename
@@ -231,7 +255,6 @@ class SpinalCordStraightener(object):
         algo_fitting = self.algo_fitting
         window_length = self.window_length
         type_window = self.type_window
-        qc = self.qc
 
         # start timer
         start_time = time.time()
@@ -277,7 +300,6 @@ class SpinalCordStraightener(object):
 
             # Get dimension
             sct.printv('\nGet dimensions...', verbose)
-            from msct_image import Image
             image_centerline = Image('centerline_rpi.nii.gz')
             nx, ny, nz, nt, px, py, pz, pt = image_centerline.dim
             sct.printv('.. matrix size: ' + str(nx) + ' x ' + str(ny) + ' x ' + str(nz), verbose)
@@ -725,7 +747,6 @@ class SpinalCordStraightener(object):
                 Transform(input_filename='centerline.nii.gz', fname_dest=fname_ref,
                           output_filename="tmp.centerline_straight.nii.gz", interp="nn",
                           warp="tmp.curve2straight.nii.gz", verbose=verbose).apply()
-                from msct_image import Image
                 file_centerline_straight = Image('tmp.centerline_straight.nii.gz', verbose=verbose)
                 coordinates_centerline = file_centerline_straight.getNonZeroCoordinates(sorting='z')
                 mean_coord = []
@@ -800,13 +821,9 @@ class SpinalCordStraightener(object):
         if self.accuracy_results:
             sct.printv('    including ' + str(int(np.round(self.elapsed_time_accuracy))) + ' s spent computing '
                                                                                       'accuracy results', verbose)
-        if self.curved2straight:
-            sct.display_viewer_syntax([fname_straight], verbose=verbose)
 
-        # output QC image
-        if qc and self.curved2straight:
-            from msct_image import Image
-            Image(fname_straight).save_quality_control(plane='sagittal', n_slices=1, path_output=self.path_output)
+        return fname_straight
+
 
 
 def get_parser():
@@ -918,11 +935,9 @@ def get_parser():
                       deprecated_by='-param')
 
     parser.add_option(name='-qc',
-                      type_value='multiple_choice',
-                      description='Output images for quality control.',
-                      mandatory=False,
-                      example=['0', '1'],
-                      default_value='0')
+                      type_value='folder_creation',
+                      description='The path where the quality control generated content will be saved',
+                      default_value=None)
 
     return parser
 
@@ -970,12 +985,14 @@ def main(args=None):
         sc_straight.path_output = arguments['-ofolder']
     else:
         sc_straight.path_output = './'
-    if "-v" in arguments:
-        sc_straight.verbose = int(arguments["-v"])
+
+    verbose = int(arguments.get("-v", 0))
+    sc_straight.verbose = verbose
+
     # if "-cpu-nb" in arguments:
     #     sc_straight.cpu_number = int(arguments["-cpu-nb"])
-    if '-qc' in arguments:
-        sc_straight.qc = int(arguments['-qc'])
+
+    qc_path = arguments.get("-qc", None)
 
     if '-disable-straight2curved' in arguments:
         sc_straight.straight2curved = False
@@ -1004,7 +1021,15 @@ def main(args=None):
             if param_split[0] == 'template_orientation':
                 sc_straight.template_orientation = int(param_split[1])
 
-    sc_straight.straighten()
+    fname_straight = sc_straight.straighten()
+
+    if sc_straight.curved2straight:
+
+        if qc_path is not None:
+           quick_check(input_filename, centerline_file,
+            fname_straight, args, os.path.abspath(qc_path))
+
+        sct.display_viewer_syntax([fname_straight], verbose=verbose)
 
 
 # START PROGRAM

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -238,7 +238,7 @@ def get_parser():
     return parser
 
 
-def quick_check(fn_in, fn_wm, args, path_qc):
+def generate_qc(fn_in, fn_wm, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the warped template.
     """
@@ -279,7 +279,7 @@ def main(args=None):
 
     if path_qc is not None:
         fname_wm = os.path.join(w.folder_out, w.folder_template, get_file_label(os.path.join(w.folder_out, w.folder_template), 'white matter'))
-        quick_check(fname_src, fname_wm, sys.argv[1:], os.path.abspath(path_qc))
+        generate_qc(fname_src, fname_wm, sys.argv[1:], os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_src,
                                    os.path.join(w.folder_out, w.folder_template, get_file_label(os.path.join(w.folder_out, w.folder_template), 'T2')),

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -40,11 +40,11 @@ class Param:
         self.warp_spinal_levels = 0
         self.list_labels_nn = ['_level.nii.gz', '_levels.nii.gz', '_csf.nii.gz', '_CSF.nii.gz', '_cord.nii.gz']  # list of files for which nn interpolation should be used. Default = linear.
         self.verbose = 1  # verbose
-        self.qc_path = None
+        self.path_qc = None
 
 
 class WarpTemplate:
-    def __init__(self, fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose, qc_path):
+    def __init__(self, fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose, path_qc):
 
         # Initialization
         self.fname_src = fname_src
@@ -228,7 +228,7 @@ def get_parser():
     parser.add_option(name='-qc',
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
-                      default_value=param_default.qc_path)
+                      default_value=param_default.path_qc)
     parser.add_option(name="-v",
                       type_value="multiple_choice",
                       description="""Verbose.""",
@@ -238,7 +238,7 @@ def get_parser():
     return parser
 
 
-def quick_check(fn_in, fn_wm, args, qc_path):
+def quick_check(fn_in, fn_wm, args, path_qc):
     """
     Generate a QC entry allowing to quickly review the warped template.
     """
@@ -250,7 +250,7 @@ def quick_check(fn_in, fn_wm, args, qc_path):
      src=fn_in,
      process="sct_warp_template",
      args=args,
-     qc_path=qc_path,
+     path_qc=path_qc,
      plane='Axial',
      qcslice=qcslice.Axial([Image(fn_in), Image(fn_wm)]),
      qcslice_operations=[qc.QcImage.template],
@@ -272,14 +272,14 @@ def main(args=None):
     folder_out = arguments['-ofolder']
     path_template = arguments['-t']
     verbose = int(arguments['-v'])
-    qc_path = arguments.get("-qc", None)
+    path_qc = arguments.get("-qc", None)
 
     # call main function
-    w = WarpTemplate(fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose, qc_path)
+    w = WarpTemplate(fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose, path_qc)
 
-    if qc_path is not None:
+    if path_qc is not None:
         fname_wm = os.path.join(w.folder_out, w.folder_template, get_file_label(os.path.join(w.folder_out, w.folder_template), 'white matter'))
-        quick_check(fname_src, fname_wm, sys.argv[1:], os.path.abspath(qc_path))
+        quick_check(fname_src, fname_wm, sys.argv[1:], os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_src,
                                    os.path.join(w.folder_out, w.folder_template, get_file_label(os.path.join(w.folder_out, w.folder_template), 'T2')),

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -44,7 +44,7 @@ class Param:
 
 
 class WarpTemplate:
-    def __init__(self, fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose, path_qc):
+    def __init__(self, fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose):
 
         # Initialization
         self.fname_src = fname_src
@@ -275,7 +275,7 @@ def main(args=None):
     path_qc = arguments.get("-qc", None)
 
     # call main function
-    w = WarpTemplate(fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose, path_qc)
+    w = WarpTemplate(fname_src, fname_transfo, warp_atlas, warp_spinal_levels, folder_out, path_template, verbose)
 
     if path_qc is not None:
         fname_wm = os.path.join(w.folder_out, w.folder_template, get_file_label(os.path.join(w.folder_out, w.folder_template), 'white matter'))

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -17,7 +17,6 @@ matplotlib.use('Agg')
 import matplotlib.colorbar as colorbar
 import matplotlib.colors as color
 import matplotlib.pyplot as plt
-from scipy import ndimage
 
 import sct_utils as sct
 
@@ -129,22 +128,6 @@ class QcImage(object):
                          aspect=self.aspect_mask)
         fig.axes.get_xaxis().set_visible(False)
         fig.axes.get_yaxis().set_visible(False)
-
-    def label_vertebrae(self, mask):
-        self.listed_seg(mask)
-        ax = plt.gca()
-        a = [0.0]
-        data = mask
-        for index, val in np.ndenumerate(data):
-            if val not in a:
-                a.append(val)
-                index = int(val)
-                if index in self._labels_regions.values():
-                    color = self._labels_color[index]
-                    x, y = ndimage.measurements.center_of_mass(np.where(data == val, data, 0))
-                    label = list(self._labels_regions.keys())[list(self._labels_regions.values()).index(index)]
-                    ax.text(y, x, label, color='black', weight='heavy', clip_on=True)
-                    ax.text(y, x, label, color=color, clip_on=True)
 
     def colorbar(self):
         fig = plt.figure(figsize=(9, 1.5))

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -382,7 +382,7 @@ class QcReport(object):
                              dest_full_path)
 
 
-def add_entry(src, process, args, qc_path, plane, background=None, foreground=None,
+def add_entry(src, process, args, path_qc, plane, background=None, foreground=None,
  qcslice=None,
  qcslice_operations=[],
  qcslice_layout=None,
@@ -390,7 +390,7 @@ def add_entry(src, process, args, qc_path, plane, background=None, foreground=No
     """
     """
 
-    qc_param = Params(src, process, args, plane, qc_path)
+    qc_param = Params(src, process, args, plane, path_qc)
     report = QcReport(qc_param, '')
 
     if qcslice is not None:
@@ -416,4 +416,4 @@ def add_entry(src, process, args, qc_path, plane, background=None, foreground=No
 
     sct.printv('Sucessfully generated the QC results in %s' % qc_param.qc_results)
     sct.printv('Use the following command to see the results in a browser:')
-    sct.printv('open file "{}/index.html"'.format(qc_path), type='info')
+    sct.printv('open file "{}/index.html"'.format(path_qc), type='info')

--- a/testing/test_sct_deepseg_gm.py
+++ b/testing/test_sct_deepseg_gm.py
@@ -20,7 +20,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2s/t2s_uncropped.nii.gz -o t2s_uncropped_gmseg.nii.gz']
+    default_args = ['-i t2s/t2s_uncropped.nii.gz -o t2s_uncropped_gmseg.nii.gz -qc testing-qc']
     param_test.dice_threshold = 0.85
     param_test.f_ground_truth = 't2s/t2s_uncropped_gmseg_manual.nii.gz'
 

--- a/testing/test_sct_deepseg_sc.py
+++ b/testing/test_sct_deepseg_sc.py
@@ -22,7 +22,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -c t2 -igt t2/t2_seg_manual.nii.gz']  # default parameters
+    default_args = ['-i t2/t2.nii.gz -c t2 -igt t2/t2_seg_manual.nii.gz -qc testing-qc']  # default parameters
 
     param_test.dice_threshold = 0.8
 

--- a/testing/test_sct_detect_pmj.py
+++ b/testing/test_sct_detect_pmj.py
@@ -22,7 +22,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i template/template/PAM50_small_t2.nii.gz -c t2 -igt template/template/PAM50_small_t2_pmj_manual.nii.gz']
+    default_args = ['-i template/template/PAM50_small_t2.nii.gz -c t2 -igt template/template/PAM50_small_t2_pmj_manual.nii.gz -qc testing-qc']
     param_test.dist_threshold = 10.0
 
     # assign default params

--- a/testing/test_sct_label_vertebrae.py
+++ b/testing/test_sct_label_vertebrae.py
@@ -17,7 +17,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -c t2 -initfile t2/init_label_vertebrae.txt -t template/']
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -c t2 -initfile t2/init_label_vertebrae.txt -t template -qc testing-qc']
     # assign default params
     if not param_test.args:
         param_test.args = default_args

--- a/testing/test_sct_propseg.py
+++ b/testing/test_sct_propseg.py
@@ -21,7 +21,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -c t2 -igt t2/t2_seg_manual.nii.gz']  # default parameters
+    default_args = ['-i t2/t2.nii.gz -c t2 -igt t2/t2_seg_manual.nii.gz -qc testing-qc']  # default parameters
     # param_test.list_fname_gt = [os.path.join(param_test.path_data, 't2', 't2_seg_manual.nii.gz')]  # file name suffix for ground truth (used for integrity testing)
     param_test.dice_threshold = 0.9
 

--- a/testing/test_sct_register_graymatter.py
+++ b/testing/test_sct_register_graymatter.py
@@ -15,7 +15,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-t mt/label/ -w mt/warp_template2mt.nii.gz -gm mt/mt1_gmseg.nii.gz -wm mt/mt1_wmseg.nii.gz -manual-gm mt/mt1_gmseg_goldstandard.nii.gz -sc mt/mt1_seg.nii.gz -qc 0 -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=im,algo=syn,metric=MeanSquares,iter=3,smooth=0,shrink=2']
+    default_args = ['-t mt/label/ -w mt/warp_template2mt.nii.gz -gm mt/mt1_gmseg.nii.gz -wm mt/mt1_wmseg.nii.gz -manual-gm mt/mt1_gmseg_goldstandard.nii.gz -sc mt/mt1_seg.nii.gz -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=im,algo=syn,metric=MeanSquares,iter=3,smooth=0,shrink=2']
     # assign default params
     if not param_test.args:
         param_test.args = default_args
@@ -59,7 +59,7 @@ def test_integrity(param_test):
 # def test(path_data, parameters=''):
 #
 #     if not parameters:
-#         parameters = ' -t mt/label/ -w mt/warp_template2mt.nii.gz -gm mt/mt1_gmseg.nii.gz -wm mt/mt1_wmseg.nii.gz -manual-gm mt/mt1_gmseg_goldstandard.nii.gz -sc mt/mt1_seg.nii.gz -qc 0' #-d mt/mt0.nii.gz
+#         parameters = ' -t mt/label/ -w mt/warp_template2mt.nii.gz -gm mt/mt1_gmseg.nii.gz -wm mt/mt1_wmseg.nii.gz -manual-gm mt/mt1_gmseg_goldstandard.nii.gz -sc mt/mt1_seg.nii.gz' #-d mt/mt0.nii.gz
 #
 #     parser = sct_register_graymatter.get_parser()
 #     dict_param = parser.parse(parameters.split(), check_file_exist=False)

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -21,7 +21,7 @@ def init(param_test):
     """
 
     # initialization
-    default_args = ['-i t2/t2.nii.gz -l t2/labels.nii.gz -s t2/t2_seg.nii.gz -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares -t template -r 0 -igt template/template/PAM50_small_cord.nii.gz']
+    default_args = ['-i t2/t2.nii.gz -l t2/labels.nii.gz -s t2/t2_seg.nii.gz -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares -t template -r 0 -igt template/template/PAM50_small_cord.nii.gz -qc testing-qc']
     param_test.dice_threshold = 0.9
 
     # assign default params

--- a/testing/test_sct_segment_graymatter.py
+++ b/testing/test_sct_segment_graymatter.py
@@ -28,7 +28,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2s/t2s.nii.gz -s t2s/t2s_seg.nii.gz -vertfile t2s/MNI-Poly-AMU_level_crop.nii.gz -ref t2s/t2s_gmseg_manual.nii.gz -ratio level']
+    default_args = ['-i t2s/t2s.nii.gz -s t2s/t2s_seg.nii.gz -vertfile t2s/MNI-Poly-AMU_level_crop.nii.gz -ref t2s/t2s_gmseg_manual.nii.gz -ratio level -qc testing-qc']
 
     param_test.hd_threshold = 3  # in mm
     param_test.wm_dice_threshold = 0.8

--- a/testing/test_sct_segment_graymatter.py
+++ b/testing/test_sct_segment_graymatter.py
@@ -28,7 +28,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2s/t2s.nii.gz -s t2s/t2s_seg.nii.gz -vertfile t2s/MNI-Poly-AMU_level_crop.nii.gz -ref t2s/t2s_gmseg_manual.nii.gz -qc 0 -ratio level']
+    default_args = ['-i t2s/t2s.nii.gz -s t2s/t2s_seg.nii.gz -vertfile t2s/MNI-Poly-AMU_level_crop.nii.gz -ref t2s/t2s_gmseg_manual.nii.gz -ratio level']
 
     param_test.hd_threshold = 3  # in mm
     param_test.wm_dice_threshold = 0.8

--- a/testing/test_sct_straighten_spinalcord.py
+++ b/testing/test_sct_straighten_spinalcord.py
@@ -25,7 +25,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -param accuracy_results=1']
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -param accuracy_results=1 -qc testing-qc']
 
     param_test.fname_segmentation = 't2/t2_seg.nii.gz'
     param_test.th_result_dist_max = 2.0

--- a/testing/test_sct_warp_template.py
+++ b/testing/test_sct_warp_template.py
@@ -16,7 +16,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-d mt/mt1.nii.gz -w mt/warp_template2mt.nii.gz -a 0 -t template -qc testing-qc']  # default parameters
+    default_args = ['-d mt/mt1.nii.gz -w mt/warp_template2mt.nii.gz -a 0 -t template']  # default parameters
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_warp_template.py
+++ b/testing/test_sct_warp_template.py
@@ -16,7 +16,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-d mt/mt1.nii.gz -w mt/warp_template2mt.nii.gz -a 0 -t template -qc 0']  # default parameters
+    default_args = ['-d mt/mt1.nii.gz -w mt/warp_template2mt.nii.gz -a 0 -t template']  # default parameters
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_warp_template.py
+++ b/testing/test_sct_warp_template.py
@@ -16,7 +16,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-d mt/mt1.nii.gz -w mt/warp_template2mt.nii.gz -a 0 -t template']  # default parameters
+    default_args = ['-d mt/mt1.nii.gz -w mt/warp_template2mt.nii.gz -a 0 -t template -qc testing-qc']  # default parameters
 
     # assign default params
     if not param_test.args:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -122,18 +122,6 @@ def test_propseg(t2_image, t2_seg_image):
     assert os.path.isfile(param.qc_results)
 
 
-def test_register_to_template(t2_image, t2_seg_image):
-    param = qc.Params(t2_image, 'sct_register_to_template', ['-w', 'aaa'], 'SagittalTemplate2Anat', '/tmp')
-    report = qc.QcReport(param, 'bla bla')
-
-    @qc.QcImage(report, 'bicubic', [qc.QcImage.no_seg_seg])
-    def test(qslice):
-        return qslice.single()
-
-    test(qcslice.SagittalTemplate2Anat(t2_image, t2_seg_image, t2_seg_image))
-    assert os.path.isfile(param.abs_bkg_img_path())
-    assert os.path.isfile(param.abs_overlay_img_path())
-
 
 # def test_segment_graymatter(t2_image, t2_seg_image):
 #     param = qc.Params(['ofolder=/tmp/graymatter', ])


### PR DESCRIPTION
This PR brings:

- Make `sct_*` scripts all use the same QC and `-qc /path/to/qc` option.
  The commands which were still using the `-qc {0,1}` option:
  - `sct_straighten_spinalcord`
  - `sct_detect_pmj`
  - `sct_warp_template`
- When a command is called with the QC option, pass it along to its children.
- Refactor the QC code to reduce some duplication, and improve clarity a little.
- Make QC known as the abbreviation of QuickCheck. Later we can have consistency with QuickDiff which would generate A/B comparison reports.

How:

- Each `sct_` script that has a QC feature has a `quick_check()` function added, which (normally) takes the inputs and outputs of the process, and generates a quick check entry.
- The function is called from the `main()` or in a context that is the same that uses the command-line argument parser. Previously, it may happen that the QC code be deeper in the processing code. We try as much as possible to have QC be something that can be called independently from the process, by importing the script module and running the function.
- The script's `quick_check()` function mostly calls the `qc.add_entry()` function, with a minimal parameter list that allows to cater for what we need. Note: the API is very rough and could be cleaned by a deeper refactoring of QC, which wasn't performed here... but it's working.

What is not done yet:

- Refactor QC image/report/add_entry to make the report generation process more straightforward:
  - Right now the decorator magic is hidden inside `qc`, but the parameters to `add_entry()` aren't as concise as they could be.
  - The way to compute the ROI (use the slice last image) is still not explicit enough.
  - The anatomical plane spec must be in accordance to the slice spec (this also leads to the HTML class of the image...) so the `plane` parameter could be everything, and a list of images could be provided. Haven't thought of an API yet, but since we're talking about generation of background and overlay images, we could have background data, and arguments for labeled data or probability data (non-binarized segmentation data, or statistical atlas). Being able to provide a locally-constructed background/overlay is still desired.
- Use `matplotlib` class API, not pyplot, and remove the matplotlib import workarounds