### PR TITLE
Adding threshold (or not) option for the sct_deepseg_gm

### DIFF
--- a/unit_testing/test_deepseg_gm.py
+++ b/unit_testing/test_deepseg_gm.py
@@ -81,6 +81,10 @@ class TestCore(object):
         thr_ret = gm_core.threshold_predictions(dummy_preds, 0.5)
         assert np.count_nonzero(thr_ret) == 0
 
+        dummy_preds = np.full((200, 200), 0.4)
+        thr_ret = gm_core.threshold_predictions(dummy_preds, None)
+        assert np.allclose(dummy_preds, thr_ret)
+
     def test_segment_volume(self):
         """Call the segmentation routine itself with a dummy input."""
         np_data = np.ones((200, 200, 2), dtype=np.float32)


### PR DESCRIPTION
This is a pull request to add an enhancement (related issue #1831).

There is now a new parameter on the `sct_deepseg_gm` command-line tool called `-thr` where the user can specify a custom threshold to be applied in the predictions of the model. For backward compatibility, this threshold is always active with the [recommended value of 0.999](https://www.nature.com/articles/s41598-018-24304-3), but now the user can specify a different threshold or even disable it with `-thr 0`.

PS: just fixed some long running strings as well.