### PR TITLE
Testing improvements relative to checking correct path handling, associated fixes

### DIFF
--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -13,11 +13,12 @@
 # ######################################################################################################################
 
 import sys
+
+import numpy as np
+
 import sct_utils as sct
 from msct_parser import Parser
 from msct_image import Image
-import numpy as np
-
 
 class Param:
     def __init__(self):
@@ -26,13 +27,14 @@ class Param:
 
 
 class Tsnr:
-    def __init__(self, param=None, fmri=None, anat=None):
+    def __init__(self, param=None, fmri=None, anat=None, out=None):
         if param is not None:
             self.param = param
         else:
             self.param = Param()
         self.fmri = fmri
         self.anat = anat
+        self.out = out
 
     def compute(self):
 
@@ -50,7 +52,7 @@ class Tsnr:
         data_tsnr = data_mean / data_std
 
         # save TSNR
-        fname_tsnr = sct.add_suffix(fname_data, '_tsnr')
+        fname_tsnr = self.out
         nii_tsnr = nii_data
         nii_tsnr.data = data_tsnr
         nii_tsnr.setFileName(fname_tsnr)
@@ -75,6 +77,11 @@ def get_parser():
                       mandatory=False,
                       default_value='1',
                       example=['0', '1'])
+    parser.add_option(name='-o',
+                      type_value='file_output',
+                      description='tSNR data output file',
+                      mandatory=False,
+                      example='fmri_tsnr.nii.gz')
     return parser
 
 
@@ -87,10 +94,11 @@ def main(args=None):
 
     arguments = parser.parse(sys.argv[1:])
     fname_src = arguments['-i']
+    fname_dst = arguments.get("-o", sct.add_suffix(fname_src, "_tsnr"))
     verbose = int(arguments['-v'])
 
     # call main function
-    tsnr = Tsnr(param=param, fmri=fname_src)
+    tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)
     tsnr.compute()
 
 

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -279,7 +279,7 @@ def main(args=None):
             # use input file name and add _"DIM+NUMBER". Keep the same extension
             l_fname_out = []
             for i, im in enumerate(im_out):
-                l_fname_out.append(add_suffix(fname_in[0], '_' + dim_list[dim].upper() + str(i).zfill(4)))
+                l_fname_out.append(add_suffix(fname_out or fname_in[0], '_' + dim_list[dim].upper() + str(i).zfill(4)))
                 im.setFileName(l_fname_out[i])
                 im.save(verbose=verbose)
             sct.display_viewer_syntax(l_fname_out)

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -196,6 +196,7 @@ def main(args):
         output_folder = arguments["-ofolder"]
     else:
         output_folder = os.getcwd()
+    output_folder = os.path.abspath(output_folder)
 
     if '-overwrite' in arguments:
         overwrite = arguments['-overwrite']

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -520,7 +520,7 @@ def main(args=None):
                                               os.path.join(path_out, file_out + ext_out), verbose)
     # generate: forward warping field
     if fname_output_warp == '':
-        fname_output_warp = path_out + 'warp_' + file_src + '2' + file_dest + '.nii.gz'
+        fname_output_warp = os.path.join(path_out, 'warp_' + file_src + '2' + file_dest + '.nii.gz')
     sct.generate_output_file(os.path.join(path_tmp, "warp_src2dest.nii.gz"), fname_output_warp, verbose)
     if generate_warpinv:
         # generate: dest_reg

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -109,6 +109,9 @@ def get_parser():
     parser.add_argument("--continue-from",
      help="Instead of running all tests (or those specified by --function, start from this one",
     )
+    parser.add_argument("--execution-folder",
+     help="Folder where to run tests from (default. temporary)",
+    )
 
     return parser
 
@@ -192,7 +195,7 @@ def main(args=None):
     sct.printv('\nPath to testing data: ' + param.path_data, param.verbose)
 
     # create temp folder that will have all results and go in it
-    param.path_tmp = sct.tmp_create(verbose=param.verbose)
+    param.path_tmp = os.path.abspath(arguments.execution_folder or sct.tmp_create(verbose=param.verbose))
     curdir = os.getcwd()
     os.chdir(param.path_tmp)
 
@@ -289,7 +292,7 @@ def main(args=None):
     os.chdir(curdir)
 
     # remove temp files
-    if param.remove_tmp_file:
+    if param.remove_tmp_file and arguments.execution_folder is None:
         sct.printv('\nRemove temporary files...', 0)
         sct.rmtree(param.path_tmp)
 

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -263,6 +263,10 @@ def main(args=None):
         print("Check filesystem used -> jobs forced to 1")
         jobs = 1
 
