### PR TITLE
Random issue fixes (Sentry, sct_pipeline, install)

### DIFF
--- a/scripts/msct_nurbs.py
+++ b/scripts/msct_nurbs.py
@@ -182,8 +182,7 @@ class NURBS():
                         list_param_that_worked.append([self.nbControle, self.pointsControle, error_curve])
 
                     except ReconstructionError as ex:
-                        if verbose >= 1:
-                            sct.log.error(ex)
+                        sct.printv('WARNING: NURBS instability -> wrong reconstruction', verbose=verbose, type="warning")
                         error_curve = last_error_curve + 10000.0
 
                     # prepare for next iteration
@@ -389,7 +388,6 @@ class NURBS():
             P_z_d.append(sum_num_z_der)
 
             if sum_den <= 0.05:
-                sct.printv('WARNING: NURBS instability -> wrong reconstruction', verbose=self.verbose, type="warning")
                 raise ReconstructionError()
 
         P_x = [P_x[i] for i in np.argsort(P_z)]
@@ -490,7 +488,6 @@ class NURBS():
             P_y_d.append(sum_num_y_der)
 
             if sum_den <= 0.05:
-                sct.printv('WARNING: NURBS instability -> wrong reconstruction', verbose=verbose, type="warning")
                 raise ReconstructionError()
 
         P_x = [P_x[i] for i in np.argsort(P_y)]
@@ -659,7 +656,6 @@ class NURBS():
         std_factor = 10.0
         std_Px, std_Py, std_Pz, std_x, std_y, std_z = std(P_xb), std(P_yb), std(P_zb), std(np.array(P_x)), std(np.array(P_y)), std(np.array(P_z))
         if std_x >= 0.1 and std_y >= 0.1 and std_z >= 0.1 and (std_Px > std_factor * std_x or std_Py > std_factor * std_y or std_Pz > std_factor * std_z):
-            sct.printv('WARNING: NURBS instability -> wrong reconstruction', verbose=verbose, type="warning")
             raise ReconstructionError()
 
         P = [[P_xb[i, 0], P_yb[i, 0], P_zb[i, 0]] for i in range(len(P_xb))]
@@ -772,7 +768,6 @@ class NURBS():
         std_factor = 10.0
         std_Px, std_Py, std_x, std_y = std(P_xb), std(P_yb), std(np.array(P_x)), std(np.array(P_y))
         if std_x >= 0.1 and std_y >= 0.1 and (std_Px > std_factor * std_x or std_Py > std_factor * std_y):
-            sct.printv('WARNING: NURBS instability -> wrong reconstruction', verbose=verbose, type="warning")
             raise ReconstructionError()
 
         P = [[P_xb[i, 0], P_yb[i, 0]] for i in range(len(P_xb))]
@@ -869,7 +864,6 @@ class NURBS():
             P_z_d.append(sum_num_z_der)
 
             if sum_den <= 0.05:
-                sct.printv('WARNING: NURBS instability -> wrong reconstruction', verbose=verbose, type="warning")
                 raise ReconstructionError()
 
         P_x = [P_x[i] for i in np.argsort(P_z)]

--- a/scripts/msct_parser.py
+++ b/scripts/msct_parser.py
@@ -147,9 +147,9 @@ class Option:
 
         elif type_option == "file_output":  # check if permission are required
             if not os.path.isdir(os.path.dirname(os.path.abspath(param))):
-                self.parser.usage.error("ERROR: Option %s parent folder doesn't exist for file %s" % (self.name, param))
+                self.parser.usage.error("Option %s parent folder doesn't exist for file %s" % (self.name, param))
             if not sct.check_write_permission(param):
-                self.parser.usage.error("ERROR: Option %s no write permission for file %s" % (self.name, param))
+                self.parser.usage.error("Option %s no write permission for file %s" % (self.name, param))
             return param
 
         elif type_option == "folder":
@@ -184,10 +184,10 @@ class Option:
                     param_splitted = param_splitted[0].split(' ')
                 return list([self.check_integrity(val, sub_type) for val in param_splitted])
             else:
-                self.parser.usage.error("ERROR: Option " + self.name + " must be correctly written. See usage.")
+                self.parser.usage.error("Option " + self.name + " must be correctly written. See usage.")
 
         else:
-            # self.parser.usage.error("ERROR: Type of option \"" + str(self.type_value) +"\" is not supported by the parser.")
+            # self.parser.usage.error("Type of option \"" + str(self.type_value) +"\" is not supported by the parser.")
             sct.printv("WARNING : Option " + str(self.type_value) + " does not exist and will have no effect on the execution of the script", "warining")
             sct.printv("Type -h to see supported options", "warning")
 
