### PR TITLE
install: use pip install -e spinalcordtoolbox to gain flexibility

### DIFF
--- a/install/sct_launcher
+++ b/install/sct_launcher
@@ -106,6 +106,7 @@ if [[ "${0}" == "${BASH_SOURCE}" ]] && [[ -n "${1}"  ]]; then
   start=$(date +%s)
 
   python ${SCT_DIR}/scripts/${@}
+  res=$?
 
   end=$(date +%s)
   difftimelps=$(($end-$start))
@@ -116,3 +117,4 @@ else
   echo Sourcing sct_laucher in your environment ${SCT_DIR}
 fi
 
+exit $res

--- a/install/update_bin.sh
+++ b/install/update_bin.sh
@@ -2,8 +2,6 @@
 # Convenience script to creates the boilerplate-script/wrapper of
 # the bin/ directory
 #
-# This script needs to be run in the install/ directory
-#
 #########################################################################################
 # Copyright (c) 2016 Polytechnique Montreal <www.neuro.polymtl.ca>
 # Author: PO Quirion
@@ -14,6 +12,9 @@
 FILES_TO_REMOVE="msct_nurbs sct_utils sct_dmri_eddy_correct sct_change_image_type sct_invert_image msct_moco msct_parser msct_smooth sct_denoising_onlm"
 # Script that uses multiprocessing
 PIPELINE_SCRIPT="sct_pipeline"
+
+SCT_SOURCE="$1"
+SCT_DIR="$2"
 
 read  -d '' boiler_plate << EOF
 #!/bin/bash
@@ -27,28 +28,31 @@ export SCT_MPI_MODE=yes
 mpiexec -n 1 \${SCT_DIR}/scripts/\$(basename \$0).py \$@
 EOF
 
-echo "$boiler_plate"
+mkdir -p ${SCT_DIR}/bin
+sed "s|{DYNAMIC_INSTALL_TEMPLATE}|${SCT_ADD_ENV_VARS}|" "${SCT_SOURCE}/install/sct_launcher" > "${SCT_DIR}/bin/sct_launcher"
+cp "${SCT_SOURCE}/install/sct_env" "${SCT_DIR}/bin/"
 
