### PR TITLE
sct_propseg: Now possible to rescale data header to be able to segment non-human spinal cord (mice, rats, etc.)

### DIFF
--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -42,7 +42,7 @@ def get_parser():
                       mandatory=False,
                       example='data_pad.nii.gz')
 
-    parser.usage.addSection('\nBasic image operations:')
+    parser.usage.addSection('\nImage operations:')
     parser.add_option(name="-pad",
                       type_value="str",
                       description='Pad 3D image. Specify padding as: "x,y,z" (in voxel)',

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -53,11 +53,6 @@ def get_parser():
                       description='Pad 3D image with asymmetric padding. Specify padding as: "x_i,x_f,y_i,y_f,z_i,z_f" (in voxel)',
                       mandatory=False,
                       example='0,0,5,10,1,1')
-    parser.add_option(name="-copy-header",
-                      type_value="file",
-                      description='Copy the header of the input image (specified in -i) to the destination image (specified here)',
-                      mandatory=False,
-                      example='data_dest.nii.gz')
     parser.add_option(name="-split",
                       type_value="multiple_choice",
                       description='Split data along the specified dimension. The suffix _DIM+NUMBER will be added to the intput file name.',
@@ -84,18 +79,25 @@ def get_parser():
                       mandatory=False,
                       example=['uint8', 'int16', 'int32', 'float32', 'complex64', 'float64', 'int8', 'uint16', 'uint32', 'int64', 'uint64'])
 
+    parser.usage.addSection('\nHeader operations:')
+    parser.add_option(name="-copy-header",
+                      type_value="file",
+                      description='Copy the header of the input image (specified in -i) to the destination image (specified here)',
+                      mandatory=False,
+                      example='data_dest.nii.gz')
+
     parser.usage.addSection("\nOrientation operations: ")
     parser.add_option(name="-getorient",
                       description='Get orientation of the input image',
                       mandatory=False)
     parser.add_option(name="-setorient",
                       type_value="multiple_choice",
-                      description='Set orientation of the input image',
+                      description='Set orientation of the input image (only modifies the header).',
                       mandatory=False,
                       example='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split())
     parser.add_option(name="-setorient-data",
                       type_value="multiple_choice",
-                      description='Set orientation of the input image\'s data. Use with care !ro',
+                      description='Set orientation of the input image\'s data (does NOT modify the header, but the data). Use with care !ro',
                       mandatory=False,
                       example='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split())
 

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -97,7 +97,7 @@ def get_parser():
                       example='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split())
     parser.add_option(name="-setorient-data",
                       type_value="multiple_choice",
-                      description='Set orientation of the input image\'s data (does NOT modify the header, but the data). Use with care !ro',
+                      description='Set orientation of the input image\'s data (does NOT modify the header, but the data). Use with care !',
                       mandatory=False,
                       example='RIP LIP RSP LSP RIA LIA RSA LSA IRP ILP SRP SLP IRA ILA SRA SLA RPI LPI RAI LAI RPS LPS RAS LAS PRI PLI ARI ALI PRS PLS ARS ALS IPR SPR IAR SAR IPL SPL IAL SAL PIR PSR AIR ASR PIL PSL AIL ASL'.split())
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -577,8 +577,8 @@ if __name__ == "__main__":
     if rescale_header is not 1:
         os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_seg")),
                   fname_seg)
-        os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_centerline")),
-                  fname_centerline)
+        fname_centerline = os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg),
+                                                                      "_centerline"))
 
     # check consistency of segmentation
     # TODO: if -rescale is used, make sure to rescale back the centerline used below

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -480,22 +480,22 @@ if __name__ == "__main__":
             params.num_points = 20
             params.interval_in_mm = 30
             params.starting_slice = 'top'
-        image = Image(fname_data)
-        tmp_output_file = Image(image)  # copy current image object into tmp_output_file
-        tmp_output_file.data *= 0
-        tmp_output_file.setFileName(sct.add_suffix(fname_data, '_labels_viewer'))
-        controller = launch_centerline_dialog(image, tmp_output_file, params)
+        im_data = Image(fname_data)
+        im_mask_viewer = Image(im_data)  # copy current image object into im_mask_viewer
+        im_mask_viewer.data *= 0
+        im_mask_viewer.setFileName(sct.add_suffix(fname_data, '_labels_viewer'))
+        controller = launch_centerline_dialog(im_data, im_mask_viewer, params)
 
         if not controller.saved:
             sct.log.error('The viewer has been closed before entering all manual points. Please try again.')
             sys.exit(1)
 
-        controller.as_niftii(tmp_output_file.absolutepath)
+        controller.as_niftii(im_mask_viewer.absolutepath)
         # add mask filename to parameters string
         if use_viewer == "centerline":
