### PR TITLE
sct_deepseg_sc - Issue when input is .nii instead of .nii.gz

### DIFF
--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -99,7 +99,7 @@ def _find_crop_start_end(coord_ctr, crop_size, im_dim):
 
 
 def crop_image_around_centerline(im_in, ctr_in, im_out, crop_size, x_dim_half, y_dim_half):
-    im_in, data_ctr = Image(im_in), np.array(Image(ctr_in).data)
+    im_in, data_ctr = Image(im_in), Image(ctr_in).data
 
     im_new = im_in.copy()
     im_new.dim = tuple([crop_size, crop_size, im_in.dim[2]] + list(im_in.dim[3:]))
@@ -108,7 +108,7 @@ def crop_image_around_centerline(im_in, ctr_in, im_out, crop_size, x_dim_half, y
 
     x_lst, y_lst = [], []
     for zz in range(im_in.dim[2]):
-        x_ctr, y_ctr = center_of_mass(data_ctr[:, :, zz])
+        x_ctr, y_ctr = center_of_mass(np.array(data_ctr[:, :, zz]))
 
         x_start, x_end = _find_crop_start_end(x_ctr, crop_size, im_in.dim[0])
         y_start, y_end = _find_crop_start_end(y_ctr, crop_size, im_in.dim[1])

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -99,7 +99,7 @@ def _find_crop_start_end(coord_ctr, crop_size, im_dim):
 
 
 def crop_image_around_centerline(im_in, ctr_in, im_out, crop_size, x_dim_half, y_dim_half):
-    im_in, im_ctr = Image(im_in), Image(ctr_in)
+    im_in, data_ctr = Image(im_in), np.array(Image(ctr_in).data)
 
     im_new = im_in.copy()
     im_new.dim = tuple([crop_size, crop_size, im_in.dim[2]] + list(im_in.dim[3:]))
@@ -108,7 +108,7 @@ def crop_image_around_centerline(im_in, ctr_in, im_out, crop_size, x_dim_half, y
 
     x_lst, y_lst = [], []
     for zz in range(im_in.dim[2]):
-        x_ctr, y_ctr = center_of_mass(im_ctr.data[:, :, zz])
+        x_ctr, y_ctr = center_of_mass(data_ctr[:, :, zz])
 
         x_start, x_end = _find_crop_start_end(x_ctr, crop_size, im_in.dim[0])
         y_start, y_end = _find_crop_start_end(y_ctr, crop_size, im_in.dim[1])
@@ -128,7 +128,7 @@ def crop_image_around_centerline(im_in, ctr_in, im_out, crop_size, x_dim_half, y
 
     im_new.save()
 
-    del im_in, im_ctr
+    del im_in
     del im_new
 
     return x_lst, y_lst


### PR DESCRIPTION
### Requirements

This issue was reported twice:
- by @stephaniealley : https://github.com/neuropoly/spinalcordtoolbox/issues/1634
- by @SaraDupont : https://github.com/neuropoly/spinalcordtoolbox/issues/1659

### Description of the Change

```
>>> from msct_image import Image
>>> s_compressed=Image('t2_seg.nii.gz')
>>> type(s_compressed.data)
<type 'numpy.ndarray'>
>>> s_not_compressed=Image('t2_seg.nii')
>>> type(s_not_compressed.data)
<class 'numpy.core.memmap.memmap'>

>>> from scipy.ndimage.measurements import center_of_mass
>>> from msct_image import Image

>>> s_not_compressed = Image('t2_seg.nii')
>>> type(s_not_compressed.data)
<class 'numpy.core.memmap.memmap'>
>>> center_of_mass(s_not_compressed.data)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chgroc/spinalcordtoolbox/python/lib/python2.7/site-packages/scipy/ndimage/measurements.py", line 1289, in center_of_mass
    return [tuple(v) for v in numpy.array(results).T]
TypeError: 'numpy.float64' object is not iterable

>>> s_compressed = Image('t2_seg.nii.gz')
>>> type(s_compressed.data)
<type 'numpy.ndarray'>
>>> center_of_mass(s_compressed.data)
(225.70722563053852, 216.90064758009544, 7.8552317655078392)

```

--> Error when `scipy.ndimage.measurements.center_of_mass` receives a `numpy.core.memmap.memmap` as input.

Proposed solution:
Cast `np.memmap` into `np.array` before to apply `scipy.ndimage.measurements.center_of_mass`.

Is there a better approach?

------

Additional tests were done on ~30 data (different contrast, centers...etc) --> works