+    print("Will run through the following tests:")
+    print("- sequentially: {}".format(" ".join(functions_serial)))
+    print("- in parallel with {} jobs: {}".format(jobs, " ".join(functions_parallel)))
+
     list_status = []
     for name, functions in (
       ("serial", functions_serial),

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -596,6 +596,7 @@ def test_function(param_test):
 
     # run command
     cmd = param_test.function_to_test + param_test.args_with_path
+    param_test.output += '\nWill run in %s:' % (os.path.join(path_testing, param_test.path_output))
     param_test.output += '\n====================================================================================================\n' + cmd + '\n====================================================================================================\n\n'  # copy command
     time_start = time.time()
     try:

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -29,7 +29,7 @@ class Param:
     def __init__(self):
         self.download = 0
         self.path_data = 'sct_testing_data'  # path to the testing data
-        self.path_output = []  # list of output folders
+        self.path_output = "."
         self.function_to_test = None
         self.remove_tmp_file = 0
         self.verbose = 0
@@ -450,7 +450,7 @@ def test_function(param_test):
 
     Returns
     -------
-    path_output [str]: path where to output testing data
+    path_output str: path where to output testing data
     """
     sct.log.debug("Starting test function")
 
@@ -463,7 +463,9 @@ def test_function(param_test):
 
     # build path_output variable
     path_testing = os.getcwd()
-    param_test.path_output = sct.tmp_create(basename=(param_test.function_to_test + '_' + subject_folder), verbose=0)
+
+    if not param_test.path_output:
+        param_test.path_output = sct.tmp_create(basename=(param_test.function_to_test + '_' + subject_folder), verbose=0)
 
     # get parser information
     parser = module_function_to_test.get_parser()

--- a/testing/test_sct_compute_ernst_angle.py
+++ b/testing/test_sct_compute_ernst_angle.py
@@ -10,6 +10,8 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+import os
+
 def init(param_test):
      """
      Initialize class: param_test
@@ -29,7 +31,7 @@ def test_integrity(param_test):
      Test integrity of function
      """
      # open result file
-     f = open('ernst_angle.txt', 'r')
+     f = open(os.path.join(param_test.path_output, 'ernst_angle.txt'), 'r')
      angle_result = float(f.read())
      f.close()
      # compare with GT

--- a/testing/test_sct_compute_hausdorff_distance.py
+++ b/testing/test_sct_compute_hausdorff_distance.py
@@ -10,6 +10,8 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+import os
+
 from pandas import DataFrame
 
 def init(param_test):
@@ -35,7 +37,7 @@ def test_integrity(param_test):
     max_hausdorff_distance = float('nan')
 
     # extract name of output: hausdorff_distance.txt
-    file_hausdorff = 'hausdorff_distance.txt'
+    file_hausdorff = os.path.join(param_test.path_output, 'hausdorff_distance.txt')
 
     # open output segmentation
     hausdorff_txt = open(file_hausdorff, 'r')

--- a/testing/test_sct_crop_image.py
+++ b/testing/test_sct_crop_image.py
@@ -10,6 +10,8 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+import os
+
 def init(param_test):
     """
     Initialize class: param_test
@@ -28,7 +30,7 @@ def test_integrity(param_test):
     """
     from msct_image import Image
     # check if cropping was correct
-    nx, ny, nz, nt, px, py, pz, pt = Image('cropped_normal.nii.gz').dim
+    nx, ny, nz, nt, px, py, pz, pt = Image(os.path.join(param_test.path_output, 'cropped_normal.nii.gz')).dim
     if (ny != 41):
         param_test.status = 99
         param_test.output += '--> FAILED'

--- a/testing/test_sct_dmri_separate_b0_and_dwi.py
+++ b/testing/test_sct_dmri_separate_b0_and_dwi.py
@@ -22,7 +22,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i dmri/dmri.nii.gz -bvec dmri/bvecs.txt -a 1 -ofolder . -r 0']
+    default_args = ['-i dmri/dmri.nii.gz -bvec dmri/bvecs.txt -a 1 -r 0']
     param_test.threshold = 0.001
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_dmri_transpose_bvecs.py
+++ b/testing/test_sct_dmri_transpose_bvecs.py
@@ -15,7 +15,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-bvec dmri/bvecs.txt']
+    default_args = ['-bvec dmri/bvecs.txt -o bvecs.txt']
     # assign default params
     if not param_test.args:
         param_test.args = default_args

--- a/testing/test_sct_fmri_compute_tsnr.py
+++ b/testing/test_sct_fmri_compute_tsnr.py
@@ -15,7 +15,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i fmri/fmri.nii.gz']
+    default_args = ['-i fmri/fmri.nii.gz -o fmri_tsnr.nii.gz']
     # assign default params
     if not param_test.args:
         param_test.args = default_args

--- a/testing/test_sct_image.py
+++ b/testing/test_sct_image.py
@@ -37,7 +37,7 @@ def init(param_test):
     default_args = ['-i ' + os.path.join(param_test.folder_data[0], param_test.file_data[0]) + ' -o test.nii.gz' + ' -pad 0,0,'+str(param_test.pad),
                     '-i ' + os.path.join(param_test.folder_data[1], param_test.file_data[1]) + ' -getorient',  # 3D
                     '-i ' + os.path.join(param_test.folder_data[2], param_test.file_data[2]) + ' -getorient',  # 4D
-                    '-i ' + os.path.join(param_test.folder_data[2], param_test.file_data[2]) + ' -split t',
+                    '-i ' + os.path.join(param_test.folder_data[2], param_test.file_data[2]) + ' -split t -o dmri.nii.gz',
                     '-i ' + input_concat + ' -concat t -o dmri_concat.nii.gz']
 
     # assign default params
@@ -70,7 +70,7 @@ def test_integrity(param_test):
         try:
             path_fname, file_fname, ext_fname = sct.extract_fname(os.path.join(param_test.path_data, param_test.folder_data[2], param_test.file_data[2]))
             ref = Image(os.path.join(param_test.path_data, param_test.dmri_t_slices[0]))
-            new = Image(os.path.join(param_test.path_data, param_test.folder_data[2], file_fname + '_T0000' + ext_fname))
+            new = Image(os.path.join(param_test.path_output, file_fname + '_T0000' + ext_fname))
             diff = ref.data - new.data
             if np.sum(diff) > threshold:
                 param_test.status = 99

--- a/testing/test_sct_process_segmentation.py
+++ b/testing/test_sct_process_segmentation.py
@@ -15,13 +15,15 @@
 # TODO: make it compatible with isct_test_function
 # TODO: add log file
 
+import sys
+import os
+import time
+
 import sct_utils as sct
 from pandas import DataFrame
-import time
 import numpy as np
 import nibabel as nib
 import pickle
-import sys
 
 
 def init(param_test):

--- a/testing/test_sct_register_multimodal.py
+++ b/testing/test_sct_register_multimodal.py
@@ -10,6 +10,8 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+import os
+
 from msct_image import Image
 import numpy as np
 
@@ -36,7 +38,7 @@ def test_integrity(param_test):
     # check if ground truth exists.
     if hasattr(param_test, 'fname_gt'):
         # compare result and groundtruth images
-        param_test = compare_two_images('mt0_reg.nii.gz', param_test.fname_gt, param_test)
+        param_test = compare_two_images(os.path.join(param_test.path_output, 'mt0_reg.nii.gz'), param_test.fname_gt, param_test)
     else:
         param_test.output += '\n--> N/A'
     return param_test

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -10,6 +10,8 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+import os
+
 from pandas import DataFrame
 from msct_image import Image, compute_dice
 import sct_apply_transfo
@@ -40,8 +42,8 @@ def test_integrity(param_test):
     sct_apply_transfo.main(args=[
         '-i', param_test.fname_gt,
         '-d', param_test.dict_args_with_path['-s'],
-        '-w', 'warp_template2anat.nii.gz',
-        '-o', 'test_template2anat.nii.gz',
+        '-w', os.path.join(param_test.path_output, 'warp_template2anat.nii.gz'),
+        '-o', os.path.join(param_test.path_output, 'test_template2anat.nii.gz'),
         '-x', 'nn',
         '-v', '0'])
 
@@ -49,14 +51,14 @@ def test_integrity(param_test):
     sct_apply_transfo.main(args=[
         '-i', param_test.dict_args_with_path['-s'],
         '-d', param_test.fname_gt,
-        '-w', 'warp_anat2template.nii.gz',
-        '-o', 'test_anat2template.nii.gz',
+        '-w', os.path.join(param_test.path_output, 'warp_anat2template.nii.gz'),
+        '-o', os.path.join(param_test.path_output, 'test_anat2template.nii.gz'),
         '-x', 'nn',
         '-v', '0'])
 
     # compute dice coefficient between template segmentation warped to anat and segmentation from anat
     im_seg = Image(param_test.dict_args_with_path['-s'])
-    im_template_seg_reg = Image('test_template2anat.nii.gz')
+    im_template_seg_reg = Image(os.path.join(param_test.path_output, 'test_template2anat.nii.gz'))
     dice_template2anat = compute_dice(im_seg, im_template_seg_reg, mode='3d', zboundaries=True)
     # check
     param_test.output += 'Dice[seg,template_seg_reg]: '+str(dice_template2anat)
@@ -67,7 +69,7 @@ def test_integrity(param_test):
         param_test.output += '\n--> FAILED'
 
     # compute dice coefficient between anat segmentation warped to template and segmentation from template
-    im_seg_reg = Image('test_anat2template.nii.gz')
+    im_seg_reg = Image(os.path.join(param_test.path_output, 'test_anat2template.nii.gz'))
     im_template_seg = Image(param_test.fname_gt)
     dice_anat2template = compute_dice(im_seg_reg, im_template_seg, mode='3d', zboundaries=True)
     # check

--- a/testing/test_sct_straighten_spinalcord.py
+++ b/testing/test_sct_straighten_spinalcord.py
@@ -61,15 +61,33 @@ def test_integrity(param_test):
 
         # apply curved2straight, then straight2curve, then compared results
         path_input, file_input, ext_input = sct.extract_fname(param_test.file_input)
-        sct.run('sct_apply_transfo -i ' + os.path.join(param_test.path_data, param_test.fname_segmentation) + ' -d ' + os.path.join(param_test.path_output, 'output.nii.gz') + ' -w ' + os.path.join(param_test.path_output, 'warp_curve2straight.nii.gz') + ' -o ' + os.path.join(param_test.path_output, 'tmp_seg_straight.nii.gz') + ' -x linear', 0)
-        sct.run('sct_apply_transfo -i ' + os.path.join(param_test.path_output, 'tmp_seg_straight.nii.gz') + ' -d ' + os.path.join(param_test.path_data, param_test.fname_segmentation) + ' -w ' + os.path.join(param_test.path_output, 'warp_straight2curve.nii.gz') + ' -o ' + os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz') + ' -x nn',0)
+
+        sct.run(["sct_apply_transfo",
+         "-i", os.path.join(param_test.path_data, param_test.fname_segmentation),
+         "-d", os.path.join(param_test.path_output, 't2_straight.nii.gz'),
+         "-w", os.path.join(param_test.path_output, 'warp_curve2straight.nii.gz'),
+         "-o", os.path.join(param_test.path_output, 'tmp_seg_straight.nii.gz'),
+         "-x", "linear"], 0)
+
+        sct.run(["sct_apply_transfo",
+         "-i", os.path.join(param_test.path_output, 'tmp_seg_straight.nii.gz'),
+         "-d", os.path.join(param_test.path_data, param_test.fname_segmentation),
+         "-w", os.path.join(param_test.path_output, 'warp_straight2curve.nii.gz'),
+         "-o", os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz'),
+         "-x", "nn"], 0)
 
         # threshold and binarize
-        sct.run('sct_maths -i ' + os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz') + ' -bin 0.5 -o ' + os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz'), 0)
+        sct.run(["sct_maths",
+         "-i", os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz'),
+         "-bin", "0.5",
+         "-o", os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz'),
+        ], 0)
 
         # compute DICE
-        cmd = 'sct_dice_coefficient -i ' + os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz') + ' -d ' + os.path.join(param_test.path_data, param_test.fname_segmentation)
-        status2, output2 = sct.run(cmd, 0)
+        status2, output2 = sct.run(["sct_dice_coefficient",
+         "-i", os.path.join(param_test.path_output, 'tmp_seg_straight_curved.nii.gz'),
+         "-d", os.path.join(param_test.path_data, param_test.fname_segmentation),
+         ], 0)
         # parse output and compare to acceptable threshold
         result_dice = float(output2.split('3D Dice coefficient = ')[1].split('\n')[0])
 

--- a/testing/testing_sct_propseg.py
+++ b/testing/testing_sct_propseg.py
@@ -154,11 +154,6 @@ def main():
     elapsed_time = time.time() - start_time
     print('Finished! Elapsed time: '+str(int(round(elapsed_time)))+'s\n')
 
-    # remove temp files
-    if param.remove_tmp_file:
-        sct.printv('\nRemove temporary files...', param.verbose)
-        sct.rmtree(param.path_tmp)
-
     e = 0
     for i in range(0,len(results_t2)):
         if (results_t2[i][4] < 0.8 or results_t2[i][4] < results_t2[i][3]):


### PR DESCRIPTION
I noticed that my `sct_testing_data` got modified, which was causing test failures when running `sct_testing` several times, and so taking some actions:
- Augment `sct_testing`:  
  - To be able to run tests in their own testing subfolder;  
  - To be able to check for tests that mess up with input data or write where they shouldn't.  
- Correct problems found (in tests or scripts) after implementation
  - Tests don't modify data in the `sct_testing_data` repo
  - Tests write to the output folder
  - Scripts that modify stuff can write to a second output file (used for testing)
  - All scripts can operate in `-ofolder != "."`

PS: I'm not friends with `sct_testing` (and `sct_pipeline` by extension).