### PR TITLE
Totally pimp the Image Slicer (to act like a sequence, to slice many images), and add unit tests for the slicer

### DIFF
--- a/scripts/msct_image.py
+++ b/scripts/msct_image.py
@@ -198,15 +198,21 @@ def decompose_affine_transform(A44):
 
 class Slicer(object):
     """
-    Image slicer utility class, that can help getting ranges and slice indices
+    Image slicer utility class.
+
+    Can help getting ranges and slice indices.
+    Can provide slices (being an *iterator*).
     """
     def __init__(self, im, axis="IS"):
+        opposite_character = {'L': 'R', 'R': 'L', 'A': 'P', 'P': 'A', 'I': 'S', 'S': 'I'}
         axis_labels = "LRPAIS"
         if len(axis) != 2:
             raise ValueError()
         if axis[0] not in axis_labels:
             raise ValueError()
         if axis[1] not in axis_labels:
+            raise ValueError()
+        if axis[0] != opposite_character[axis[1]]:
             raise ValueError()
 
         for idx_axis in range(2):
@@ -216,6 +222,9 @@ class Slicer(object):
         if dim_nr == -1:
             raise ValueError()
 
+        # SCT convention
+        from_dir = im.orientation[dim_nr]
+        self.direction = +1 if axis[0] == from_dir else -1
         self.nb_slices = im.dim[dim_nr]
         self.im = im
         self.axis = axis
@@ -237,12 +246,37 @@ class Slicer(object):
         constructing a Slicer on "IS" (or "SI"),
         getting a range on "IS" would get [0,1,2],
         getting a range on "SI" would get [2,1,0].
+
+        Notes:
+
+        - To be used with direct image indexing, not as indexes for Slice[]
+          which are "logical" according to the slicing direction..
+
         """
         if axis == self.axis:
             return range(0, self.nb_slices)
         if axis == self.axis[::-1]:
             return range(self.nb_slices-1, -1, -1)
         raise ValueError()
+
+    def __len__(self):
+       return self.nb_slices
+
+    def __getitem__(self, idx):
+       """
+       :return: an image slice, at slicing index idx
+       :param idx: slicing index (according to the slicing direction)
+       """
+       if isinstance(idx, slice):
+           raise NotImplementedError()
+
+       if idx >= self.nb_slices:
+           raise IndexError("I just have {} slices!".format(self.nb_slices))
+
+       if self.direction == -1:
+           idx = self.nb_slices - 1 - idx
+
+       return self.im.data[self.slice(idx)]
 
 
 class Image(object):

--- a/scripts/msct_image.py
+++ b/scripts/msct_image.py
@@ -198,11 +198,29 @@ def decompose_affine_transform(A44):
 
 class Slicer(object):
     """
+    Image(s) slicer utility class.
+
+    Can help getting ranges and slice indices.
+    Can provide slices (being an *iterator*).
+    """
+
+    def __new__(cls, arg, axis="IS"):
+        if isinstance(arg, (list, tuple)):
+            return SlicerMany(arg, axis=axis)
+        elif isinstance(arg, Image):
+            return SlicerSingle(arg, axis=axis)
+        else:
+            raise ValueError()
+
+
+class SlicerSingle(object):
+    """
     Image slicer utility class.
 
     Can help getting ranges and slice indices.
     Can provide slices (being an *iterator*).
     """
+
     def __init__(self, im, axis="IS"):
         opposite_character = {'L': 'R', 'R': 'L', 'A': 'P', 'P': 'A', 'I': 'S', 'S': 'I'}
         axis_labels = "LRPAIS"
@@ -277,6 +295,47 @@ class Slicer(object):
            idx = self.nb_slices - 1 - idx
 
        return self.im.data[self.slice(idx)]
+
+    def __call__(self):
+        """
+        Slice generator
+
+        Example: [slice for slice in Slicer(im)()]
+        """
+        for idx_slice in self.range(self.axis):
+            yield self.im[self.slice(idx_slice)]
+
+
+class SlicerMany(object):
+    """
+    Images slicer utility class.
+
+    Can help getting ranges and slice indices.
+    Can provide slices (being an *iterator*).
+    """
+    def __init__(self, images, axis="IS"):
+        if len(images) == 0:
+            raise ValueError("Don't expect me to work on 0 images!")
+
+        self.slicers = [ Slicer(im, axis=axis) for im in images ]
+
+
+        nb_slices = [ x.nb_slices for x in self.slicers ]
+        if len(set(nb_slices)) != 1:
+            raise ValueError("All images must have the same number of slices along the slicing axis!")
+        self.nb_slices = nb_slices[0]
+
+    def __len__(self):
+        return self.nb_slices
+
+    def __getitem__(self, idx):
+        return [ x[idx] for x in self.slicers ]
+
+    def range(self, axis):
+        return self.slicer[0].range(axis)
+
+    def slice(self, idx):
+        return self.slicer[0].slice(idx)
 
 
 class Image(object):

--- a/scripts/msct_image.py
+++ b/scripts/msct_image.py
@@ -258,7 +258,7 @@ class SlicerSingle(object):
 
     def range(self, axis):
         """