@@ -199,14 +199,14 @@ class Option:
         try:
             return self.__safe_cast__(param, eval(type_option))
         except ValueError:
-            self.parser.usage.error("ERROR: Option " + self.name + " must be " + type_option)
+            self.parser.usage.error("Option " + self.name + " must be " + type_option)
 
     def checkFile(self, param):
         # check if the file exist
         sct.printv("Check file existence...", 0)
         if self.parser.check_file_exist:
             if not os.path.isfile(param):
-                self.parser.usage.error("ERROR: Option " + self.name + " file doesn't exist: " + param)
+                self.parser.usage.error("Option " + self.name + " file doesn't exist: " + param)
         return param
 
     def checkIfNifti(self, param):
@@ -233,7 +233,7 @@ class Option:
         elif param.lower() in self.list_no_image:
             no_image = True
         else:
-            self.parser.usage.error("ERROR: Option " + self.name + " file " + param + " is not a NIFTI image file. Exiting")
+            self.parser.usage.error("Option " + self.name + " file " + param + " is not a NIFTI image file. Exiting")
         if nii:
             return param_tmp + '.nii'
         elif niigz:
@@ -242,13 +242,13 @@ class Option:
             return param
         else:
             sct.log.debug('executed in {}'.format(os.getcwd()))
-            self.parser.usage.error("ERROR: Option " + self.name + " file " + param + " does not exist.")
+            self.parser.usage.error("Option " + self.name + " file " + param + " does not exist.")
 
     def checkFolder(self, param):
         # check if the folder exist. If not, create it.
         if self.parser.check_file_exist:
             if not os.path.isdir(param):
-                self.parser.usage.error("ERROR: Option " + self.name + " folder doesn't exist: " + param)
+                self.parser.usage.error("Option " + self.name + " folder doesn't exist: " + param)
         return param
 
     def checkFolderCreation(self, param):
@@ -363,11 +363,11 @@ class Parser:
                     if len(arguments) > index + 1:  # Check if option is not the last item
                         param = arguments[index + 1]
                     else:
-                        self.usage.error("ERROR: Option " + self.options[arg].name + " needs an argument...")
+                        self.usage.error("Option " + self.options[arg].name + " needs an argument...")
 
                     # check if option has an argument that is not another option
                     if param in self.options:
-                        self.usage.error("ERROR: Option " + self.options[arg].name + " needs an argument...")
+                        self.usage.error("Option " + self.options[arg].name + " needs an argument...")
 
                     # check if this flag has already been used before, then create a list and append this string to the previous string
                     if arg in dictionary:
@@ -386,9 +386,9 @@ class Parser:
                 # check if the input argument is close to a known option
                 spelling_candidates = self.spelling.correct(arg)
                 if len(spelling_candidates) != 0:
-                    self.usage.error("ERROR: argument " + arg + " does not exist. Did you mean: " + ', '.join(spelling_candidates) + '?')
+                    self.usage.error("argument " + arg + " does not exist. Did you mean: " + ', '.join(spelling_candidates) + '?')
                 else:
-                    self.usage.error("ERROR: argument " + arg + " does not exist. See documentation.")
+                    self.usage.error("argument " + arg + " does not exist. See documentation.")
 
         # check if all mandatory arguments are provided by the user
         for option in [opt for opt in self.options if self.options[opt].mandatory and self.options[opt].deprecated_by is None]:
@@ -563,7 +563,7 @@ class Usage:
 
         if error:
             sct.log.info(usage)
-            sct.log.error(error + '\nAborted...')
+            sct.log.error("Command-line usage error: {}\nAborted...".format(error))
         else:
             sct.log.info(usage)
 

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -96,6 +96,10 @@ def module_import(module_name, suppress_stderr=False):
 # MAIN
 # ==========================================================================================
 def main():
+    path_sct = os.environ.get("SCT_DIR", os.path.dirname(os.path.dirname(__file__)))
+    print("SCT info:")
+    print("- version: {}".format(sct.__version__))
+    print("- path: {0}".format(path_sct))
 
     # initialization
     fsl_is_working = 1
@@ -144,6 +148,7 @@ def main():
         os_running = 'osx'
     elif (platform_running.find('linux') != -1):
         os_running = 'linux'
+
     print('OS: ' + os_running + ' (' + platform.platform() + ')')
 
     # Check number of CPU cores
@@ -154,15 +159,6 @@ def main():
     # check RAM
     sct.checkRAM(os_running, 0)
 
