### PR TITLE
Adding TTA (test-time augmentation) support for sct_deepseg_gm

### DIFF
--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -67,6 +67,13 @@ def get_parser():
                       description='File name of ground-truth segmentation.',
                       mandatory=False)
 
+    parser.add_option(name="-t",
+                      type_value=None,
+                      description="Enable TTA (test-time augmentation). "
+                                  "Better results, but takes more time and "
+                                  "provides non-deterministic results.",
+                      mandatory=False)
+
     parser.add_option(name="-v",
                       type_value='multiple_choice',
                       description="Verbose: 0 = no verbosity, 1 = verbose.",
@@ -109,6 +116,7 @@ def run_main():
     except KeyError:
         output_filename = sct.add_suffix(input_filename, '_gmseg')
 
+    use_tta = "-t" in arguments
     verbose = arguments["-v"]
     model_name = arguments["-m"]
     threshold = arguments['-thr']
@@ -121,7 +129,8 @@ def run_main():
         threshold = None
 
     out_fname = deepseg_gm.segment_file(input_filename, output_filename,
-                                        model_name, threshold, int(verbose))
+                                        model_name, threshold, int(verbose),
+                                        use_tta)
 
     path_qc = arguments.get("-qc", None)
     if path_qc is not None:

--- a/spinalcordtoolbox/deepseg_gm/deepseg_gm.py
+++ b/spinalcordtoolbox/deepseg_gm/deepseg_gm.py
@@ -200,12 +200,14 @@ def threshold_predictions(predictions, thr=0.999):
 
 
 def segment_volume(ninput_volume, model_name,
-                   threshold=0.999):
+                   threshold=0.999, use_tta=False):
     """Segment a nifti volume.
 
     :param ninput_volume: the input volume.
     :param model_name: the name of the model to use.
     :param threshold: threshold to be applied in predictions.
+    :param use_tta: whether TTA (test-time augmentation)
+                    should be used or not.
     :return: segmented slices.
     """
     gmseg_model_challenge = DataResource('deepseg_gm_models')
@@ -251,9 +253,26 @@ def segment_volume(ninput_volume, model_name,
     normalization = VolumeStandardizationTransform()
     axial_slices = normalization(axial_slices)
 
-    preds = deepgmseg_model.predict(axial_slices, batch_size=8,
-                                    verbose=True)
-    preds = threshold_predictions(preds, threshold)
+    if use_tta:
+        pred_sampled = []
+        for i in range(8):
+            sampled_value = np.random.uniform(high=2.0)
+            sampled_axial_slices = axial_slices + sampled_value
+            preds = deepgmseg_model.predict(sampled_axial_slices, batch_size=8,
+                                            verbose=True)
+            pred_sampled.append(preds)
+
+        preds = deepgmseg_model.predict(axial_slices, batch_size=8,
+                                        verbose=True)
+        pred_sampled.append(preds)
+        pred_sampled = np.asarray(pred_sampled)
+        pred_sampled = np.mean(pred_sampled, axis=0)
+        preds = threshold_predictions(pred_sampled, threshold)
+    else:
+        preds = deepgmseg_model.predict(axial_slices, batch_size=8,
+                                        verbose=True)
+        preds = threshold_predictions(preds, threshold)
+
     pred_slices = []
 
     # Un-cropping
@@ -270,7 +289,8 @@ def segment_volume(ninput_volume, model_name,
 
 
 def segment_file(input_filename, output_filename,
-                 model_name, threshold, verbosity):
+                 model_name, threshold, verbosity,
+                 use_tta):
     """Segment a volume file.
 
     :param input_filename: the input filename.
@@ -279,6 +299,8 @@ def segment_file(input_filename, output_filename,
     :param threshold: threshold to apply in predictions (if None,
                       no threshold will be applied)
     :param verbosity: the verbosity level.
+    :param use_tta: whether it should use TTA (test-time augmentation)
+                    or not.
     :return: the output filename.
     """
     nii_original = nipy.load_image(input_filename)
@@ -291,7 +313,8 @@ def segment_file(input_filename, output_filename,
                                                  verbosity)
 
     nii_resampled = nipy2nifti(nii_resampled)
-    pred_slices = segment_volume(nii_resampled, model_name, threshold)
+    pred_slices = segment_volume(nii_resampled, model_name, threshold,
+                                 use_tta)
 
     original_res = "{:.5f}x{:.5f}x{:.5f}".format(
         nii_original.header["pixdim"][1],


### PR DESCRIPTION
This pull-request will add an **optional parameter** called `-t` that will give better results at the expense of **more processing time** (usually 8x more, depending on how many cores you have of course) during the inference using the `sct_deepseg_gm`. The flag will enable the TTA (test-time augmentation), where a scalar value is sampled from a uniform distribution (between 0.0 and 2.0) and added to each voxel of the entire MRI volume (before doing prediction), this process is repeated for 8 times and in the end all predictions are averaged together with the original prediction. I found that this usually improves the results and it provides a better segmentation without FP (false positives). It also helps when the voxel intensity is far away from the trained distributions (when there is a domain shift).

Example of one segmentation using the `t2s.nii.gz` from the example data:

## Without TTA
![image](https://user-images.githubusercontent.com/412328/42072186-3a7c56a6-7b2d-11e8-80ea-52f7f5eace34.png)

## With TTA enabled
![image](https://user-images.githubusercontent.com/412328/42072198-42a72ea0-7b2d-11e8-9fcf-e510b59a661d.png)

## Violin plot (between master and this PR)
Here is the violin plot between the master and this PR:

![image](https://user-images.githubusercontent.com/412328/42072232-7681c1ea-7b2d-11e8-8117-5f48a557edd7.png)

(note the difference between PASS/FAIL between branches). The distribution seems very similar but these differences are really hard to see with violin plot, so I did another plot of the Dice per volume.

## Per volume Dice plot

Note that it almost always a little better, except in some particular volumes (like the juntendo*), but I guess that these ground truths for the juntend were made from the `sct_deepseg_gm`. In the legend, the "Random Samples (0.1)" is this PR.
 
![image](https://user-images.githubusercontent.com/412328/42072287-b1b1d44e-7b2d-11e8-981e-e55df0d7b7ad.png)