-            cmd += ["-init-centerline", tmp_output_file.absolutepath]
+            cmd += ["-init-centerline", im_mask_viewer.absolutepath]
         elif use_viewer == "mask":
-            cmd += ["-init-mask", tmp_output_file.absolutepath]
+            cmd += ["-init-mask", im_mask_viewer.absolutepath]
 
     # If using OptiC
     elif use_optic:
@@ -569,7 +569,7 @@ if __name__ == "__main__":
     # remove temporary files
     # if remove_temp_files:
     #     sct.log.info("Remove temporary files...")
-    #     os.remove(tmp_output_file.absolutepath)
+    #     os.remove(im_mask_viewer.absolutepath)
 
     if path_qc is not None:
         generate_qc(fname_input_data, fname_seg, args, os.path.abspath(path_qc))

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -247,6 +247,14 @@ If the segmentation fails at some location (e.g. due to poor contrast between sp
                       type_value="image_nifti",
                       description="mask containing binary pixels at edges of the spinal cord on which the segmentation algorithm will be forced to register the surface. Can be used in case of poor/missing contrast between spinal cord and CSF or in the presence of artefacts/pathologies.",
                       mandatory=False)
+    parser.add_option(name="-rescale",
+                      type_value="float",
+                      description="Rescale the image (only the header, not the data) in order to enable segmentation "
+                                  "on spinal cords with dimensions different than that of humans (e.g., mice, rats, "
+                                  "elephants, etc.). For example, if the spinal cord is 2x smaller than that of human,"
+                                  "then use -rescale 2",
+                      default_value=1,
+                      mandatory=False)
     parser.add_option(name="-radius",
                       type_value="float",
                       description="approximate radius (in mm) of the spinal cord, default is 4",
@@ -478,6 +486,7 @@ if __name__ == "__main__":
         cmd += ["-dsearch", str(arguments["-distance-search"])]
     if "-alpha" in arguments:
         cmd += ["-alpha", str(arguments["-alpha"])]
+    rescale_header = arguments["-rescale"]
 
     # check if input image is in 3D. Otherwise itk image reader will cut the 4D image in 3D volumes and only take the first one.
     from msct_image import Image
@@ -489,8 +498,7 @@ if __name__ == "__main__":
     path_data, file_data, ext_data = sct.extract_fname(fname_data)
 
     # rescale header (see issue #1406)
-    rescale_header = 2  # TODO add flag
-    if rescale_header:
+    if rescale_header is not 1:
         fname_data_propseg = func_rescale_header(fname_data, rescale_header)
     else:
         fname_data_propseg = fname_data

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -571,10 +571,10 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # build output filename
-    fname_seg = os.path.join(folder_output, os.path.abspath(sct.add_suffix(fname_data, "_seg")))
-    fname_centerline = os.path.join(folder_output, os.path.abspath(sct.add_suffix(fname_data, "_centerline")))
+    fname_seg = os.path.join(folder_output, os.path.basename(sct.add_suffix(fname_data, "_seg")))
+    fname_centerline = os.path.join(folder_output, os.path.basename(sct.add_suffix(fname_data, "_centerline")))
     # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
-    if rescale_header:
+    if rescale_header is not 1:
         os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_seg")),
                   fname_seg)
         os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_centerline")),

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -10,6 +10,9 @@
 #
 # About the license: see the file LICENSE.TXT
 #########################################################################################
+
+# TODO: remove temp files in case rescaled is not "1"
+
 import os
 import sys
 
@@ -22,7 +25,8 @@ from msct_parser import Parser
 from spinalcordtoolbox.centerline import optic
 
 
