### PR TITLE
Improvements in straightening and registration to the template

### DIFF
--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -837,21 +837,21 @@ def get_parser():
                       description="centerline or segmentation.",
                       mandatory=False,
                       deprecated_by='-s')
-    parser.add_option(name="-ref",
+    parser.add_option(name="-dest",
                       type_value="image_nifti",
-                      description="reference centerline (or segmentation) on which to register the input image, using the same philosophy as straightening procedure..",
+                      description="The spinal cord centerline of a destination image to which the input image will be registered. By default, a length-wise algorithm will match the two centerline prior to registration. For other schemes, see parameters -ldisc_input.",
                       mandatory=False,
                       example="centerline.nii.gz")
-    parser.add_option(name="-disks-input",
+    parser.add_option(name="-ldisc_input",
                       type_value="image_nifti",
-                      description="",
+                      description="Labels centered at the level of the intervertebral discs, for the input file (-i). Ideally, all levels should be provided. E.g.: Value=3 corresponds to C2-C3 disc. This option must be used with the -ldisc_dest parameter.",
                       mandatory=False,
-                      example="disks.nii.gz")
-    parser.add_option(name="-disks-ref",
+                      example="ldisc_input.nii.gz")
+    parser.add_option(name="-ldisc_dest",
                       type_value="image_nifti",
-                      description="",
+                      description="Labels centered at the level of the intervertebral discs, for the destination file (-dest). This option must be used with the -ldisc_input parameter.",
                       mandatory=False,
-                      example="disks_ref.nii.gz")
+                      example="ldisc_dest.nii.gz")
     parser.add_option(name="-p",
                       type_value=None,
                       description="amount of padding for generating labels.",
@@ -955,17 +955,17 @@ def main(args=None):
         sc_straight.use_straight_reference = True
         sc_straight.centerline_reference_filename = str(arguments["-ref"])
 
-    if "-disks-input" in arguments:
+    if "-ldisc_input" in arguments:
         if not sc_straight.use_straight_reference:
-            sct.printv('Warning: disks position are not yet taken into account if reference is not provided.')
+            sct.printv('Warning: discs position are not taken into account if reference is not provided.')
         else:
-            sc_straight.disks_input_filename = str(arguments["-disks-input"])
+            sc_straight.disks_input_filename = str(arguments["-ldisc_input"])
             sc_straight.precision = 4.0
-    if "-disks-ref" in arguments:
+    if "-ldisc_dest" in arguments:
         if not sc_straight.use_straight_reference:
-            sct.printv('Warning: disks position are not yet taken into account if reference is not provided.')
+            sct.printv('Warning: discs position are not taken into account if reference is not provided.')
         else:
-            sc_straight.disks_ref_filename = str(arguments["-disks-ref"])
+            sc_straight.disks_ref_filename = str(arguments["-ldisc_dest"])
             sc_straight.precision = 4.0
 
     # Handling optional arguments

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -216,6 +216,7 @@ class SpinalCordStraightener(object):
         self.elapsed_time_accuracy = 0.0
 
         self.template_orientation = 0
+        self.xy_size = 35  # in mm
 
     def straighten(self):
         # Initialization
@@ -437,7 +438,7 @@ class SpinalCordStraightener(object):
                 start_point = (z_centerline[0] - middle_slice) * factor_curved_straight + middle_slice
                 end_point = (z_centerline[-1] - middle_slice) * factor_curved_straight + middle_slice
 
-                xy_space = 35  # in mm
+                self.xy_size = 35  # in mm
                 offset_z = 0
 
                 # if the destination image is resampled, we still create the straight reference space with the native resolution
@@ -448,8 +449,8 @@ class SpinalCordStraightener(object):
                     nx, ny, nz, nt, px, py, pz, pt = image_centerline_pad.dim
                     start_point_coord_native = image_centerline_pad.transfo_phys2pix([[0, 0, start_point]])[0]
                     end_point_coord_native = image_centerline_pad.transfo_phys2pix([[0, 0, end_point]])[0]
-                    straight_size_x = int(xy_space / px)
-                    straight_size_y = int(xy_space / py)
+                    straight_size_x = int(self.xy_size / px)
+                    straight_size_y = int(self.xy_size / py)
                     warp_space_x = [int(np.round(nx / 2)) - straight_size_x, int(np.round(nx / 2)) + straight_size_x]
                     warp_space_y = [int(np.round(ny / 2)) - straight_size_y, int(np.round(ny / 2)) + straight_size_y]
                     if warp_space_x[0] < 0:
@@ -466,7 +467,7 @@ class SpinalCordStraightener(object):
                         ])
 
                     fname_ref = 'tmp.centerline_pad_crop_native.nii.gz'
-                    xy_space = 40
+                    self.xy_size = 40
                     offset_z = 4
                 else:
                     fname_ref = 'tmp.centerline_pad_crop.nii.gz'