-    path_sct = os.environ.get("SCT_DIR", os.path.dirname(os.path.dirname(__file__)))
-    print('SCT path: {0}'.format(path_sct))
-
-    # fetch SCT version
-    install_type, sct_commit, sct_branch, version_sct = sct._git_info()
-    print('Installation type: %s' % install_type)
-    print('  version: ' + version_sct)
-    print('  commit: ' + sct_commit)
-    print('  branch: ' + sct_branch)
 
     # check if Python path is within SCT path
     print_line('Check Python executable')

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -224,7 +224,7 @@ def main():
         output_folder = os.getcwd()
 
     if '-r' in arguments:
-        remove_temp_files = arguments['-r']
+        remove_temp_files = int(arguments['-r'])
 
     if '-v' in arguments:
         verbose = arguments['-v']

--- a/scripts/sct_pipeline.py
+++ b/scripts/sct_pipeline.py
@@ -480,7 +480,7 @@ if __name__ == "__main__":
     parser = get_parser()
     arguments = parser.parse(sys.argv[1:])
     function_to_test = arguments["-f"]
-    path_data = arguments["-d"]
+    path_data = os.path.abspath(arguments["-d"])
     if "-p" in arguments:
         # in case users used more than one '-p' flag, the output will be a list of all arguments (for each -p)
         if isinstance(arguments['-p'], list):

--- a/scripts/sct_pipeline.py
+++ b/scripts/sct_pipeline.py
@@ -510,12 +510,6 @@ if __name__ == "__main__":
     if '-email' in arguments:
         create_log = True
         send_email = True
-        addr_to = None
-        addr_from = None
-        login = None
-        passwd_from = None
-        smtp_host = None
-        smtp_port = None
         # loop across fields
         for i in arguments['-email']:
             k, v = i.split("=")

--- a/scripts/sct_pipeline.py
+++ b/scripts/sct_pipeline.py
@@ -253,7 +253,9 @@ def function_launcher(args):
     param_testing.path_data = args[1]
     param_testing.args = args[2]
     param_testing.test_integrity = args[3]
-    param_testing.redirect_to_file = True  # create individual logs for each subject.
+    param_testing.redirect_stdout = True # create individual logs for each subject.
+    if create_log:
+        param_testing.fname_log = os.path.join(os.getcwd(), "%s-%s.log" % (file_log, os.path.basename(args[1])))
     # load modules of function to test
     module_testing = importlib.import_module('test_' + param_testing.function_to_test)
     # initialize parameters specific to the test

