### PR TITLE
Remove sct_deepseg_gm restriction on the network input size (small inputs)

### DIFF
--- a/spinalcordtoolbox/deepseg_gm/model.py
+++ b/spinalcordtoolbox/deepseg_gm/model.py
@@ -16,9 +16,6 @@ from keras.layers import BatchNormalization
 from keras.layers import concatenate, GlobalAveragePooling2D
 from keras.optimizers import Adam
 
-CROP_WIDTH = 200
-CROP_HEIGHT = 200
-
 # Models
 # Tuple of (model, metadata)
 MODELS = {
@@ -50,12 +47,19 @@ def dice_coef_loss(y_true, y_pred):
     return -dice_coef(y_true, y_pred)
 
 
-def create_model(nfilters):
+def create_model(nfilters, input_size=(200, 200)):
+    """Create the ASPP model.
+
+    :param nfilters: number of filters at each block.
+    :param input_size: the network input size (H, W)
+    """
     drop_rate_concat = 0.4
     drop_rate_hidden = 0.4
     bn_momentum = 0.1
 
-    inputs = Input((CROP_HEIGHT, CROP_WIDTH, 1))
+    input_height, input_width = input_size
+
+    inputs = Input((input_height, input_width, 1))
 
     conv1 = Conv2D(nfilters, (3, 3), activation='relu', padding='same')(inputs)
     conv1 = BatchNormalization(momentum=bn_momentum)(conv1)
@@ -128,8 +132,8 @@ def create_model(nfilters):
 
     # Branch for the global context
     global_pool = GlobalAveragePooling2D()(conv1)
-    global_pool = RepeatVector(CROP_HEIGHT * CROP_WIDTH)(global_pool)
-    global_pool = Reshape((CROP_HEIGHT, CROP_WIDTH, nfilters))(global_pool)
+    global_pool = RepeatVector(input_height * input_width)(global_pool)
+    global_pool = Reshape((input_height, input_width, nfilters))(global_pool)
 
     # Concatenation
     concat = concatenate([conv3a, conv4, conv5,

--- a/unit_testing/test_deepseg_gm.py
+++ b/unit_testing/test_deepseg_gm.py
@@ -53,6 +53,11 @@ class TestModel(object):
         model = gm_model.create_model(64)
         assert model.count_params() == 478017
 
+        diff_size_model = gm_model.create_model(32, (103, 102))
+        axial_slices_mock = np.random.randn(1, 103, 102, 1)
+        preds = diff_size_model.predict(axial_slices_mock, batch_size=8)
+        assert preds.shape == axial_slices_mock.shape
+
 
 class TestCore(object):
     def test_data_resource(self):


### PR DESCRIPTION
I just realized that given that I can dynamically change the TensorFlow model input size for that particular model architecture that I'm using, it makes it possible to handle input sizes smaller than the sizes that the network was trained on by avoiding padding. 

This PR removes the restriction error that we had for smaller volume sizes (after resampling), that was usually thrown when the user inputs a cropped volume. That shouldn't be an issue anymore because now the network input size is dynamically resized (a property of the ASPP architecture allow that). For larger sizes, the process continues the same, with the traditional cropping.