### PR TITLE
Lazy loading for the deepseg_gm module

### DIFF
--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -8,12 +8,11 @@
 #     Spinal cord gray matter segmentation using deep dilated convolutions.
 #     URL: https://arxiv.org/abs/1710.01269
 
-import sys, os
+import sys
+import os
 
 import sct_utils as sct
 from msct_parser import Parser
-
-from spinalcordtoolbox.deepseg_gm import deepseg_gm
 
 
 def get_parser():
@@ -106,7 +105,6 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
 
 
 def run_main():
-    deepseg_gm.check_backend()
     parser = get_parser()
     arguments = parser.parse(sys.argv[1:])
     input_filename = arguments["-i"]
@@ -127,6 +125,9 @@ def run_main():
     # Threshold zero means no thresholding
     if threshold == 0.0:
         threshold = None
+
+    from spinalcordtoolbox.deepseg_gm import deepseg_gm
+    deepseg_gm.check_backend()
 
     out_fname = deepseg_gm.segment_file(input_filename, output_filename,
                                         model_name, threshold, int(verbose),


### PR DESCRIPTION
This is a minor change to delay the load of the `deepseg_gm` module for only when required, it reduced the command usage help from 3.2s to 0.3s due to Keras/TensorFlow loading.

## Profile before
![image](https://user-images.githubusercontent.com/412328/42359867-ef48646e-80b2-11e8-9252-084c5cbb5841.png)

## Profile after
![image](https://user-images.githubusercontent.com/412328/42359876-f8dc51f2-80b2-11e8-8c06-7783d1c586be.png)