--- a/scripts/sct_pipeline.py
+++ b/scripts/sct_pipeline.py
@@ -349,11 +349,11 @@ def run_function(function, folder_dataset, list_subj, list_args=[], nb_cpu=None,
             arguments = future_dirs[future][2]
             try:
                 result = future.result()
+                sct.log.info('{}/{}: {} done'.format(count, len(list_func_subj_args), subject))
+                all_results.append(result)
             except Exception as exc:
                 sct.log.error('{} {} generated an exception: {}'.format(subject, arguments, exc))
 
-            sct.log.info('{}/{}: {} done'.format(count, len(list_func_subj_args), subject))
-            all_results.append(result)
         compute_time = time() - compute_time
 
         # concatenate all_results into single Panda structure

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -41,6 +41,7 @@ class Param:
         self.output = ''  # output string
         self.results = ''  # results in Panda DataFrame
         self.redirect_stdout = 0  # for debugging, set to 0. Otherwise set to 1.
+        self.fname_log = None
 
 
 # define nice colors
@@ -388,7 +389,10 @@ def test_function(param_test):
         param_test.args_with_path += ' -ofolder ' + param_test.path_output
     # open log file
     # Note: the statement below is not included in the if, because even if redirection does not occur, we want the file to be create otherwise write_to_log will fail
-    param_test.fname_log = os.path.join(param_test.path_output, param_test.function_to_test + '.log')
+
+    if param_test.fname_log is None:
+        param_test.fname_log = os.path.join(param_test.path_output, param_test.function_to_test + '.log')
+
     # redirect to log file
     if param_test.redirect_stdout:
         file_handler = sct.add_file_handler_to_logger(param_test.fname_log)

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -574,8 +574,8 @@ def checkRAM(os, verbose=1):
         ram_total = float(ram_split[3])
 
         # Get process info
-        ps = subprocess.Popen(['ps', '-caxm', '-orss,comm'], stdout=subprocess.PIPE).communicate()[0].decode()
-        vm = subprocess.Popen(['vm_stat'], stdout=subprocess.PIPE).communicate()[0].decode()
+        ps = subprocess.Popen(['ps', '-caxm', '-orss,comm'], stdout=subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding)
+        vm = subprocess.Popen(['vm_stat'], stdout=subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding)
 
         # Iterate processes
         processLines = ps.split('\n')

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -248,6 +248,17 @@ def server_log_handler(client):
     from raven.handlers.logging import SentryHandler
 
     sh = SentryHandler(client=client, level=logging.ERROR)
+
+    # Don't send Sentry events for command-line usage errors
+    old_emit = sh.emit
+    def emit(self, record):
+        if record.message.startswith("Command-line usage error:"):
+            return
+        return old_emit(record)
+
+    sh.emit = lambda x: emit(sh, x)
+
+
     fmt = ("[%(asctime)s][%(levelname)s] %(filename)s: %(lineno)d | "
             "%(message)s")
     formatter = logging.Formatter(fmt=fmt, datefmt="%H:%M:%S")

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -192,7 +192,7 @@ def init_error_client():
     :return:
     """
     if os.getenv('SENTRY_DSN'):
-        log.info('Configuring sentry report')
+        log.debug('Configuring sentry report')
         try:
             client = raven.Client(
              release=__version__,
@@ -202,7 +202,6 @@ def init_error_client():
             )
             server_log_handler(client)
             traceback_to_server(client)
-            log.info('sentry is set!')
 
             old_exitfunc = sys.exitfunc
             def exitfunc():
@@ -222,7 +221,7 @@ def init_error_client():
             sys.exitfunc = exitfunc
         except raven.exceptions.InvalidDsn:
             # This could happen if sct staff change the dsn
-            log.debug('sentry dsn not valid anymore, not reporting errors')
+            log.debug('Sentry DSN not valid anymore, not reporting errors')
 
 
 def traceback_to_server(client):

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -230,9 +230,7 @@ def traceback_to_server(client):
     """
 
     def excepthook(exctype, value, traceback):
-        if exctype.__name__ in ("ReconstructionError",):
-            pass
-        elif issubclass(exctype, Exception):
+        if issubclass(exctype, Exception):
             client.captureException(exc_info=(exctype, value, traceback))
         sys.__excepthook__(exctype, value, traceback)
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -155,11 +155,6 @@ __data_dir__ = os.getenv("SCT_DATA_DIR", os.path.join(__sct_dir__, 'data'))
 __version__ = _version_string()
 
 
-# statistic report level
-__report_log_level__ = logging.ERROR  # DEBUG, INFO, WARNING, ERROR
-__report_exception_level__ = Exception
-
-
 def init_sct():
     """ Initialize the sct for typical terminal usage
 
@@ -219,7 +214,9 @@ def traceback_to_server(client):
     """
 
     def excepthook(exctype, value, traceback):
-        if issubclass(exctype, __report_exception_level__):
+        if exctype.__name__ in ("ReconstructionError",):
+            pass
+        elif issubclass(exctype, Exception):
             client.captureException(exc_info=(exctype, value, traceback))
         sys.__excepthook__(exctype, value, traceback)
 
@@ -233,7 +230,7 @@ def server_log_handler(client):
     """
     from raven.handlers.logging import SentryHandler
 
-    sh = SentryHandler(client=client, level=__report_log_level__)
+    sh = SentryHandler(client=client, level=logging.ERROR)
     fmt = ("[%(asctime)s][%(levelname)s] %(filename)s: %(lineno)d | "
             "%(message)s")
     formatter = logging.Formatter(fmt=fmt, datefmt="%H:%M:%S")

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -203,6 +203,23 @@ def init_error_client():
             server_log_handler(client)
             traceback_to_server(client)
             log.info('sentry is set!')
+
+            old_exitfunc = sys.exitfunc
+            def exitfunc():
+                sent_something = False
+                try:
+                    # implementation-specific
+                    import atexit
+                    for handler, args, kw in atexit._exithandlers:
+                        if handler.__module__.startswith("raven."):
+                            sent_something = True
+                except:
+                    pass
+                old_exitfunc()
+                if sent_something:
+                    print("Note: you can opt out of Sentry reporting by editing the file ${SCT_DIR}/bin/sct_launcher and delete the line starting with \"export SENTRY_DSN\"")
+
+            sys.exitfunc = exitfunc
         except raven.exceptions.InvalidDsn:
             # This could happen if sct staff change the dsn
             log.debug('sentry dsn not valid anymore, not reporting errors')


### PR DESCRIPTION
This PR brings:

- Some `sct_pipeline` minor fixes
- Fix for #1745: Mac installation on system where "ps" could print non-ASCII
- Fix for #1708: print Sentry opt-out message after sending a report
- Fix for one Sentry false positive https://sentry.io/neuropoly-k0/sct/issues/557250868 due to capture of a control flow exception
- Fix for many Sentry false positives: events due to users misusing command line arguments are not reported anymore
- Change `sct.__version__` format to be more human-readable (installed package will simply be the package version)