### PR TITLE
Fixup regressions in sct_launcher & install_sct

### DIFF
--- a/install/sct_launcher
+++ b/install/sct_launcher
@@ -124,9 +124,7 @@ if [[ "${0}" == "${BASH_SOURCE}" ]] && [[ -n "${1}"  ]]; then
   difftimelps=$(($end-$start))
   echo "Total processing time: $(($difftimelps / 60)) min $(($difftimelps % 60)) s"
   echo
-
+  exit $res
 else
   echo Sourcing sct_laucher in your environment ${SCT_DIR}
 fi
-
-exit $res

--- a/install_sct
+++ b/install_sct
@@ -151,7 +151,6 @@ usage()
   echo -e "\n\t-m \v Prevent the (re)-installation of the \"python/\" directory "
   echo -e "\n\t-b \v Prevent the (re)-installation of the SCT binaries files "
   echo -e "\n\t--mpi,-p \v Will use the MPI interface to run pipelines (Linux support only)"
-  echo -e "\n\t-z \v Will install spinalcordtoolbox in development mode"
 }
 
 

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -33,7 +33,7 @@ class Param:
         self.path_output = []  # list of output folders
         self.function_to_test = None
         self.remove_tmp_file = 0
-        self.verbose = 1
+        self.verbose = 0
         self.path_tmp = None
         self.args = []  # list of input arguments to the function
         self.args_with_path = ''  # input arguments to the function, with path

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -171,6 +171,10 @@ def main(args=None):
     functions_to_test = arguments.function
     param.remove_tmp_file = int(arguments.remove_temps)
     jobs = arguments.jobs
+
+    if jobs == 0:
+        jobs = multiprocessing.cpu_count()
+
     param.verbose = arguments.verbose
 
     start_time = time.time()
@@ -197,6 +201,7 @@ def main(args=None):
             if f not in list_functions:
                 sct.printv('Command-line usage error: Function "%s" is not part of the list of testing functions' % function_to_test, type='error')
         list_functions = functions_to_test
+        jobs = min(jobs, len(functions_to_test))
 
     try:
         if jobs != 1:

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -99,6 +99,10 @@ def get_parser():
      help="# of simultaneous tests to run (jobs). 0 means # of available CPU threads",
      default=arg_jobs(0),
     )
+    parser.add_argument("--verbose", "-v",
+     choices=("0", "1"),
+     default=param_default.verbose,
+    )
 
     return parser
 
@@ -167,6 +171,7 @@ def main(args=None):
     functions_to_test = arguments.function
     param.remove_tmp_file = int(arguments.remove_temps)
     jobs = arguments.jobs
+    param.verbose = arguments.verbose
 
     start_time = time.time()
 
@@ -181,7 +186,7 @@ def main(args=None):
     sct.printv('\nPath to testing data: ' + param.path_data, param.verbose)
 
     # create temp folder that will have all results and go in it
-    param.path_tmp = sct.tmp_create(verbose=0)
+    param.path_tmp = sct.tmp_create(verbose=param.verbose)
     curdir = os.getcwd()
     os.chdir(param.path_tmp)
 
@@ -224,6 +229,10 @@ def main(args=None):
                         print("   %s" % line)
             else:
                 print_ok()
+                if param.verbose:
+                    for output in list_output:
+                        for line in output.splitlines():
+                            print("   %s" % line)
                 status = 0
             # append status function to global list of status
             list_status.append(status)


### PR DESCRIPTION
This PR fixes:
- #1899 
- #1897 
- #1895 (for good)

And brings some misc changes:
- Limit # of forks of sct_testing depending on number of functions to test or host CPUs
- Add verbose feature to sct_testing