-def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_output='', threshold_distance=5.0, remove_temp_files=1, verbose=0):
+def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_output='', threshold_distance=5.0,
+                                   remove_temp_files=1, verbose=0):
     """
     This function takes the outputs of isct_propseg (centerline and segmentation) and check if the centerline of the
     segmentation is coherent with the centerline provided by the isct_propseg, especially on the edges (related
@@ -589,11 +593,6 @@ if __name__ == "__main__":
     im_seg = Image(fname_seg)
     im_seg = copy_header(image_input, im_seg)
     im_seg.save(type='int8')
-
-    # remove temporary files
-    # if remove_temp_files:
-    #     sct.log.info("Remove temporary files...")
-    #     os.remove(im_mask_viewer.absolutepath)
 
     if path_qc is not None:
         generate_qc(fname_input_data, fname_seg, args, os.path.abspath(path_qc))

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -481,7 +481,7 @@ if __name__ == "__main__":
             params.interval_in_mm = 30
             params.starting_slice = 'top'
         image = Image(fname_data)
-        tmp_output_file = Image(image)
+        tmp_output_file = Image(image)  # copy current image object into tmp_output_file
         tmp_output_file.data *= 0
         tmp_output_file.setFileName(sct.add_suffix(fname_data, '_labels_viewer'))
         controller = launch_centerline_dialog(image, tmp_output_file, params)
@@ -535,6 +535,8 @@ if __name__ == "__main__":
         path_tmp = sct.tmp_create(basename="propseg", verbose=verbose)
         fname_data_propseg = os.path.join(path_tmp, "data_rescaled.nii.gz")
         nib.save(img_rescaled, fname_data_propseg)
+        # if "-init-mask" in arguments:
+
     else:
         fname_data_propseg = fname_data
     cmd += ['-i', fname_data_propseg]

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -496,7 +496,7 @@ if __name__ == "__main__":
         fname_data_propseg = fname_data
 
     # add to command
-    cmd = ['-i', fname_data_propseg]
+    cmd += ['-i', fname_data_propseg]
 
     # if centerline or mask is asked using viewer
     if use_viewer:
@@ -563,8 +563,11 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # build output filename
-    file_seg = file_data + "_seg" + ext_data
-    fname_seg = os.path.normpath(os.path.join(folder_output, file_seg))
+    fname_seg = os.path.join(folder_output, os.path.abspath(sct.add_suffix(fname_data, "_seg")))
+    # in case header was rescaled, we need to update the output segmentation file name by removing the "_rescaled"
+    if rescale_header:
+        os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_seg")),
+                  fname_seg)
 
     # check consistency of segmentation
     if arguments["-correct-seg"] == "1":

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -581,7 +581,6 @@ if __name__ == "__main__":
                                                                       "_centerline"))
 
     # check consistency of segmentation
-    # TODO: if -rescale is used, make sure to rescale back the centerline used below
     if arguments["-correct-seg"] == "1":
         check_and_correct_segmentation(fname_seg, fname_centerline, folder_output=folder_output, threshold_distance=3.0,
                                        remove_temp_files=remove_temp_files, verbose=verbose)

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -509,6 +509,23 @@ if __name__ == "__main__":
     # enabling centerline extraction by default (needed by check_and_correct_segmentation() )
     cmd += ['-centerline-binary']
 
+    # rescale header (see issue #1406)
+    rescale_header = 2
+    if rescale_header:
+        # TODO: rescale header of image and init-centerline/mask
+        import nibabel as nib
+        img = nib.load(fname_data)
+        # get qform
+        qform = img.header.get_qform()
+        # multiply by scaling factor
+        qform[0:3, 0:3] *= rescale_header
+        # save as new nifti file
+        new_header = img.header.copy()
+        new_header.set_qform(qform)
+        new_img = nib.nifti1.Nifti1Image(img.get_data(), None, header=new_header)
+        nib.save(new_img, "data_rescaled.nii.gz")
+
+
     # run propseg
     status, output = sct.run(cmd, verbose, raise_exception=False)
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -572,14 +572,17 @@ if __name__ == "__main__":
 
     # build output filename
     fname_seg = os.path.join(folder_output, os.path.abspath(sct.add_suffix(fname_data, "_seg")))
-    # in case header was rescaled, we need to update the output segmentation file name by removing the "_rescaled"
+    fname_centerline = os.path.join(folder_output, os.path.abspath(sct.add_suffix(fname_data, "_centerline")))
+    # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
     if rescale_header:
         os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_seg")),
                   fname_seg)
+        os.rename(os.path.join(folder_output, sct.add_suffix(os.path.basename(fname_data_propseg), "_centerline")),
+                  fname_centerline)
 
     # check consistency of segmentation
+    # TODO: if -rescale is used, make sure to rescale back the centerline used below
     if arguments["-correct-seg"] == "1":
-        fname_centerline = os.path.join(folder_output, file_data + '_centerline' + ext_data)
         check_and_correct_segmentation(fname_seg, fname_centerline, folder_output=folder_output, threshold_distance=3.0,
                                        remove_temp_files=remove_temp_files, verbose=verbose)
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -14,11 +14,11 @@ import os
 import sys
 
 import numpy as np
+from scipy import ndimage as ndi
 import sct_image
+from sct_image import orientation, copy_header
 import sct_utils as sct
 from msct_parser import Parser
-from scipy import ndimage as ndi
-from sct_image import orientation
 from spinalcordtoolbox.centerline import optic
 
 
@@ -576,7 +576,6 @@ if __name__ == "__main__":
                                        remove_temp_files=remove_temp_files, verbose=verbose)
 
     # copy header from input to segmentation to make sure qform is the same
-    from sct_image import copy_header
     im_seg = Image(fname_seg)
     im_seg = copy_header(image_input, im_seg)
     im_seg.save(type='int8')

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -283,6 +283,14 @@ If the segmentation fails at some location (e.g. due to poor contrast between sp
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
                       default_value=None)
+    parser.add_option(name='-correct-seg',
+                      type_value="multiple_choice",
+                      description="Enable (1) or disable (0) the algorithm that checks and correct the output "
+                                  "segmentation. More specifically, the algorithm checks if the segmentation is "
+                                  "consistent with the centerline provided by isct_propseg.",
+                      mandatory=False,
+                      example=["0", "1"],
+                      default_value="1")
     parser.add_option(name='-igt',
                       type_value='image_nifti',
                       description='File name of ground-truth segmentation.',
@@ -510,7 +518,7 @@ if __name__ == "__main__":
     cmd += ['-centerline-binary']
 
     # rescale header (see issue #1406)
-    rescale_header = 2
+    rescale_header = 2  # TODO add flag
     if rescale_header:
         # TODO: rescale header of image and init-centerline/mask
         import nibabel as nib
@@ -545,8 +553,10 @@ if __name__ == "__main__":
     fname_seg = os.path.normpath(os.path.join(folder_output, file_seg))
 
     # check consistency of segmentation
-    fname_centerline = os.path.join(folder_output, file_data + '_centerline' + ext_data)
-    check_and_correct_segmentation(fname_seg, fname_centerline, folder_output=folder_output, threshold_distance=3.0, remove_temp_files=remove_temp_files, verbose=verbose)
+    if arguments["-correct-seg"] == "1":
+        fname_centerline = os.path.join(folder_output, file_data + '_centerline' + ext_data)
+        check_and_correct_segmentation(fname_seg, fname_centerline, folder_output=folder_output, threshold_distance=3.0,
+                                       remove_temp_files=remove_temp_files, verbose=verbose)
 
     # copy header from input to segmentation to make sure qform is the same
     from sct_image import copy_header

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -351,7 +351,7 @@ if __name__ == "__main__":
     contrast_type_propseg = contrast_type_conversion[contrast_type]
 
     # Building the command
-    cmd = ['isct_propseg', '-i', fname_data, '-t', contrast_type_propseg]
+    cmd = ['isct_propseg', '-t', contrast_type_propseg]
 
     if "-ofolder" in arguments:
         folder_output = arguments["-ofolder"]
@@ -519,12 +519,17 @@ if __name__ == "__main__":
         qform = img.header.get_qform()
         # multiply by scaling factor
         qform[0:3, 0:3] *= rescale_header
-        # save as new nifti file
-        new_header = img.header.copy()
-        new_header.set_qform(qform)
-        new_img = nib.nifti1.Nifti1Image(img.get_data(), None, header=new_header)
-        nib.save(new_img, "data_rescaled.nii.gz")
-
+        # generate a new nifti file
+        header_rescaled = img.header.copy()
+        header_rescaled.set_qform(qform)
+        # the data are the same-- only the header changes
+        img_rescaled = nib.nifti1.Nifti1Image(img.get_data(), None, header=header_rescaled)
+        path_tmp = sct.tmp_create(basename="propseg", verbose=verbose)
+        fname_data_propseg = os.path.join(path_tmp, "data_rescaled.nii.gz")
+        nib.save(img_rescaled, fname_data_propseg)
+    else:
+        fname_data_propseg = fname_data
+    cmd += ['-i', fname_data_propseg]
 
     # run propseg
     status, output = sct.run(cmd, verbose, raise_exception=False)

--- a/spinalcordtoolbox/gui/centerline.py
+++ b/spinalcordtoolbox/gui/centerline.py
@@ -241,6 +241,13 @@ class Centerline(base.BaseDialog):
 
 
 def launch_centerline_dialog(im_input, im_output, params):
+    """
+    Launch GUI where user clicks on axial view to generate centerline information.
+    :param im_input: input image object
+    :param im_output: output image object that will contain the generated manual labels
+    :param params: # TODO: define all params
+    :return:
+    """
     params.input_file_name = im_input.absolutepath
     params.subtitle += u"[KEYBOARD] Up/Down arrows: Navigate the superior-inferior direction" \
                        "\n[MOUSE] Right click: Change brightness (left/right) and contrast (up/down)." \


### PR DESCRIPTION
### Description of the Change

- Fixes #1406: New flag `-rescale`, which rescales the image (only the header, not the data) in order to enable segmentation on spinal cords with dimensions different than that of humans (e.g., mice, rats, elephants, etc.) 
- Fixes #1874: New flag `-correct-seg`, which enables/disables a few corrections on the output segmentation. This was introduced because sometimes the correction makes things worse.