@@ -480,8 +481,8 @@ class SpinalCordStraightener(object):
                 start_point_coord = image_centerline_pad.transfo_phys2pix([[0, 0, start_point]])[0]
                 end_point_coord = image_centerline_pad.transfo_phys2pix([[0, 0, end_point]])[0]
 
-                straight_size_x = int(xy_space / px)
-                straight_size_y = int(xy_space / py)
+                straight_size_x = int(self.xy_size / px)
+                straight_size_y = int(self.xy_size / py)
                 warp_space_x = [int(np.round(nx / 2)) - straight_size_x, int(np.round(nx / 2)) + straight_size_x]
                 warp_space_y = [int(np.round(ny / 2)) - straight_size_y, int(np.round(ny / 2)) + straight_size_y]
                 
@@ -871,6 +872,11 @@ def get_parser():
                                   'To keep native resolution, set this option to 0.\n',
                       mandatory=False,
                       default_value=0)
+    parser.add_option(name="-xy_size",
+                      type_value='float',
+                      description='Change the size of the XY FOV, in mm. The resolution is the same as the source image (-i).\n',
+                      mandatory=False,
+                      default_value=35.0)
     parser.add_option(name="-o",
                       type_value="file_output",
                       description="straightened file",
@@ -987,6 +993,9 @@ def main(args=None):
 
     if '-speed_factor' in arguments:
         sc_straight.resample_factor = arguments['-speed_factor']
+
+    if '-xy_size' in arguments:
+        sc_straight.xy_size = arguments['-xy_size']
 
     if "-param" in arguments:
         params_user = arguments['-param']

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -286,7 +286,10 @@ class SpinalCordStraightener(object):
             if self.resample_factor != 0.0:
                 sct.mv('centerline_rpi.nii.gz', 'centerline_rpi_native.nii.gz')
                 pz_native = pz
-                sct.run(['sct_resample', '-i', 'centerline_rpi_native.nii.gz', '-mm', str(self.resample_factor) + 'x' + str(self.resample_factor) + 'x' + str(self.resample_factor), '-o', 'centerline_rpi.nii.gz'])
+
+                px_r, py_r, pz_r = px * self.resample_factor, py * self.resample_factor, pz * self.resample_factor
+
+                sct.run(['sct_resample', '-i', 'centerline_rpi_native.nii.gz', '-mm', str(px_r) + 'x' + str(py_r) + 'x' + str(pz_r), '-o', 'centerline_rpi.nii.gz'])
                 image_centerline = Image('centerline_rpi.nii.gz')
                 nx, ny, nz, nt, px, py, pz, pt = image_centerline.dim
 
@@ -861,10 +864,10 @@ def get_parser():
                       type_value=None,
                       description="Disable curved to straight transformation computation.",
                       mandatory=False)
-    parser.add_option(name="-resample",
+    parser.add_option(name="-speed_factor",
                       type_value='float',
-                      description='Isotropic resolution of the straightening output, in millimeters.\n'
-                                  'Resampling to lower resolution decreases computational time while decreasing straightening accuracy.\n'
+                      description='Acceleration factor for the calculation of the straightening warping field.\n'
+                                  'This speed factor enables an intermediate resampling to a lower resolution, which decreases the computational time while decreasing straightening accuracy.\n'
                                   'To keep native resolution, set this option to 0.\n',
                       mandatory=False,
                       default_value=0)
@@ -982,8 +985,8 @@ def main(args=None):
     if '-disable-curved2straight' in arguments:
         sc_straight.curved2straight = False
 
-    if '-resample' in arguments:
-        sc_straight.resample_factor = arguments['-resample']
+    if '-speed_factor' in arguments:
+        sc_straight.resample_factor = arguments['-speed_factor']
 
     if "-param" in arguments:
         params_user = arguments['-param']


### PR DESCRIPTION
### Description of the Change

This Pull Request introduces several important modifications to `sct_straighten_spinalcord` and `sct_register_to_template`:
- improvements in the documentation of `sct_straighten_spinalcord` and introduced a speed factor parameter.
- addition of a flag to adjust the XY size of the straightened image
- implementation of vertebral alignment between an image and the template.

Explain the approach and possible drawback(s). Use labels to add context.

### Steps and Constraints

The file `PAM50_label_disc.nii.gz` of the PAM50 template should be replaced by the file attached here: [PAM50_label_disc.nii.gz](https://github.com/neuropoly/spinalcordtoolbox/files/1888539/PAM50_label_disc.nii.gz). The new file includes two additional labels:
- label 50: pontomedullary junction
- label 49: pontomedullary groove

To reproduce the issue, you can apply the following command within this folder: 
[test_registration.zip](https://github.com/neuropoly/spinalcordtoolbox/files/1888548/test_registration.zip)

```
sct_register_to_template -i t2.nii.gz -s t2_seg.nii.gz -ldisc ldisc.nii.gz
```

# Applicable Issues

Implements #949 and #1433 