-        :return: a range allowing to traverse the desired axis
+        :return: a range providing indices for all the slices along the desired axis
 
         Example: Assuming image is in RPI with 3 z-slices,
         constructing a Slicer on "IS" (or "SI"),
@@ -308,10 +308,12 @@ class SlicerSingle(object):
 
 class SlicerMany(object):
     """
-    Images slicer utility class.
+    Image*s* slicer utility class.
 
     Can help getting ranges and slice indices.
     Can provide slices (being an *iterator*).
+
+    Use with great care for now, that it's not very documented.
     """
     def __init__(self, images, axis="IS"):
         if len(images) == 0:

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# pytest unit tests for Image stuff
+
+import sys, io, os, time, itertools
+
+import pytest
+
+import numpy as np
+import nibabel
+import nibabel.orientations
+
+import sct_utils as sct
+import msct_image
+import sct_image
+
+@pytest.fixture(scope="session")
+def image_paths():
+    ret = []
+    sct_dir = os.path.dirname(os.path.dirname(__file__))
+    data_dir = os.path.join(sct_dir, "data")
+    for cwd, dirs, files in os.walk(data_dir):
+        for file in files:
+            if file.endswith((".nii.gz", ".nii")):
+                path = os.path.join(cwd, file)
+                ret.append(path)
+    return ret
+
+
+
+@pytest.fixture(scope="session")
+def fake_3dimage():
+    """
+    :return: a Nifti1Image (3D) in RAS+ space
+
+    Following characteristics:
+
+    - shape[LR] = 7
+    - shape[PA] = 8
+    - shape[IS] = 9
+    """
+    shape = (7,8,9)
+    data = np.zeros(shape, dtype=np.float32, order="F")
+
+    for z in range(shape[2]):
+        for y in range(shape[1]):
+            for x in range(shape[0]):
+                data[x,y,z] = (1+x)*1 + (1+y)*10 + (1+z)*100
+
+    if 0:
+        for z in range(shape[2]):
+            for y in range(shape[1]):
+                for x in range(shape[0]):
+                    sys.stdout.write(" % 3d" % data[x,y,z])
+                sys.stdout.write("\n")
+            sys.stdout.write("\n")
+
+    affine = np.eye(4)
+    return nibabel.nifti1.Nifti1Image(data, affine)
+
+
+@pytest.fixture(scope="session")
+def fake_3dimage_sct():
+    """
+    :return: an Image (3D) in RAS+ (aka SCT LPI) space
+    """
+    i = fake_3dimage()
+    img = msct_image.Image(i.get_data(), hdr=i.header,
+     orientation="LPI",
+     dim=i.header.get_data_shape(),
+    )
+    return img
+
+
+def test_slicer(fake_3dimage_sct):
+    im3d = fake_3dimage_sct
+    slicer = msct_image.Slicer(im3d, "IS")
+    assert slicer.direction == +1
+    assert slicer.nb_slices == 9
+    if 0:
+        for im2d in slicer:
+            print(im2d)
+
+    assert 100 < np.mean(slicer[0]) < 200
+
+    slicer = msct_image.Slicer(im3d, "SI")
+    assert slicer.direction == -1
+    assert slicer.nb_slices == 9
+
+    if 0:
+        for im2d in slicer:
+            print(im2d)
+
+    assert 900 < np.mean(slicer[0]) < 1000
+
+    with pytest.raises(ValueError):
+        slicer = msct_image.Slicer(im3d, "LI")
+


### PR DESCRIPTION
This new code allows to write:
```python
[ im_2d for im_2d in Slicer(im_3d) ]
```
as well as:
```python
[ dice(x, y) for (x,y) in Slicer((im3d_x, im3d_y)) ]
```

illustrating a suggestion in https://github.com/neuropoly/spinalcordtoolbox/issues/1621#issuecomment-406765731