### PR TITLE
Make use of Github's new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ about: Create a report to help improve SCT
 ---
 
 Hi, thanks for reporting an issue, please take some time to consider the applicable guidelines:
-https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#reporting-a-bug-or-a-requesting-a-feature
+https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#reporting-a-bug-or-requesting-a-feature
 (about how to suitably describe issues or requests) prior to deleting this blurb when about to submit the issue.
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,12 @@
+---
+name: Bug report
+about: Create a report to help improve SCT
+
+---
+
 Hi, thanks for reporting an issue, please take some time to consider the applicable guidelines:
 https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#reporting-a-bug-or-a-requesting-a-feature
 (about how to suitably describe issues or requests) prior to deleting this blurb when about to submit the issue.
-
 
 ### Description
 
@@ -21,3 +26,4 @@ https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#repo
 **Expected behavior:** <What you expect to happen>
 
 **Actual behavior:** <What actually happens>
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Want improvements or new features in SCT?
+
+---
+
+Hi, thanks for opening a feature request, please take some time to consider the applicable guidelines:
+https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#reporting-a-bug-or-a-requesting-a-feature
+(about how to suitably describe issues or requests) prior to deleting this blurb when about to submit the issue.
+
+**Feature justification: Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context (references, screenshots...) about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Want improvements or new features in SCT?
 ---
 
 Hi, thanks for opening a feature request, please take some time to consider the applicable guidelines:
-https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#reporting-a-bug-or-a-requesting-a-feature
+https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#reporting-a-bug-or-requesting-a-feature
 (about how to suitably describe issues or requests) prior to deleting this blurb when about to submit the issue.
 
 **Feature justification: Is your feature request related to a problem? Please describe.**

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,8 @@ Reporting a Bug or Requesting a Feature
 #######################################
 
 
-Issues can be submitted `on our project's issue page
+Issues (bugs, feature requests, or others) can be submitted
+`on our project's issue page
 <https://github.com/neuropoly/spinalcordtoolbox/issues>`_.
 
 .. contents:: See below for guidelines on the steps for opening a


### PR DESCRIPTION
Make use of Github's [new issue templates](https://blog.github.com/2018-05-02-issue-template-improvements/).

Split the template into one for bug reports, and one for feature requests.

Fixes #1945.
