### PR TITLE
Third pass at Image refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 # test dependencies
 #  - sct_check_dependencies
 # test functions & integrity
-  - bash -c "sudo apt-get install -qq libalglib-dev libinsighttoolkit4-dev; apt-cache show libvtk6-dev && sudo apt-get install -qq libvtk6-dev; apt-cache show libvtk7-dev && sudo apt-get install -qq libvtk7-dev; cd $HOME/build/neuropoly/spinalcordtoolbox/dev/isct_propseg; mkdir -p build; cd build; cmake ..; make; echo"
+#  - bash -c "sudo apt-get install -qq libalglib-dev libinsighttoolkit4-dev; apt-cache show libvtk6-dev && sudo apt-get install -qq libvtk6-dev; apt-cache show libvtk7-dev && sudo apt-get install -qq libvtk7-dev; cd $HOME/build/neuropoly/spinalcordtoolbox/dev/isct_propseg; mkdir -p build; cd build; cmake ..; make; echo"
   - pip install coverage
   - bash -c 'echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py'
   - bash -c 'echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc'

--- a/install/requirements/requirementsPip.txt
+++ b/install/requirements/requirementsPip.txt
@@ -8,3 +8,4 @@ tensorflow==1.3.0; (sys_platform == 'linux2') and ("Debian" not in platform_vers
 https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.3.0-py2-none-any.whl; sys_platform == 'darwin'
 Keras==2.0.6
 h5py==2.7.0
+transforms3d

--- a/scripts/isct_convert_binary_to_trilinear.py
+++ b/scripts/isct_convert_binary_to_trilinear.py
@@ -20,7 +20,7 @@ import os
 import getopt
 import time
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 
 class Param:

--- a/scripts/isct_warpmovie_generator.py
+++ b/scripts/isct_warpmovie_generator.py
@@ -12,7 +12,7 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from scipy.misc import toimage
 
 import sct_utils as sct

--- a/scripts/msct_gmseg_utils.py
+++ b/scripts/msct_gmseg_utils.py
@@ -15,8 +15,8 @@ import sys, io, os, math, time, random, shutil
 
 import numpy as np
 
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from sct_utils import extract_fname, printv, add_suffix
 import sct_utils as sct
 from sct_crop_image import ImageCropper

--- a/scripts/msct_image.py
+++ b/scripts/msct_image.py
@@ -198,29 +198,110 @@ def decompose_affine_transform(A44):
     return T, Rmat, np.array([sx, sy, sz]), np.array([sxy, sxz, syz])
 
 
+def _get_permutations(im_src_orientation, im_dst_orientation):
+    """
+    :return: list of axes permutations and list of inversions to achive an orientation change
+    """
+
+    opposite_character = {'L': 'R', 'R': 'L', 'A': 'P', 'P': 'A', 'I': 'S', 'S': 'I'}
+
+    perm = [0, 1, 2]
+    inversion = [1, 1, 1]
+    for i, character in enumerate(im_src_orientation):
+        try:
+            perm[i] = im_dst_orientation.index(character)
+        except ValueError:
+            perm[i] = im_dst_orientation.index(opposite_character[character])
+            inversion[i] = -1
+
+    return perm, inversion
+
+
 class Slicer(object):
     """
-    Image(s) slicer utility class.
+    Provides a sliced view onto original image data.
+    Can be used as a sequence.
 
-    Can help getting ranges and slice indices.
-    Can provide slices (being an *iterator*).
+    Notes:
+
+    - The original image data is directly available without copy,
+      which is a nice feature, not a bug! Use .copy() if you need copies...
+
+    Example:
+
+    .. code:: python
+
+       for slice2d in msct_image.SlicerFancy(im3d, "RPI"):
+           print(slice)
+
     """
+    def __init__(self, im, orientation="LPI"):
+        """
+        :param im: image to iterate through
+        :param spec: "from" letters to indicate how to slice the image.
+                     The slices are done on the last letter axis,
+                     and they are defined as the first/second letter.
+        """
 
-    def __new__(cls, arg, axis="IS"):
-        if isinstance(arg, (list, tuple)):
-            return SlicerMany(arg, axis=axis)
-        elif isinstance(arg, Image):
-            return SlicerSingle(arg, axis=axis)
+        if not isinstance(im, Image):
+            raise ValueError("Expecting an image")
+        if not orientation in all_refspace_strings():
+            raise ValueError("Invalid orientation spec")
+
+        # Get a different view on data, as if we were doing a reorientation
+
+        perm, inversion = _get_permutations(im.orientation, orientation)
+
+        # axes inversion (flip)
+        data = im.data[::inversion[0], ::inversion[1], ::inversion[2]]
+
+        # axes manipulations (transpose)
+        if perm == [1, 0, 2]:
+            data = np.swapaxes(data, 0, 1)
+        elif perm == [2, 1, 0]:
+            data = np.swapaxes(data, 0, 2)
+        elif perm == [0, 2, 1]:
+            data = np.swapaxes(data, 1, 2)
+        elif perm == [2, 0, 1]:
+            data = np.swapaxes(data, 0, 2)  # transform [2, 0, 1] to [1, 0, 2]
+            data = np.swapaxes(data, 0, 1)  # transform [1, 0, 2] to [0, 1, 2]
+        elif perm == [1, 2, 0]:
+            data = np.swapaxes(data, 0, 2)  # transform [1, 2, 0] to [0, 2, 1]
+            data = np.swapaxes(data, 1, 2)  # transform [0, 2, 1] to [0, 1, 2]
+        elif perm == [0, 1, 2]:
+            # do nothing
+            pass
         else:
-            raise ValueError()
+            raise NotImplementedError()
 
+        self._data = data
+        self._orientation = orientation
+        self._nb_slices = data.shape[2]
 
-class SlicerSingle(object):
+    def __len__(self):
+       return self._nb_slices
+
+    def __getitem__(self, idx):
+       """
+       :return: an image slice, at slicing index idx
+       :param idx: slicing index (according to the slicing direction)
+       """
+       if not isinstance(idx, int):
+           raise NotImplementedError()
+
+       if idx >= self._nb_slices:
+           raise IndexError("I just have {} slices!".format(self._nb_slices))
+
+       return self._data[:,:,idx]
+
+class SlicerOneAxis(object):
     """
-    Image slicer utility class.
+    Image slicer to use when you don't care about the 2D slice orientation,
+    and don't want to specify them.
+    The slicer will just iterate through the right axis that corresponds to
+    its specification.
 
     Can help getting ranges and slice indices.
-    Can provide slices (being an *iterator*).
     """
 
     def __init__(self, im, axis="IS"):
@@ -250,35 +331,6 @@ class SlicerSingle(object):
         self.axis = axis
         self._slice = lambda idx: tuple([(idx if x in axis else slice(None)) for x in im.orientation])
 
-    def slice(self, idx):
-        """
-        :return: a multi-dimensional slice (what goes in numpy array __getitem__)
-                 at the specified slice index of the slicer.
-        :param idx: slice index
-        """
-        return self._slice(idx)
-
-    def range(self, axis):
-        """
-        :return: a range providing indices for all the slices along the desired axis
-
-        Example: Assuming image is in RPI with 3 z-slices,
-        constructing a Slicer on "IS" (or "SI"),
-        getting a range on "IS" would get [0,1,2],
-        getting a range on "SI" would get [2,1,0].
-
-        Notes:
-
-        - To be used with direct image indexing, not as indexes for Slice[]
-          which are "logical" according to the slicing direction..
-
-        """
-        if axis == self.axis:
-            return range(0, self.nb_slices)
-        if axis == self.axis[::-1]:
-            return range(self.nb_slices-1, -1, -1)
-        raise ValueError()
-
     def __len__(self):
        return self.nb_slices
 
@@ -296,17 +348,7 @@ class SlicerSingle(object):
        if self.direction == -1:
            idx = self.nb_slices - 1 - idx
 
-       return self.im.data[self.slice(idx)]
-
-    def __call__(self):
-        """
-        Slice generator
-
-        Example: [slice for slice in Slicer(im)()]
-        """
-        for idx_slice in self.range(self.axis):
-            yield self.im[self.slice(idx_slice)]
-
+       return self.im.data[self._slice(idx)]
 
 class SlicerMany(object):
     """
@@ -317,29 +359,22 @@ class SlicerMany(object):
 
     Use with great care for now, that it's not very documented.
     """
-    def __init__(self, images, axis="IS"):
+    def __init__(self, images, slicerclass, *args, **kw):
         if len(images) == 0:
             raise ValueError("Don't expect me to work on 0 images!")
 
-        self.slicers = [ Slicer(im, axis=axis) for im in images ]
+        self.slicers = [ slicerclass(im, *args, **kw) for im in images ]
 
-
-        nb_slices = [ x.nb_slices for x in self.slicers ]
+        nb_slices = [ x._nb_slices for x in self.slicers ]
         if len(set(nb_slices)) != 1:
             raise ValueError("All images must have the same number of slices along the slicing axis!")
-        self.nb_slices = nb_slices[0]
+        self._nb_slices = nb_slices[0]
 
     def __len__(self):
-        return self.nb_slices
+        return self._nb_slices
 
     def __getitem__(self, idx):
         return [ x[idx] for x in self.slicers ]
-
-    def range(self, axis):
-        return self.slicer[0].range(axis)
-
-    def slice(self, idx):
-        return self.slicer[0].slice(idx)
 
 
 class Image(object):
@@ -652,30 +687,6 @@ class Image(object):
         return averaged_coordinates
 
 
-    @staticmethod
-    def get_permutation_from_orientations(orientation_in, orientation_out):
-        """
-        This function return the permutation necessary to convert a coordinate/image from orientation_in
-        to orientation_out
-        :param orientation_in: string (ex: AIL)
-        :param orientation_out: string (ex: RPI)
-        :return: two lists: permutation list (int) and inversion list (-1 if need to inverse)
-        """
-        opposite_character = {'L': 'R', 'R': 'L', 'A': 'P', 'P': 'A', 'I': 'S', 'S': 'I'}
-
-        # change the orientation of the image
-        perm = [0, 1, 2]
-        inversion = [1, 1, 1]
-        for i, character in enumerate(orientation_in):
-            try:
-                perm[i] = orientation_out.index(character)
-            except ValueError:
-                perm[i] = orientation_out.index(opposite_character[character])
-                inversion[i] = -1
-
-        return perm, inversion
-
-
     def transfo_pix2phys(self, coordi=None):
         """
         This function returns the physical coordinates of all points of 'coordi'.
@@ -910,18 +921,17 @@ def find_zmin_zmax(im, threshold=0.1):
     :param threshold: threshold to apply before looking for zmin/zmax, typically corresponding to noise level.
     :return: [zmin, zmax]
     """
-    slicer = Slicer(im, axis="IS")
+    slicer = SlicerOneAxis(im, axis="IS")
 
     # Iterate from bottom to top until we find data
-    for zmin in slicer.range("IS"):
-        dataz = im.data[slicer.slice(zmin)]
-        if np.any(dataz > threshold):
+    for zmin in range(0, len(slicer)):
+        if np.any(slicer[zmin] > threshold):
             break
 
     # Conversely from top to bottom
-    for zmax in slicer.range("SI"):
-        dataz = im.data[slicer.slice(zmax)]
-        if np.any(dataz > threshold):
+    for zmax in range(len(slicer)-1, zmin, -1):
+        dataz = slicer[zmax]
+        if np.any(slicer[zmax] > threshold):
             break
 
     return zmin, zmax
@@ -1028,28 +1038,13 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False):
     else:
         raise NotImplementedError("Don't know how to change orientation for this image")
 