-sed "s|{DYNAMIC_INSTALL_TEMPLATE}|${SCT_ADD_ENV_VARS}|" sct_launcher > ../bin/sct_launcher
-cp sct_env ../bin/.
-
-grep -l "__main__" ../scripts/*.py | while read -r filename ; do
+grep -l "__main__" "${SCT_SOURCE}/scripts/"*.py | while read -r filename ; do
 
   filename=$(basename ${filename})
   filename=${filename%.*}
 
-  [[ ${FILES_TO_REMOVE} =~ ${filename} ]] && echo "no ${filename}" && continue || echo "yes ${filename}"
-   
+  [[ ${FILES_TO_REMOVE} =~ ${filename} ]] && echo -n " -${filename}" && continue || echo -n " +${filename}"
+
+  if [ -x "${SCT_DIR}/bin/${filename}" ]; then
+    rm -f "${SCT_DIR}/bin/${filename}"
+  fi
+
   if [[ ${PIPELINE_SCRIPT} =~ ${filename} && -n ${SCT_MPI_MODE} ]]; then
     # distribute2mpi script
-    echo "${boiler_plate_pipeline}" > ../bin/${filename}
+    echo "${boiler_plate_pipeline}" > "${SCT_DIR}/bin/${filename}"
   else
     # Normal script
-    echo "${boiler_plate}" > ../bin/${filename}
+    echo "${boiler_plate}" > "${SCT_DIR}/bin/${filename}"
   fi
-  chmod 755 ../bin/${filename}
-
 done
+
+chmod 755 "${SCT_DIR}/bin/"*
 
 
 

--- a/install_sct
+++ b/install_sct
@@ -188,10 +188,6 @@ while getopts ":dmhbpz" opt; do
       echo " Multiprocessing using MPI activated"
       export SCT_MPI_MODE=yes
       ;;
-    z)
-      echo " Development mode"
-      export SCT_DEV_MODE=yes
-      ;;
     h)
       usage
       exit 0
@@ -515,14 +511,9 @@ else
   fi
 fi
 
-## Install the spinalcordtoolbox into conda
-if [ ${SCT_DEV_MODE} ]; then
-  pip install -e ${SCT_SOURCE}
-  e_status=$?
-else
-  pip install -e ${SCT_DIR}
-  e_status=$?
-fi
+## Install the spinalcordtoolbox into the Conda venv
+pip install -e ${SCT_DIR}
+e_status=$?
 if [ ${e_status} != 0 ]; then
   echo "Failed to pip install sct, which is quite unexpected."
   exit ${e_status}

--- a/install_sct
+++ b/install_sct
@@ -362,29 +362,20 @@ else
 fi
 SCT_DIR=${INSTALL_DIR}
 
+# Copy files to destination directory
+if [ "${SCT_DIR}" != "${SCT_SOURCE}" ]; then
+  echo -e "\nCopying source files from ${SCT_SOURCE} to ${SCT_DIR}"
+  cp -vR ${SCT_INSTALL_CP_OPTIONS} "${SCT_SOURCE}/"*  "${SCT_DIR}/" | while read line; do echo -n "."; done
+
+else
+  echo -e "\nSkipping copy of source files (source and destination folders are the same)"
+fi
+
 # Clean old install setup in bin/ if existing
 if [ -x ${SCT_DIR}/${BIN_DIR} ]; then
   echo -e "\nRemoving sct and isct softlink from ${SCT_DIR}/${BIN_DIR}"
   find ${SCT_DIR}/${BIN_DIR} -type l -name "sct_*" -exec rm {} \;
   find ${SCT_DIR}/${BIN_DIR} -type l -name "isct_*" -exec rm {} \;
-fi
-
-# Copy files to destination directory
-if [ "${SCT_DIR}" != "${SCT_SOURCE}" ]; then
-  echo -e "\nCopying source files from ${SCT_SOURCE} to ${SCT_DIR}"
-  cp -vR ${SCT_SOURCE}/${SCRIPT_DIR}  ${SCT_DIR}/.
-  cp ${SCT_SOURCE}/version.txt  ${SCT_DIR}/.
-  cp ${SCT_SOURCE}/commit.txt  ${SCT_DIR}/.
-  cp ${SCT_SOURCE}/README.md  ${SCT_DIR}/.
-  cp ${SCT_SOURCE}/CHANGES.md  ${SCT_DIR}/.
-  cp ${SCT_SOURCE}/batch_processing.sh  ${SCT_DIR}/.
-  cp ${SCT_SOURCE}/batch_processing_PAM50.sh  ${SCT_DIR}/.
-  mkdir -p ${SCT_DIR}/install
-  cp -vRp ${SCT_SOURCE}/install ${SCT_DIR}
-  cp -vRp ${SCT_SOURCE}/testing ${SCT_DIR}/.
-  mkdir -p ${SCT_DIR}/documentation/imgs && cp -vRp ${SCT_SOURCE}/documentation/imgs/* ${SCT_DIR}/documentation/imgs
-else
-  echo -e "\nSkipping copy of source files (source and destination folders are the same)"
 fi
 
 # Go to installation folder
@@ -404,12 +395,13 @@ if [ ${REPORT_STATS} ]; then
   download "${TMP_DIR}/stats_dsn.txt" "$STATS_DSN"
   SCT_ADD_ENV_VARS="export SENTRY_DSN=$(cat ${TMP_DIR}/stats_dsn.txt)"
 fi
-echo -e "\nCreate launchers for Python scripts"
-cmd="mkdir -p ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
-# update_bin has to be executed from the install directory
-cmd="cd ${SCT_DIR}/install"; echo ">> "$cmd; $cmd
-cmd="./update_bin.sh"; echo ">> "$cmd; $cmd  # N.B. This script needs to be run from /install folder (because uses relative path)
-# Copy binaries
+echo -e "\nCreating launchers for Python scripts..."
+cmd="install/update_bin.sh ${SCT_SOURCE} ${SCT_DIR}"; echo ">> "$cmd; $cmd
+res=$?
+if [[ $res != 0 ]]; then
+  echo "\nProblem creating launchers!"
+  exit $res
+fi
 
 ## INSTALL PYTHON
 # We make sure that there is no conflict with local python install by unsetting PYTHONPATH
@@ -528,7 +520,7 @@ if [ ${SCT_DEV_MODE} ]; then
   pip install -e ${SCT_SOURCE}
   e_status=$?
 else
-  pip install ${SCT_SOURCE}
+  pip install -e ${SCT_DIR}
   e_status=$?
 fi
 if [ ${e_status} != 0 ]; then
@@ -543,13 +535,13 @@ else
   echo -e "\nInstalling binaries..."
   cmd=". ${SCT_DIR}/${PYTHON_DIR}/bin/activate ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
   if [ $OS == "linux" ]; then
-    cmd="python ../scripts/sct_download_data.py -d binaries_debian -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
+    cmd="python scripts/sct_download_data.py -d binaries_debian -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
     e_status=$?
   elif [ $OS == "linux_centos6" ]; then
-    cmd="python ../scripts/sct_download_data.py -d binaries_centos -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
+    cmd="python scripts/sct_download_data.py -d binaries_centos -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
     e_status=$?
   elif [ $OS == "osx" ]; then
-    cmd="python ../scripts/sct_download_data.py -d binaries_osx -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
+    cmd="python scripts/sct_download_data.py -d binaries_osx -o ${SCT_DIR}/${BIN_DIR}"; echo ">> "$cmd; $cmd
     e_status=$?
   else
     echo "Unsupported OS $OS: can't install binaries."


### PR DESCRIPTION
This PR brings a "solution" for #1702, whereby users can tinker with the running code in all cases:

- Users installing sct as a package or in ~/sct_dev will not see anything change, but they may edit scripts as well as spinalcordtoolbox files in their installation.
- Users installing sct in-place (from git) will save some installation time (because of no copy needed) and can stop going crazy (previously ``pip install --upgrade`` needed to be ran).
- Users installing sct in development mode will not see anything change (the development mode actually becomes moot as it basically just enables to use the *source* spinalcordtoolbox folder even when performing package installs... it could be removed to save some installer space).

Bonus:

- hot fix for #1895