### PR TITLE
fixup sct_pipeline crashing when branch name has a slash in it

### DIFF
--- a/scripts/sct_pipeline.py
+++ b/scripts/sct_pipeline.py
@@ -531,7 +531,7 @@ if __name__ == "__main__":
     # build log file name
     if create_log:
         # global log:
-        file_log = "_".join([output_time, function_to_test, sct.__get_branch()]).replace("sct_", "")
+        file_log = "_".join([output_time, function_to_test, sct.__get_branch().replace("/", "~")]).replace("sct_", "")
         fname_log = file_log + '.log'
         # handle_log = sct.ForkStdoutToFile(fname_log)
         file_handler = sct.add_file_handler_to_logger(fname_log)


### PR DESCRIPTION
Title says it all. We have a new branch naming convention but it reveals surprises.