-    opposite_character = {'L': 'R', 'R': 'L', 'A': 'P', 'P': 'A', 'I': 'S', 'S': 'I'}
-
-    im_src_orientation = orientation_string_sct2nib(im_src.orientation)
-    im_dst_orientation = orientation_string_sct2nib(orientation)
+    im_src_orientation = im_src.orientation
+    im_dst_orientation = orientation
     if inverse:
         im_src_orientation, im_dst_orientation = im_dst_orientation, im_src_orientation
 
 
-    def get_permutations(im_src_orientation, im_dst_orientation):
-        # change the orientation of the image
-        perm = [0, 1, 2]
-        inversion = [1, 1, 1]
-        for i, character in enumerate(im_src_orientation):
-            try:
-                perm[i] = im_dst_orientation.index(character)
-            except ValueError:
-                perm[i] = im_dst_orientation.index(opposite_character[character])
-                inversion[i] = -1
-
-        return perm, inversion
-
-    perm, inversion = get_permutations(im_src_orientation, im_dst_orientation)
+    perm, inversion = _get_permutations(im_src_orientation, im_dst_orientation)
 
     if im_dst is None:
         im_dst = im_src.copy()

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -21,7 +21,7 @@
 import sys, os, glob
 import numpy as np
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from sct_image import split_data
 
 path_sct = os.environ.get("SCT_DIR", os.path.dirname(os.path.dirname(__file__)))

--- a/scripts/msct_multiatlas_seg.py
+++ b/scripts/msct_multiatlas_seg.py
@@ -24,7 +24,7 @@ from sklearn import decomposition, manifold
 
 from msct_gmseg_utils import (apply_transfo, average_gm_wm, normalize_slice,
                               pre_processing, register_data)
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 from sct_utils import printv
 import sct_utils as sct

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -24,7 +24,7 @@ from scipy import ndimage
 from scipy.io import loadmat
 from nibabel import load, Nifti1Image, save
 
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 import sct_utils as sct
 from sct_convert import convert
 from sct_register_multimodal import Paramreg

