### PR TITLE
Make sct_process_segmentation compatible with the new ldisc convention

### DIFF
--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -861,7 +861,7 @@ def compute_corr_3d(src, target, x, xshift, xsize, y, yshift, ysize, z, zshift, 
 def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     """
     Label segmentation image
-    :param fname_seg: fname of the segmentation, expected image orientation: RPI
+    :param fname_seg: fname of the segmentation, no orientation expected
     :param list_disc_z: list of z that correspond to a disc
     :param list_disc_value: list of associated disc values
     :param verbose:

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -15,7 +15,7 @@
 # TODO: write label C2-C3 when user uses viewer
 # TODO: find automatically if -c =t1 or t2 (using dilated seg)
 # TODO: address the case when there is more than one max correlation
-# TODO: Change the disc convention: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
+# TODO: Change the disc convention in label_segmentation: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
 
 import sys, io, os
 
@@ -869,6 +869,7 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     :return:
     """
     # TODO: Change the disc convention: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
+    # TODO: When the disc convention has been changed: change the function label_vert in sct_process_segmentation which called this function (i.e. remove the "-1" in the loop for)
 
     # open segmentation
     seg = Image(fname_seg)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -15,7 +15,6 @@
 # TODO: write label C2-C3 when user uses viewer
 # TODO: find automatically if -c =t1 or t2 (using dilated seg)
 # TODO: address the case when there is more than one max correlation
-# TODO: Change the disc convention in label_segmentation: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
 
 import sys, io, os
 
@@ -868,8 +867,6 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     :param verbose:
     :return:
     """
-    # TODO: Change the disc convention: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
-    # TODO: When the disc convention has been changed: change the function label_vert in sct_process_segmentation which called this function (i.e. remove the "-1" in the loop for)
 
     # open segmentation
     seg = Image(fname_seg)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -861,7 +861,7 @@ def compute_corr_3d(src, target, x, xshift, xsize, y, yshift, ysize, z, zshift, 
 def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     """
     Label segmentation image
-    :param fname_seg: fname of the segmentation
+    :param fname_seg: fname of the segmentation, expected image orientation: RPI
     :param list_disc_z: list of z that correspond to a disc
     :param list_disc_value: list of associated disc values
     :param verbose:

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -871,8 +871,8 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     # open segmentation
     seg = Image(fname_seg)
 
-    # change the orientation to RPI because the function assume dim[2] to be the Superior-to-Inferior axis
-    init_oriantation = seg.orientation
+    # Change the orientation to RPI so that any orientation can be input
+    init_orientation = seg.orientation
     seg.change_orientation('RPI')
 
     dim = seg.dim
@@ -901,7 +901,7 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
             plt.scatter(int(round(ny / 2)), iz, c=vertebral_level, vmin=min(list_disc_value), vmax=max(list_disc_value), cmap='prism', marker='_', s=200)
     # write file
     seg.file_name += '_labeled'
-    seg.change_orientation(init_oriantation)
+    seg.change_orientation(init_orientation)
     seg.save()
 
 

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -15,6 +15,7 @@
 # TODO: write label C2-C3 when user uses viewer
 # TODO: find automatically if -c =t1 or t2 (using dilated seg)
 # TODO: address the case when there is more than one max correlation
+# TODO: Change the disc convention: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
 
 import sys, io, os
 
@@ -867,6 +868,8 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     :param verbose:
     :return:
     """
+    # TODO: Change the disc convention: "disc labelvalue=3 ==> disc C2/C3" (expected) instead of "disc labelvalue=3 ==> disc C3/C4" (current)
+
     # open segmentation
     seg = Image(fname_seg)
 

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -869,6 +869,11 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
     """
     # open segmentation
     seg = Image(fname_seg)
+
+    # change the orientation to RPI because the function assume dim[2] to be the Superior-to-Inferior axis
+    init_oriantation = seg.orientation
+    seg.change_orientation('RPI')
+
     dim = seg.dim
     ny = dim[1]
     nz = dim[2]
@@ -895,6 +900,7 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
             plt.scatter(int(round(ny / 2)), iz, c=vertebral_level, vmin=min(list_disc_value), vmax=max(list_disc_value), cmap='prism', marker='_', s=200)
     # write file
     seg.file_name += '_labeled'
+    seg.change_orientation(init_oriantation)
     seg.save()
 
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -906,7 +906,7 @@ def label_vert(fname_seg, fname_label, verbose=1):
     """
     # Open labels
     im_disc = Image(fname_label)
-    # change the orientation to RPI because the function label_segmentation assume this orientation as input
+    # Change the orientation to RPI so that the z axis correspond to the superior-to-inferior axis
     im_disc.change_orientation('RPI')
     # retrieve all labels
     coord_label = im_disc.getNonZeroCoordinates()

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -915,7 +915,7 @@ def label_vert(fname_seg, fname_label, verbose=1):
     list_disc_value = []
     for i in range(len(coord_label)):
         list_disc_z.insert(0, coord_label[i].z)
-        # '-1' because the function label_segmentation uses the convention "disc labelvalue=3 ==> disc C3/C4"
+        # '-1' to use the convention "disc labelvalue=3 ==> disc C2/C3"
         list_disc_value.insert(0, coord_label[i].value - 1)
 
     list_disc_value = [x for (y, x) in sorted(zip(list_disc_z, list_disc_value), reverse=True)]

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -125,7 +125,7 @@ def get_parser():
                       mandatory=False)
     parser.add_option(name='-discfile',
                       type_value='image_nifti',
-                      description='Disc labeling. Only use with -p label-vert',
+                      description='Disc labeling with the convention "disc labelvalue=3 ==> disc C2/C3". Only use with -p label-vert',
                       mandatory=False)
     parser.add_option(name='-r',
                       type_value='multiple_choice',
@@ -906,6 +906,8 @@ def label_vert(fname_seg, fname_label, verbose=1):
     """
     # Open labels
     im_disc = Image(fname_label)
+    # change the orientation to RPI because the function label_segmentation assume this orientation as input
+    im_disc.change_orientation('RPI')
     # retrieve all labels
     coord_label = im_disc.getNonZeroCoordinates()
     # compute list_disc_z and list_disc_value
@@ -913,7 +915,8 @@ def label_vert(fname_seg, fname_label, verbose=1):
     list_disc_value = []
     for i in range(len(coord_label)):
         list_disc_z.insert(0, coord_label[i].z)
-        list_disc_value.insert(0, coord_label[i].value)
+        # '-1' because the function label_segmentation uses the convention "disc labelvalue=3 ==> disc C3/C4"
+        list_disc_value.insert(0, coord_label[i].value - 1)
 
     list_disc_value = [x for (y, x) in sorted(zip(list_disc_z, list_disc_value), reverse=True)]
     list_disc_z = [y for (y, x) in sorted(zip(list_disc_z, list_disc_value), reverse=True)]

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -899,7 +899,7 @@ def compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_te
 def label_vert(fname_seg, fname_label, verbose=1):
     """
     Label segmentation using vertebral labeling information
-    :param fname_segmentation, expected image orientation: RPI
+    :param fname_segmentation, no orientation expected
     :param fname_label:
     :param verbose:
     :return:

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -899,14 +899,14 @@ def compute_csa(fname_segmentation, output_folder, overwrite, verbose, remove_te
 def label_vert(fname_seg, fname_label, verbose=1):
     """
     Label segmentation using vertebral labeling information
-    :param fname_segmentation:
+    :param fname_segmentation, expected image orientation: RPI
     :param fname_label:
     :param verbose:
     :return:
     """
     # Open labels
     im_disc = Image(fname_label)
-    # Change the orientation to RPI so that the z axis correspond to the superior-to-inferior axis
+    # Change the orientation to RPI so that the z axis corresponds to the superior-to-inferior axis
     im_disc.change_orientation('RPI')
     # retrieve all labels
     coord_label = im_disc.getNonZeroCoordinates()


### PR DESCRIPTION
### Requirements

* [x] Is there a issue open describing the motivation for this pull request ?
https://github.com/neuropoly/spinalcordtoolbox/issues/1734

### Description of the Change

- Make the function `label_vert` of `sct_process_segmentation` compatible with non-RPI oriented images
- Use the new definition of discs in `sct_process_segmentation`