### PR TITLE
Added a case if image is not 2D or 3D

### DIFF
--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -169,9 +169,6 @@ class ProcessLabels(object):
 
         # loop across labels
         for i, coord in enumerate(self.coordinates):
-            # display info
-            sct.printv('Label #' + str(i) + ': ' + str(coord.x) + ',' + str(coord.y) + ',' + str(coord.z) + ' --> ' +
-                       str(coord.value), 1)
             if len(image_output.data.shape) == 3:
                 image_output.data[int(coord.x), int(coord.y), int(coord.z)] = coord.value
             elif len(image_output.data.shape) == 2:
@@ -179,6 +176,9 @@ class ProcessLabels(object):
                 image_output.data[int(coord.x), int(coord.y)] = coord.value
             else:
                 sct.printv('ERROR: Data should be 2D or 3D. Current shape is: ' + str(image_output.data.shape), 1, 'error')
+            # display info
+            sct.printv('Label #' + str(i) + ': ' + str(coord.x) + ',' + str(coord.y) + ',' + str(coord.z) + ' --> ' +
+                       str(coord.value), 1)
         return image_output
 
     def create_label_along_segmentation(self):

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -177,6 +177,8 @@ class ProcessLabels(object):
             elif len(image_output.data.shape) == 2:
                 assert str(coord.z) == '0', "ERROR: 2D coordinates should have a Z value of 0. Z coordinate is :" + str(coord.z)
                 image_output.data[int(coord.x), int(coord.y)] = coord.value
+            else:
+                sct.printv('ERROR: Data should be 2D or 3D. Current shape is: ' + str(image_output.data.shape), 1, 'error')
         return image_output
 
     def create_label_along_segmentation(self):


### PR DESCRIPTION
### Description of the Change

If image has 5 dimensions (e.g., RGB from histology converted to nifti: (690, 462, 75, 1, 3)), `sct_label_utils -create` fails. This PR fixes it.

### Applicable Issues

Fixes #1743 