--- a/scripts/msct_register_landmarks.py
+++ b/scripts/msct_register_landmarks.py
@@ -49,7 +49,7 @@ def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', ve
     :param verbose: 0, 1, 2
     :return:
     """
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
     # open src label
     im_src = Image(fname_src)
     # coord_src = im_src.getNonZeroCoordinates(sorting='value')  # landmarks are sorted by value

--- a/scripts/msct_shape.py
+++ b/scripts/msct_shape.py
@@ -25,8 +25,8 @@ import tqdm
 from skimage import measure, filters
 import matplotlib.pyplot as plt
 from itertools import compress
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_types import Centerline
 from sct_straighten_spinalcord import smooth_centerline
 

--- a/scripts/msct_types.py
+++ b/scripts/msct_types.py
@@ -3,7 +3,7 @@
 #
 # msct_types
 # This file contains many useful (and tiny) classes corresponding to data types.
-# Large data types with many options have their own file (e.g., msct_image)
+# Large data types with many options have their own file (e.g., spinalcordtoolbox.image)
 #
 # ---------------------------------------------------------------------------------------
 # Copyright (c) 2013 Polytechnique Montreal <www.neuro.polymtl.ca>

--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -18,8 +18,8 @@ import numpy as np
 import pandas as pd
 from skimage.measure import label
 
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 from msct_types import Centerline
 from sct_straighten_spinalcord import smooth_centerline

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -18,8 +18,8 @@ import tqdm
 from skimage.feature import greycomatrix, greycoprops
 
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 
 def get_parser():

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -20,7 +20,7 @@ from msct_parser import Parser
 import sct_utils as sct
 import sct_convert
 import sct_image
-import msct_image
+import spinalcordtoolbox.image as msct_image
 from sct_crop_image import ImageCropper
 
 

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -15,8 +15,8 @@ import sys, io, os, time, shutil
 import numpy as np
 
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 
 # TODO: display results ==> not only max : with a violin plot of h1 and h2 distribution ? see dev/straightening --> seaborn.violinplot
@@ -409,9 +409,7 @@ def resample_image(fname, suffix='_resampled.nii.gz', binary=False, npx=0.3, npy
     else:
         if orientation != 'RPI':
             fname = sct.add_suffix(fname, "_RPI")
-            im_in = msct_image \
-             .change_orientation(im_in, orientation) \
-             .save(fname)
+            im_in = msct_image.change_orientation(im_in, orientation).save(fname)
 
         sct.printv('Image resolution already ' + str(npx) + 'x' + str(npy) + 'xpz')
         return fname

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -35,7 +35,7 @@ class Param:
 #=======================================================================================================================
 def main(args=None):
     import numpy as np
-    import msct_image
+    import spinalcordtoolbox.image as msct_image
 
     # Initialization
     fname_mt0 = ''

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -16,8 +16,8 @@ import sys, io, os, shutil
 
 import numpy as np
 from msct_parser import Parser
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 import sct_image
 import sct_utils as sct
 
@@ -112,16 +112,16 @@ def main():
     if input_orient != 'RPI':
         # change orientation and load data
         sct.printv('\nChange input image orientation and load it...', verbose)
-        input_im_rpi = sct_image.change_orientation_nd(input_im, "RPI")
+        input_im_rpi = msct_image.change_orientation(input_im, "RPI")
         input_data = input_im_rpi.data
         # Do the same for the mask
         sct.printv('\nChange mask orientation and load it...', verbose)
-        mask_im_rpi = sct_image.change_orientation_nd(Image(fname_mask), "RPI")
+        mask_im_rpi = msct_image.change_orientation(Image(fname_mask), "RPI")
         mask_data = mask_im_rpi.data
         # Do the same for vertebral labeling if present
         if vert_levels != 'None':
             sct.printv('\nChange vertebral labeling file orientation and load it...', verbose)
-            vert_label_im_rpi = sct_image.change_orientation_nd(Image(vert_label_fname), "RPI")
+            vert_label_im_rpi = msct_image.change_orientation(Image(vert_label_fname), "RPI")
             vert_labeling_data = vert_label_im_rpi.data
     else:
         # Load data

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -18,7 +18,7 @@ import sys, io, os, getopt, functools
 
 import sct_utils as sct
 from msct_parser import Parser
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 # DEFAULT PARAMETERS
 

--- a/scripts/sct_convert.py
+++ b/scripts/sct_convert.py
@@ -62,7 +62,7 @@ def convert(fname_in, fname_out, squeeze_data=True, dtype=None, verbose=1):
     Convert data
     :return True/False
     """
-    import msct_image
+    import spinalcordtoolbox.image as msct_image
     sct.printv('sct_convert -i ' + fname_in + ' -o ' + fname_out, verbose, 'code')
     im = msct_image.Image(fname_in)
     if squeeze_data:

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -24,8 +24,8 @@ import nibabel
 from scipy import ndimage
 
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from sct_image import concat_data
 from msct_parser import Parser
 

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -18,7 +18,8 @@ import nibabel
 
 import sct_utils as sct
 from msct_parser import Parser
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 
 
 class LineBuilder:

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -90,7 +90,7 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
 
     import spinalcordtoolbox.reports.qc as qc
     import spinalcordtoolbox.reports.slice as qcslice
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
 
     qc.add_entry(
      src=fn_in,

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -22,8 +22,8 @@ from scipy.interpolate.interpolate import interp1d
 
 from spinalcordtoolbox.centerline import optic
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 
 import spinalcordtoolbox.resample.nipy_resample

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -22,8 +22,8 @@ from scipy.ndimage import distance_transform_edt
 
 from spinalcordtoolbox.centerline import optic
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 
 import spinalcordtoolbox.resample.nipy_resample

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -17,8 +17,8 @@ import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 import nibabel as nib
 
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 import sct_utils as sct
 

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -15,7 +15,7 @@ import os
 
 from msct_parser import Parser
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 def get_parser():
     parser = Parser(__file__)
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 
     # # Computation of Dice coefficient using Python implementation.
     # # commented for now as it does not cover all the feature of isct_dice_coefficient
-    # #from msct_image import Image, compute_dice
+    # #from spinalcordtoolbox.image import Image, compute_dice
     # #dice = compute_dice(Image(fname_input1), Image(fname_input2), mode='3d', zboundaries=False)
     # #sct.printv('Dice (python-based) = ' + str(dice), verbose)
 

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -120,7 +120,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     :return: True/False
     """
     # Open file.
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
     nii = Image(fname_in)
     data = nii.data
     sct.printv('data.shape (%d, %d, %d, %d)' % data.shape)

--- a/scripts/sct_dmri_eddy_correct.py
+++ b/scripts/sct_dmri_eddy_correct.py
@@ -21,7 +21,7 @@ import os
 import getopt
 import time
 import numpy as np
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 import sct_utils as sct
 # get path of the toolbox
 path_sct = os.environ.get("SCT_DIR", os.path.dirname(os.path.dirname(__file__)))

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -37,7 +37,7 @@ import msct_moco as moco
 from sct_dmri_separate_b0_and_dwi import identify_b0
 import importlib
 from sct_convert import convert
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from sct_image import split_data, concat_data
 from msct_parser import Parser
 

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -20,7 +20,7 @@ import time
 import os
 
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from sct_image import split_data
 from msct_parser import Parser
 

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -30,7 +30,7 @@ from spinalcordtoolbox.utils import parse_num_list
 from spinalcordtoolbox.template import get_slices_from_vertebral_levels, get_vertebral_level_from_slice
 
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 
 # get path of the script and the toolbox

--- a/scripts/sct_flatten_sagittal.py
+++ b/scripts/sct_flatten_sagittal.py
@@ -17,8 +17,8 @@ import sys, os
 import numpy as np
 
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 from sct_straighten_spinalcord import smooth_centerline
 from skimage import transform, img_as_float, img_as_uint

--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -17,9 +17,9 @@ import sys
 import numpy as np
 
 import sct_utils as sct
-import msct_image
+import spinalcordtoolbox.image as msct_image
 from msct_parser import Parser
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 
 class Param:

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -22,7 +22,7 @@ import math
 import sct_utils as sct
 import msct_moco as moco
 from sct_convert import convert
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from sct_image import split_data, concat_data
 # from sct_average_data_across_dimension import average_data_across_dimension
 from msct_parser import Parser

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -7,8 +7,8 @@ import shutil
 import sct_utils as sct
 from msct_parser import Parser
 from spinalcordtoolbox.centerline import optic
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_types import Centerline
 from sct_viewer import ClickViewerPropseg
 from sct_straighten_spinalcord import smooth_centerline

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -15,8 +15,8 @@ import os, sys, warnings
 import numpy as np
 
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 
 

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -234,11 +234,11 @@ def main(args=None):
     elif "-setorient" in arguments:
         sct.printv(fname_in[0])
         im_in = Image(fname_in[0])
-        im_out = [change_orientation_nd(im_in, arguments["-setorient"]).save(fname_out)]
+        im_out = [msct_image.change_orientation(im_in, arguments["-setorient"]).save(fname_out)]
 
     elif "-setorient-data" in arguments:
         im_in = Image(fname_in[0])
-        im_out = [change_orientation_nd(im_in, arguments["-setorient-data"], inverse=True).save(fname_out)]
+        im_out = [msct_image.change_orientation(im_in, arguments["-setorient-data"], inverse=True).save(fname_out)]
 
     elif "-split" in arguments:
         dim = arguments["-split"]
@@ -548,50 +548,6 @@ def multicomponent_merge(fname_list):
     im_out.hdr.set_intent('vector', (), '')
     im_out.absolutepath = sct.add_suffix(im_out.absolutepath, '_multicomponent')
     return im_out
-
-
-def change_orientation_nd(src, orientation, dst=None, inverse=False):
-    """
-    """
-    warnings.warn("Deprecated, this function has no value over msct_image.change_orientation()")
-
-    nx, ny, nz, nt, px, py, pz, pt = src.dim
-
-    if dst is None:
-        dst = msct_image.empty_like(src)
-        dst._path = None
-
-    if (nz == 1 or nt == 1) and len(src.data.shape) < 5:
-        dst = msct_image.change_orientation(src, orientation, dst, inverse=inverse)
-    else:
-        # 4D data: split along T dimension
-        # or 5D data: split along 5th dimension
-
-        if len(src.data.shape) == 5 and src.data.shape[-1] not in [0, 1]:
-            # 5D data
-            im_split_list = multicomponent_split(src)
-            dim = 5
-        else:
-            # 4D data
-            im_split_list = split_data(src, 3)
-            dim = 4
-
-        for im_s in im_split_list:
-            im_s.save()
-
-        if 1:
-            im_changed_ori_list = []
-            for im_s in im_split_list:
-                im_set = msct_image.change_orientation(im_s, orientation, inverse=inverse)
-                im_changed_ori_list.append(im_set)
-
-            if dim == 4:
-                dst.data = concat_data(im_changed_ori_list, 3).data
-            elif dim == 5:
-                fname_changed_ori_list = [im_ch_ori.absolutepath for im_ch_ori in im_changed_ori_list]
-                dst.data = multicomponent_merge(fname_changed_ori_list).data
-
-    return dst
 
 
 def visualize_warp(fname_warp, fname_grid=None, step=3, rm_tmp=True):

--- a/scripts/sct_invert_image.py
+++ b/scripts/sct_invert_image.py
@@ -14,7 +14,7 @@
 
 import sys
 from msct_parser import Parser
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 import sct_utils as sct
 
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -22,8 +22,8 @@ import numpy as np
 from scipy import ndimage
 
 from msct_parser import Parser
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_types import CoordinateValue
 import sct_utils as sct
 
@@ -685,7 +685,7 @@ class ProcessLabels(object):
 
         params = base.AnatomicalParams()
         params.vertebraes = labels
-        params.input_file_name = self.image_input.file_name
+        params.input_file_name = self.image_input.absolutepath
         params.output_file_name = self.fname_output
         params.subtitle = self.msg
         output = msct_image.zeros_like(self.image_input)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -23,7 +23,8 @@ import scipy.ndimage.measurements
 
 from sct_maths import mutual_information
 from msct_parser import Parser
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 import sct_utils as sct
 from spinalcordtoolbox.metadata import get_file_label
 

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -14,7 +14,7 @@ import sys
 
 import numpy as np
 from msct_parser import Parser
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from sct_utils import printv, extract_fname
 import sct_utils as sct
 

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -22,7 +22,7 @@ import numpy as np
 from msct_parser import Parser
 import sct_utils as sct
 import sct_apply_transfo
-import msct_image
+import spinalcordtoolbox.image as msct_image
 import sct_maths
 
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -23,8 +23,8 @@ import pandas as pd
 
 import sct_utils as sct
 from sct_straighten_spinalcord import smooth_centerline
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 import msct_shape
 from msct_types import Centerline
@@ -1151,7 +1151,7 @@ def ellipse_dim(a):
 #=======================================================================================================================
 def edge_detection(f):
 
-    img = Image.open(f)  # grayscale
+    img = Image(f)  # grayscale
     imgdata = np.array(img, dtype = float)
     G = imgdata
     #G = ndi.filters.gaussian_filter(imgdata, sigma)

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -18,8 +18,8 @@ import os, sys
 import numpy as np
 from scipy import ndimage as ndi
 
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 import sct_image
 import sct_utils as sct
 from msct_parser import Parser
@@ -502,7 +502,6 @@ def propseg(img_input, options_dict):
         cmd += ["-alpha", str(arguments["-alpha"])]
 
     # check if input image is in 3D. Otherwise itk image reader will cut the 4D image in 3D volumes and only take the first one.
-    from msct_image import Image
     image_input = Image(fname_data)
     nx, ny, nz, nt, px, py, pz, pt = image_input.dim
     if nt > 1:

--- a/scripts/sct_register_graymatter.py
+++ b/scripts/sct_register_graymatter.py
@@ -17,7 +17,7 @@ import sys, io, os, shutil
 path_sct = os.environ.get("SCT_DIR", os.path.dirname(os.path.dirname(__file__)))
 
 from msct_parser import Parser
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from sct_convert import convert
 import sct_utils as sct
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -36,8 +36,8 @@ import sys, io, os, time, shutil
 
 import sct_utils as sct
 from msct_parser import Parser
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 
 
 def get_parser(paramreg=None):

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -25,8 +25,8 @@ from spinalcordtoolbox.metadata import get_file_label
 from sct_utils import add_suffix
 from sct_register_multimodal import Paramreg, ParamregMultiStep, register
 from msct_parser import Parser
-import msct_image
-from msct_image import Image, find_zmin_zmax
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from sct_straighten_spinalcord import smooth_centerline
 
 # get path of the toolbox
@@ -479,7 +479,7 @@ def main(args=None):
         # binarize
         im_new.data = im.data > 0.5
         # find min-max of anat2template (for subsequent cropping)
-        zmin_template, zmax_template = find_zmin_zmax(im_new, threshold=0.5)
+        zmin_template, zmax_template = msct_image.find_zmin_zmax(im_new, threshold=0.5)
         # save binarized segmentation
         im_new.save(add_suffix(ftmp_seg, '_bin')) # unused?
         # crop template in z-direction (for faster processing)

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -363,12 +363,12 @@ def main(args=None):
             # if we do not align the vertebral levels, we crop the segmentation from top to bottom
             im_seg_rpi = Image(ftmp_seg_)
             bottom = 0
-            for data in msct_image.Slicer(im_seg_rpi, "IS"):
+            for data in msct_image.SlicerOneAxis(im_seg_rpi, "IS"):
                 if (data != 0).any():
                     break
                 bottom += 1
             top = im_seg_rpi.data.shape[2]
-            for data in msct_image.Slicer(im_seg_rpi, "SI"):
+            for data in msct_image.SlicerOneAxis(im_seg_rpi, "SI"):
                 if (data != 0).any():
                     break
                 top -= 1

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -56,8 +56,8 @@ import sct_process_segmentation
 import sct_register_multimodal
 from msct_gmseg_utils import (apply_transfo, average_gm_wm, binarize,
                               normalize_slice, pre_processing, register_data)
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_multiatlas_seg import Model, Param, ParamData, ParamModel
 from msct_parser import Parser
 import sct_utils as sct

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -20,7 +20,7 @@ import sys, io, os, getopt, shutil, time
 import numpy as np
 
 import sct_utils as sct
-import msct_image
+import spinalcordtoolbox.image as msct_image
 from sct_convert import convert
 from msct_parser import Parser
 
@@ -103,7 +103,7 @@ def main(args=None):
     sct.printv('  Verbose ........................... ' + str(verbose))
 
     # Check that input is 3D:
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
     nx, ny, nz, nt, px, py, pz, pt = Image(fname_anat).dim
     dim = 4  # by default, will be adjusted later
     if nt == 1:

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -19,8 +19,8 @@ from nibabel import Nifti1Image, save
 from scipy import ndimage
 import tqdm
 
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from msct_parser import Parser
 from msct_types import Centerline
 from sct_apply_transfo import Transform

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -805,7 +805,7 @@ def check_if_3d(fname):
     :param fname:
     :return: True or False
     """
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
     nx, ny, nz, nt, px, py, pz, pt = Image(fname).dim
     if not nt == 1:
         printv('\nERROR: ' + fname + ' is not a 3D volume. Exit program.\n', 1, 'error')
@@ -973,7 +973,7 @@ def check_if_installed(cmd, name_software):
 #=======================================================================================================================
 # check if two images are in the same space and same orientation
 def check_if_same_space(fname_1, fname_2):
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
     from numpy import min, nonzero, all, around
     from numpy import abs as np_abs
     from numpy import log10 as np_log10

--- a/scripts/sct_viewer.py
+++ b/scripts/sct_viewer.py
@@ -13,7 +13,7 @@
 # If you are interested into selecting manually some points in an image, you can use the following code.
 
 # from sct_viewer import ClickViewer
-# from msct_image import Image
+# from spinalcordtoolbox.image import Image
 #
 # im_input = Image('my_image.nii.gz')
 #
@@ -51,7 +51,7 @@ from matplotlib.widgets import Slider, Button, RadioButtons
 
 
 from msct_parser import Parser
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 from msct_types import *
 import sct_utils as sct
 

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -16,7 +16,7 @@ import sys, io, os, time
 
 import spinalcordtoolbox.metadata
 
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 from msct_parser import Parser
 import sct_utils as sct

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -6,8 +6,8 @@ import numpy as np
 
 import sct_utils as sct
 import sct_image
-import msct_image
-from msct_image import Image
+from .. import image as msct_image
+from ..image import Image
 
 
 

--- a/spinalcordtoolbox/gui/cli.py
+++ b/spinalcordtoolbox/gui/cli.py
@@ -8,7 +8,8 @@
 import os
 import sys
 
-from scripts.msct_image import Image
+from ..image import Image
+
 from scripts.msct_parser import Parser
 from scripts.sct_utils import printv
 from spinalcordtoolbox.gui import base

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -17,182 +17,10 @@ import nibabel.orientations
 import numpy as np
 from scipy.ndimage import map_coordinates
 
+import transforms3d.affines as affines
+
 from msct_types import Coordinate
 import sct_utils as sct
-
-
-def striu2mat(striu):
-    """
-    Construct shear matrix from upper triangular vector
-    Parameters
-    ----------
-    striu : array, shape (N,)
-       vector giving triangle above diagonal of shear matrix.
-    Returns
-    -------
-    SM : array, shape (N, N)
-       shear matrix
-    Notes
-    -----
-    Shear lengths are triangular numbers.
-    See http://en.wikipedia.org/wiki/Triangular_number
-    This function has been taken from https://github.com/matthew-brett/transforms3d/blob/39a1b01398f1d932630f722a540a5020c6c07422/transforms3d/affines.py
-    """
-    # Caching dictionary for common shear Ns, indices
-    _shearers = {}
-    for n in range(1, 11):
-        x = (n ** 2 + n) / 2.0
-        i = n + 1
-        _shearers[x] = (i, np.triu(np.ones((i, i)), 1).astype(bool))
-
-    n = len(striu)
-    # cached case
-    if n in _shearers:
-        N, inds = _shearers[n]
-    else:  # General case
-        N = ((-1 + math.sqrt(8 * n + 1)) / 2.0) + 1  # n+1 th root
-        if N != math.floor(N):
-            raise ValueError('%d is a strange number of shear elements' %
-                             n)
-        inds = np.triu(np.ones((N, N)), 1).astype(bool)
-    M = np.eye(N)
-    M[inds] = striu
-    return M
-
-
-def compose(T, R, Z, S=None):
-    """
-    Compose translations, rotations, zooms, [shears]  to affine
-    Parameters
-    ----------
-    T : array-like shape (N,)
-        Translations, where N is usually 3 (3D case)
-    R : array-like shape (N,N)
-        Rotation matrix where N is usually 3 (3D case)
-    Z : array-like shape (N,)
-        Zooms, where N is usually 3 (3D case)
-    S : array-like, shape (P,), optional
-       Shear vector, such that shears fill upper triangle above
-       diagonal to form shear matrix.  P is the (N-2)th Triangular
-       number, which happens to be 3 for a 4x4 affine (3D case)
-    Returns
-    -------
-    A : array, shape (N+1, N+1)
-        Affine transformation matrix where N usually == 3
-        (3D case)
-    This function has been taken from https://github.com/matthew-brett/transforms3d/blob/39a1b01398f1d932630f722a540a5020c6c07422/transforms3d/affines.py
-    """
-    n = len(T)
-    R = np.asarray(R)
-    if R.shape != (n, n):
-        raise ValueError('Expecting shape (%d,%d) for rotations' % (n, n))
-    A = np.eye(n + 1)
-    if S is not None:
-        Smat = striu2mat(S)
-        ZS = np.dot(np.diag(Z), Smat)
-    else:
-        ZS = np.diag(Z)
-    A[:n, :n] = np.dot(R, ZS)
-    A[:n, n] = T[:]
-    return A
-
-
-def decompose_affine_transform(A44):
-    """
-    Decompose 4x4 homogenous affine matrix into parts.
-    The parts are translations, rotations, zooms, shears.
-    This is the same as :func:`decompose` but specialized for 4x4 affines.
-    Decomposes `A44` into ``T, R, Z, S``, such that::
-       Smat = np.array([[1, S[0], S[1]],
-                        [0,    1, S[2]],
-                        [0,    0,    1]])
-       RZS = np.dot(R, np.dot(np.diag(Z), Smat))
-       A44 = np.eye(4)
-       A44[:3,:3] = RZS
-       A44[:-1,-1] = T
-    The order of transformations is therefore shears, followed by
-    zooms, followed by rotations, followed by translations.
-    This routine only works for shape (4,4) matrices
-    Parameters
-    ----------
-    A44 : array shape (4,4)
-    Returns
-    -------
-    T : array, shape (3,)
-       Translation vector
-    R : array shape (3,3)
-        rotation matrix
-    Z : array, shape (3,)
-       Zoom vector.  May have one negative zoom to prevent need for negative
-       determinant R matrix above
-    S : array, shape (3,)
-       Shear vector, such that shears fill upper triangle above
-       diagonal to form shear matrix (type ``striu``).
-    Notes
-    -----
-    The implementation inspired by:
-    *Decomposing a matrix into simple transformations* by Spencer
-    W. Thomas, pp 320-323 in *Graphics Gems II*, James Arvo (editor),
-    Academic Press, 1991, ISBN: 0120644819.
-    The upper left 3x3 of the affine consists of a matrix we'll call
-    RZS::
-       RZS = R * Z *S
-    where R is a rotation matrix, Z is a diagonal matrix of scalings::
-       Z = diag([sx, sy, sz])
-    and S is a shear matrix of form::
-       S = [[1, sxy, sxz],
-            [0,   1, syz],
-            [0,   0,   1]])
-    Running all this through sympy (see 'derivations' folder) gives
-    ``RZS`` as ::
-       [R00*sx, R01*sy + R00*sx*sxy, R02*sz + R00*sx*sxz + R01*sy*syz]
-       [R10*sx, R11*sy + R10*sx*sxy, R12*sz + R10*sx*sxz + R11*sy*syz]
-       [R20*sx, R21*sy + R20*sx*sxy, R22*sz + R20*sx*sxz + R21*sy*syz]
-    ``R`` is defined as being a rotation matrix, so the dot products between
-    the columns of ``R`` are zero, and the norm of each column is 1.  Thus
-    the dot product::
-       R[:,0].T * RZS[:,1]
-    that results in::
-       [R00*R01*sy + R10*R11*sy + R20*R21*sy + sx*sxy*R00**2 + sx*sxy*R10**2 + sx*sxy*R20**2]
-    simplifies to ``sy*0 + sx*sxy*1`` == ``sx*sxy``.  Therefore::
-       R[:,1] * sy = RZS[:,1] - R[:,0] * (R[:,0].T * RZS[:,1])
-    allowing us to get ``sy`` with the norm, and sxy with ``R[:,0].T *
-    RZS[:,1] / sx``.
-    Similarly ``R[:,0].T * RZS[:,2]`` simplifies to ``sx*sxz``, and
-    ``R[:,1].T * RZS[:,2]`` to ``sy*syz`` giving us the remaining
-    unknowns.
-    This function has been taken from https://github.com/matthew-brett/transforms3d/blob/39a1b01398f1d932630f722a540a5020c6c07422/transforms3d/affines.py
-    """
-    A44 = np.asarray(A44)
-    T = A44[:-1, -1]
-    RZS = A44[:-1, :-1]
-    # compute scales and shears
-    M0, M1, M2 = np.array(RZS).T
-    # extract x scale and normalize
-    sx = math.sqrt(np.sum(M0**2))
-    M0 /= sx
-    # orthogonalize M1 with respect to M0
-    sx_sxy = np.dot(M0, M1)
-    M1 -= sx_sxy * M0
-    # extract y scale and normalize
-    sy = math.sqrt(np.sum(M1**2))
-    M1 /= sy
-    sxy = sx_sxy / sx
-    # orthogonalize M2 with respect to M0 and M1
-    sx_sxz = np.dot(M0, M2)
-    sy_syz = np.dot(M1, M2)
-    M2 -= (sx_sxz * M0 + sy_syz * M1)
-    # extract z scale and normalize
-    sz = math.sqrt(np.sum(M2**2))
-    M2 /= sz
-    sxz = sx_sxz / sx
-    syz = sy_syz / sy
-    # Reconstruct rotation matrix, ensure positive determinant
-    Rmat = np.array([M0, M1, M2]).T
-    if np.linalg.det(Rmat) < 0:
-        sx *= -1
-        Rmat[:, 0] *= -1
-    return T, Rmat, np.array([sx, sy, sz]), np.array([sxy, sxz, syz])
 
 
 def _get_permutations(im_src_orientation, im_dst_orientation):
@@ -773,23 +601,23 @@ class Image(object):
         if mode == 'affine':
             transform = np.matmul(np.linalg.inv(aff_im_self), aff_im_ref)
         else:
-            T_self, R_self, Sc_self, Sh_self = decompose_affine_transform(aff_im_self)
-            T_ref, R_ref, Sc_ref, Sh_ref = decompose_affine_transform(aff_im_ref)
+            T_self, R_self, Sc_self, Sh_self = affines.decompose44(aff_im_self)
+            T_ref, R_ref, Sc_ref, Sh_ref = affines.decompose44(aff_im_ref)
             if mode == 'translation':
                 T_transform = T_ref - T_self
                 R_transform = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
                 Sc_transform = np.array([1.0, 1.0, 1.0])
-                transform = compose(T_transform, R_transform, Sc_transform)
+                transform = affines.compose(T_transform, R_transform, Sc_transform)
             elif mode == 'rigid':
                 T_transform = T_ref - T_self
                 R_transform = np.matmul(np.linalg.inv(R_self), R_ref)
                 Sc_transform = np.array([1.0, 1.0, 1.0])
-                transform = compose(T_transform, R_transform, Sc_transform)
+                transform = affines.compose(T_transform, R_transform, Sc_transform)
             elif mode == 'rigid_scaling':
                 T_transform = T_ref - T_self
                 R_transform = np.matmul(np.linalg.inv(R_self), R_ref)
                 Sc_transform = Sc_ref / Sc_self
-                transform = compose(T_transform, R_transform, Sc_transform)
+                transform = affines.compose(T_transform, R_transform, Sc_transform)
             else:
                 transform = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
         return transform
@@ -800,23 +628,23 @@ class Image(object):
         if mode == 'affine':
             transform = np.matmul(np.linalg.inv(aff_im_ref), aff_im_self)
         else:
-            T_self, R_self, Sc_self, Sh_self = decompose_affine_transform(aff_im_self)
-            T_ref, R_ref, Sc_ref, Sh_ref = decompose_affine_transform(aff_im_ref)
+            T_self, R_self, Sc_self, Sh_self = affines.decompose44(aff_im_self)
+            T_ref, R_ref, Sc_ref, Sh_ref = affines.decompose44(aff_im_ref)
             if mode == 'translation':
                 T_transform = T_self - T_ref
                 R_transform = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
                 Sc_transform = np.array([1.0, 1.0, 1.0])
-                transform = compose(T_transform, R_transform, Sc_transform)
+                transform = affines.compose(T_transform, R_transform, Sc_transform)
             elif mode == 'rigid':
                 T_transform = T_self - T_ref
                 R_transform = np.matmul(np.linalg.inv(R_ref), R_self)
                 Sc_transform = np.array([1.0, 1.0, 1.0])
-                transform = compose(T_transform, R_transform, Sc_transform)
+                transform = affines.compose(T_transform, R_transform, Sc_transform)
             elif mode == 'rigid_scaling':
                 T_transform = T_self - T_ref
                 R_transform = np.matmul(np.linalg.inv(R_ref), R_self)
                 Sc_transform = Sc_self / Sc_ref
-                transform = compose(T_transform, R_transform, Sc_transform)
+                transform = affines.compose(T_transform, R_transform, Sc_transform)
             else:
                 transform = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
 
@@ -829,7 +657,7 @@ class Image(object):
             X, Y and Z axes of the image
         """
         direction_matrix = self.header.get_best_affine()
-        T_self, R_self, Sc_self, Sh_self = decompose_affine_transform(direction_matrix)
+        T_self, R_self, Sc_self, Sh_self = affines.decompose44(direction_matrix)
         return R_self[0:3, 0], R_self[0:3, 1], R_self[0:3, 2]
 
     def interpolate_from_image(self, im_ref, fname_output=None, interpolation_mode=1, border='constant'):

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python
-#############################################################################
+#########################################################################################
 #
-# Image class implementation
+# SCT Image API
 #
-#
-# ---------------------------------------------------------------------------
-# Copyright (c) 2015 Polytechnique Montreal <www.neuro.polymtl.ca>
-# Authors: Augustin Roux, Benjamin De Leener
-# Modified: 2015-02-20
+# ---------------------------------------------------------------------------------------
+# Copyright (c) 2018 Polytechnique Montreal <www.neuro.polymtl.ca>
 #
 # About the license: see the file LICENSE.TXT
-#############################################################################
+#########################################################################################
 
 import sys, io, os, math, itertools, warnings
 
@@ -411,12 +408,10 @@ class Image(object):
         elif isinstance(param, list):
             self.data = np.zeros(param)
             self.hdr = hdr
-            self.absolutepath = absolutepath
         # create a copy of im_ref
         elif isinstance(param, (np.ndarray, np.generic)):
             self.data = param
             self.hdr = hdr
-            self.absolutepath = absolutepath
         else:
             raise TypeError('Image constructor takes at least one argument.')
 
@@ -813,7 +808,7 @@ class Image(object):
         This function interpolates an image by following the grid of a reference image.
         Example of use:
 
-        from msct_image import Image
+        from spinalcordtoolbox.image import Image
         im_input = Image(fname_input)
         im_ref = Image(fname_ref)
         im_input.interpolate_from_image(im_ref, fname_output, interpolation_mode=1)
@@ -1016,7 +1011,7 @@ def change_shape(im_src, shape, im_dst=None):
         im_dst.data = im_src.data.reshape(shape, order="C")
     else:
         # image data may be a view
-        im_dst_data = im_src_data.copy().reshape(shape, order="F")
+        im_dst_data = im_src.data.copy().reshape(shape, order="F")
 
     pair = nibabel.nifti1.Nifti1Pair(im_dst.data, im_dst.hdr.get_best_affine(), im_dst.hdr)
     im_dst.hdr = pair.header
@@ -1131,7 +1126,7 @@ def change_type(im_src, dtype, im_dst=None):
         # check if voxel values are real or integer
         isInteger = True
         if dtype == 'minimize':
-            for vox in self.data.flatten():
+            for vox in im_src.data.flatten():
                 if int(vox) != vox:
                     isInteger = False
                     break

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -318,9 +318,9 @@ class Image(object):
         self.hdr = self.im_file.get_header()
         self.absolutepath = path
         if path != self.absolutepath:
-            sct.log.info("Loaded %s (%s) orientation %s shape %s", path, self.absolutepath, self.orientation, self.data.shape)
+            sct.log.debug("Loaded %s (%s) orientation %s shape %s", path, self.absolutepath, self.orientation, self.data.shape)
         else:
-            sct.log.info("Loaded %s orientation %s shape %s", path, self.orientation, self.data.shape)
+            sct.log.debug("Loaded %s orientation %s shape %s", path, self.orientation, self.data.shape)
 
 
     def change_shape(self, shape, generate_path=False):
@@ -446,10 +446,10 @@ class Image(object):
 
         # save file
         if os.path.isabs(path):
-            sct.log.info("Saving image to %s orientation %s shape %s",
+            sct.log.debug("Saving image to %s orientation %s shape %s",
              path, self.orientation, data.shape)
         else:
-            sct.log.info("Saving image to %s (%s) orientation %s shape %s",
+            sct.log.debug("Saving image to %s (%s) orientation %s shape %s",
              path, os.path.abspath(path), self.orientation, data.shape)
 
         nibabel.save(img, path)

--- a/spinalcordtoolbox/mtsat/mtsat.py
+++ b/spinalcordtoolbox/mtsat/mtsat.py
@@ -7,9 +7,10 @@
 
 import os
 import sct_utils as sct
-from msct_image import Image
 import numpy as np
 
+
+from ..image import Image
 
 def compute_mtsat(nii_mt, nii_pd, nii_t1,
                   tr_mt, tr_pd, tr_t1,

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -8,7 +8,7 @@ import math
 import numpy as np
 from scipy import ndimage
 
-import msct_image
+from .. import image as msct_image
 
 logger = logging.getLogger("sct.{}".format(__file__))
 

--- a/testing/test_sct_analyze_texture.py
+++ b/testing/test_sct_analyze_texture.py
@@ -12,7 +12,7 @@
 
 from pandas import DataFrame
 import numpy as np
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 import sct_utils as sct
 
 

--- a/testing/test_sct_apply_transfo.py
+++ b/testing/test_sct_apply_transfo.py
@@ -15,7 +15,7 @@
 import os
 import numpy as np
 import sct_utils as sct
-import msct_image
+import spinalcordtoolbox.image as msct_image
 
 def init(param_test):
     """

--- a/testing/test_sct_crop_image.py
+++ b/testing/test_sct_crop_image.py
@@ -28,7 +28,7 @@ def test_integrity(param_test):
     """
     Test integrity of function
     """
-    from msct_image import Image
+    from spinalcordtoolbox.image import Image
     # check if cropping was correct
     nx, ny, nz, nt, px, py, pz, pt = Image(os.path.join(param_test.path_output, 'cropped_normal.nii.gz')).dim
     if (ny != 41):

--- a/testing/test_sct_deepseg_gm.py
+++ b/testing/test_sct_deepseg_gm.py
@@ -12,7 +12,7 @@
 
 import os
 import sct_utils as sct
-from msct_image import Image, compute_dice
+from spinalcordtoolbox.image import Image, compute_dice
 
 
 def init(param_test):

--- a/testing/test_sct_deepseg_sc.py
+++ b/testing/test_sct_deepseg_sc.py
@@ -13,7 +13,7 @@
 import sys, io, os
 
 import sct_utils as sct
-from msct_image import Image, compute_dice
+from spinalcordtoolbox.image import Image, compute_dice
 from pandas import DataFrame
 
 

--- a/testing/test_sct_detect_pmj.py
+++ b/testing/test_sct_detect_pmj.py
@@ -15,7 +15,7 @@ import math, shutil, os
 import numpy as np
 
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 def init(param_test):
     """

--- a/testing/test_sct_dice_coefficient.py
+++ b/testing/test_sct_dice_coefficient.py
@@ -13,7 +13,7 @@
 import sys, io, os
 
 import sct_utils as sct
-from msct_image import Image, compute_dice
+from spinalcordtoolbox.image import Image, compute_dice
 
 
 def init(param_test):

--- a/testing/test_sct_dmri_separate_b0_and_dwi.py
+++ b/testing/test_sct_dmri_separate_b0_and_dwi.py
@@ -14,7 +14,7 @@ import sys, io, os
 
 import numpy as np
 
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 
 def init(param_test):

--- a/testing/test_sct_get_centerline.py
+++ b/testing/test_sct_get_centerline.py
@@ -16,8 +16,8 @@ import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 
 import sct_utils as sct
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 from pandas import DataFrame
 
 

--- a/testing/test_sct_image.py
+++ b/testing/test_sct_image.py
@@ -14,7 +14,7 @@
 import sys, io, os
 
 import sct_utils as sct
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 import numpy as np
 
 

--- a/testing/test_sct_label_vertebrae.py
+++ b/testing/test_sct_label_vertebrae.py
@@ -155,7 +155,7 @@ def test_integrity(param_test):
 #             label_results = ProcessLabels(os.path.join(path_output, contrast + '_seg_labeled_center.nii.gz'))
 #             list_label_results = label_results.image_input.getNonZeroCoordinates(sorting='value')
 #             # get dimension
-#             # from msct_image import Image
+#             # from spinalcordtoolbox.image import Image
 #             # img = Image(os.path.join(path_output, contrast+'_seg_labeled.nii.gz'))
 #             nx, ny, nz, nt, px, py, pz, pt = label_results.image_input.dim
 #         except:

--- a/testing/test_sct_propseg.py
+++ b/testing/test_sct_propseg.py
@@ -13,7 +13,7 @@
 import sys, io, os
 
 import sct_utils as sct
-from msct_image import Image, compute_dice
+from spinalcordtoolbox.image import Image, compute_dice
 
 
 def init(param_test):

--- a/testing/test_sct_register_graymatter.py
+++ b/testing/test_sct_register_graymatter.py
@@ -51,7 +51,7 @@ def test_integrity(param_test):
 # import time
 # from pandas import DataFrame
 # import sct_register_graymatter
-# from msct_image import Image
+# from spinalcordtoolbox.image import Image
 # import sct_utils as sct
 # from numpy import sum, mean
 #

--- a/testing/test_sct_register_multimodal.py
+++ b/testing/test_sct_register_multimodal.py
@@ -12,7 +12,7 @@
 
 import os
 
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 import numpy as np
 
 

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -13,8 +13,8 @@
 import os
 
 from pandas import DataFrame
-import msct_image
-from msct_image import Image
+import spinalcordtoolbox.image as msct_image
+from spinalcordtoolbox.image import Image
 import sct_apply_transfo
 
 

--- a/testing/test_sct_resample.py
+++ b/testing/test_sct_resample.py
@@ -13,7 +13,7 @@
 
 import sys, io, os
 
-from msct_image import Image
+from spinalcordtoolbox.image import Image
 
 
 def init(param_test):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2,7 +2,7 @@ import logging
 import os
 import unittest
 
-from scripts import msct_image
+import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.gui import base, centerline, sagittal
 from spinalcordtoolbox.gui.base import InvalidActionWarning
 

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -11,7 +11,7 @@ import nibabel
 import nibabel.orientations
 
 import sct_utils as sct
-import msct_image
+import spinalcordtoolbox.image as msct_image
 import sct_image
 
 

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -15,19 +15,6 @@ import spinalcordtoolbox.image as msct_image
 import sct_image
 
 
-def old_change_orientation(im_src, orientation, im_dst=None):
-    im_src.save("a.nii")
-    sct.run(["isct_orientation3d", "-i", "a.nii", "-orientation", orientation, "-o", "b.nii"])
-    im_dst2 = msct_image.Image("b.nii")
-    if im_dst is None:
-        return im_dst2
-    else:
-        im_dst.data = im_dst2.data
-        im_dst.header = im_dst2.header
-        return im_dst
-
-#msct_image.change_orientation = old_change_orientation
-
 @pytest.fixture(scope="session")
 def image_paths():
     ret = []

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -264,25 +264,22 @@ def fake_3dimage_sct2():
 
 
 def test_slicer(fake_3dimage_sct, fake_3dimage_sct2):
-    im3d = fake_3dimage_sct
-    slicer = msct_image.Slicer(im3d, "IS")
-    assert slicer.direction == +1
-    assert slicer.nb_slices == 9
+    im3d = fake_3dimage_sct.copy()
+    slicer = msct_image.Slicer(im3d, "LPI")
     if 0:
         for im2d in slicer:
             print(im2d)
-
+    assert slicer._nb_slices == 9
     assert 100 < np.mean(slicer[0]) < 200
 
-    slicer = msct_image.Slicer(im3d, "SI")
-    assert slicer.direction == -1
-    assert slicer.nb_slices == 9
 
+    slicer = msct_image.Slicer(im3d, "LPS")
     if 0:
         for im2d in slicer:
             print(im2d)
-
+    assert slicer._nb_slices == 9
     assert 900 < np.mean(slicer[0]) < 1000
+
 
     with pytest.raises(ValueError):
         slicer = msct_image.Slicer(im3d, "LI")
@@ -298,16 +295,40 @@ def test_slicer(fake_3dimage_sct, fake_3dimage_sct2):
 
     im3d2 = fake_3dimage_sct.copy()
     im3d2.data += 1000
-    slicer = msct_image.Slicer((im3d, im3d2), "IS")
+    slicer = msct_image.SlicerMany((im3d, im3d2), msct_image.Slicer, orientation="LPI")
     for idx_slice, (im2d_a, im2d_b) in enumerate(slicer):
         assert np.all(im2d_b == im2d_a + 1000)
 
-    im3d2 = fake_3dimage_sct2
     with pytest.raises(ValueError):
-        slicer = msct_image.Slicer((im3d, im3d2), "IS")
+        slicer = msct_image.SlicerMany((im3d, im3d2), msct_image.Slicer, orientation="IS")
+
+    im3d2 = fake_3dimage_sct2.copy()
+    with pytest.raises(ValueError):
+        slicer = msct_image.SlicerMany((im3d, im3d2), msct_image.Slicer, orientation="LPI")
 
     with pytest.raises(ValueError):
         slicer = msct_image.Slicer(1)
+
+    im3d = fake_3dimage_sct.copy()
+
+    d = im3d.data.copy()
+
+    slicer = msct_image.Slicer(im3d, "RPI")
+    if 0:
+        for im2d in slicer:
+            print(im2d)
+    slicer = msct_image.Slicer(im3d, "ASR")
+    if 0:
+        for im2d in slicer:
+            print(im2d)
+
+    msct_image.Slicer(im3d, "ASR")[0][0,0] = -1
+
+    for idx_slice, (slice2d_new, slice2d_old) in enumerate(msct_image.SlicerMany((im3d, fake_3dimage_sct.copy()), msct_image.Slicer, orientation="ASR")):
+        if idx_slice == 0:
+            assert slice2d_new[0,0] == -1
+            slice2d_new[0,0] = slice2d_old[0,0]
+        assert (slice2d_new == slice2d_old).all()
 
 
 def test_nibabel(fake_3dimage):

--- a/unit_testing/test_transfo.py
+++ b/unit_testing/test_transfo.py
@@ -11,7 +11,7 @@ import nibabel
 import nibabel.orientations
 
 import sct_utils as sct
-import msct_image
+import spinalcordtoolbox.image as msct_image
 import sct_image
 import sct_apply_transfo
 

--- a/unit_testing/test_transfo.py
+++ b/unit_testing/test_transfo.py
@@ -112,7 +112,7 @@ def test_transfo_null():
     print(" Check that the destination is identical to the source since the field was null")
     dat_src = img_src.data
     dat_dst = np.array(img_dst.data)
-    for idx_slice, (slice_src, slice_dst) in enumerate(msct_image.Slicer((img_src, img_dst))):
+    for idx_slice, (slice_src, slice_dst) in enumerate(msct_image.SlicerMany((img_src, img_dst), msct_image.Slicer)):
         slice_src = np.array(slice_src)
         slice_dst = np.array(slice_dst)
         print(slice_src)


### PR DESCRIPTION
This PR brings:
- move `msct_image` to `spinalcordtoolbox.image`
- change some Image methods to be free functions (reducing `Image` API)
- remove some dead code
- update dependent code (inside scripts, import of `spinalcordtoolbox.image` is done  `as msct_image`)
- fixup errors in second pass found during tests/reviews (fixes #1994)
