### PR TITLE
sct_dmri_compute_dti: Output tensor eigenvectors

### DIFF
--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -173,8 +173,12 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     nii.save('float32')
     # if evecs:
     from dipy.reconst import dti
-    data_evecs =
-
+    data_evecs = tenfit.evecs
+    # output 1st (V1), 2nd (V2) and 3rd (V3) eigenvectors as 4d data
+    for idim in range(3):
+        nii.data = data_evecs[:, :, :, :, idim]
+        nii.setFileName(prefix + 'V' + str(idim+1) + '.nii.gz')
+        nii.save('float32')
 
     return True
 

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -11,10 +11,13 @@
 #########################################################################################
 
 import sys
-
 from msct_parser import Parser
 import sct_utils as sct
 import nibabel as nib
+from dipy.io import read_bvals_bvecs
+from dipy.core.gradients import gradient_table
+import dipy.reconst.dti as dti
+
 
 class Param:
     def __init__(self):
@@ -123,9 +126,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     sct.printv('data.shape (%d, %d, %d, %d)' % data.shape)
 
     # open bvecs/bvals
-    from dipy.io import read_bvals_bvecs
     bvals, bvecs = read_bvals_bvecs(fname_bvals, fname_bvecs)
-    from dipy.core.gradients import gradient_table
     gtab = gradient_table(bvals, bvecs)
 
     # mask and crop the data. This is a quick way to avoid calculating Tensors on the background of the image.
@@ -137,7 +138,6 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
 
     # fit tensor model
     sct.printv('Computing tensor using "' + method + '" method...', param.verbose)
-    import dipy.reconst.dti as dti
     if method == 'standard':
         tenmodel = dti.TensorModel(gtab)
         if file_mask == '':

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -116,7 +116,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     :param evecs: bool: output diffusion tensor eigenvectors
     :return: True/False
     """
-    # Open file.
+    # Open file
     from msct_image import Image
     nii = Image(fname_in)
     data = nii.data
@@ -171,14 +171,13 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     nii.data = tenfit.ad
     nii.setFileName(prefix + 'AD.nii.gz')
     nii.save('float32')
-    # if evecs:
-    from dipy.reconst import dti
-    data_evecs = tenfit.evecs
-    # output 1st (V1), 2nd (V2) and 3rd (V3) eigenvectors as 4d data
-    for idim in range(3):
-        nii.data = data_evecs[:, :, :, :, idim]
-        nii.setFileName(prefix + 'V' + str(idim+1) + '.nii.gz')
-        nii.save('float32')
+    if evecs:
+        data_evecs = tenfit.evecs
+        # output 1st (V1), 2nd (V2) and 3rd (V3) eigenvectors as 4d data
+        for idim in range(3):
+            nii.data = data_evecs[:, :, :, :, idim]
+            nii.setFileName(prefix + 'V' + str(idim+1) + '.nii.gz')
+            nii.save('float32')
 
     return True
 

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -50,6 +50,12 @@ def get_parser():
                       mandatory=False,
                       default_value='standard',
                       example=['standard', 'restore'])
+    parser.add_option(name="-evecs",
+                      type_value="multiple_choice",
+                      description="""To output tensor eigenvectors, set to 1.""",
+                      mandatory=False,
+                      default_value='0',
+                      example=['0', '1'])
     parser.add_option(name='-m',
                       type_value='file',
                       description='Mask used to compute DTI in for faster processing.',
@@ -87,18 +93,19 @@ def main(args = None):
     fname_bvecs = arguments['-bvec']
     prefix = arguments['-o']
     method = arguments['-method']
+    evecs = bool(arguments['-evecs'])
     if "-m" in arguments:
         file_mask = arguments['-m']
     param.verbose = int(arguments['-v'])
 
     # compute DTI
-    if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, file_mask):
+    if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):
         sct.printv('ERROR in compute_dti()', 1, 'error')
 
 
 # compute_dti
 # ==========================================================================================
-def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, file_mask):
+def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):
     """
     Compute DTI.
     :param fname_in: input 4d file.
@@ -106,6 +113,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, file_mask):
     :param bvecs: bvecs txt file
     :param prefix: output prefix. Example: "dti_"
     :param method: algo for computing dti
+    :param evecs: bool: output diffusion tensor eigenvectors
     :return: True/False
     """
     # Open file.
@@ -148,25 +156,25 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, file_mask):
     # Compute metrics
     sct.printv('Computing metrics...', param.verbose)
     # FA
-    from dipy.reconst.dti import fractional_anisotropy
-    nii.data = fractional_anisotropy(tenfit.evals)
+    nii.data = tenfit.fa
     nii.setFileName(prefix + 'FA.nii.gz')
     nii.save('float32')
     # MD
-    from dipy.reconst.dti import mean_diffusivity
-    nii.data = mean_diffusivity(tenfit.evals)
+    nii.data = tenfit.md
     nii.setFileName(prefix + 'MD.nii.gz')
     nii.save('float32')
     # RD
-    from dipy.reconst.dti import radial_diffusivity
-    nii.data = radial_diffusivity(tenfit.evals)
+    nii.data = tenfit.rd
     nii.setFileName(prefix + 'RD.nii.gz')
     nii.save('float32')
     # AD
-    from dipy.reconst.dti import axial_diffusivity
-    nii.data = axial_diffusivity(tenfit.evals)
+    nii.data = tenfit.ad
     nii.setFileName(prefix + 'AD.nii.gz')
     nii.save('float32')
+    # if evecs:
+    from dipy.reconst import dti
+    data_evecs =
+
 
     return True
 

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -26,13 +26,6 @@ class Param:
 def get_parser():
     param = Param()
 
-    # parser initialisation
-    parser = Parser(__file__)
-
-    # # initialize parameters
-    # param = Param()
-    # param_default = Param()
-
     # Initialize the parser
     parser = Parser(__file__)
     parser.usage.set_description('Compute Diffusion Tensor Images (DTI) using dipy.')
@@ -176,27 +169,6 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, file_mask):
     nii.save('float32')
 
     return True
-
-
-# # Get bvecs
-# # ==========================================================================================
-# def get_bvecs(fname):
-#     """
-#     Read bvecs file and output array
-#     :param fname: bvecs file
-#     :return: (nx3) array
-#     """
-#     text_file = open(fname, 'r')
-#     list_bvecs = text_file.readlines()
-#     text_file.close()
-#     # parse txt file and transform to array
-#     from numpy import array
-#     bvecs = array([[float(j.strip("\n")) for j in list_bvecs[i].split(" ")] for i in range(len(list_bvecs))])
-#     # make sure one dimension is "3"
-#     if not 3 in bvecs.shape:
-#         sct.printv('ERROR: bvecs should be text file with 3 lines (or columns).', 1, 'error')
-#     return bvecs
-#
 
 
 # START PROGRAM

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -162,7 +162,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     if evecs:
         # output 1st (V1), 2nd (V2) and 3rd (V3) eigenvectors as 4d data
         for idim in range(3):
-            nib.save(nib.Nifti1Image(tenfit.evecs[:, :, :, idim], nii.affine), prefix + 'V'+str(idim+1)+'.nii.gz')
+            nib.save(nib.Nifti1Image(tenfit.evecs[:, :, :, :, idim], nii.affine), prefix + 'V'+str(idim+1)+'.nii.gz')
 
     return True
 

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -13,7 +13,6 @@
 import sys
 from msct_parser import Parser
 import sct_utils as sct
-import nibabel as nib
 from dipy.io import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
 import dipy.reconst.dti as dti
@@ -119,10 +118,10 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     :param evecs: bool: output diffusion tensor eigenvectors
     :return: True/False
     """
-    # Open file
-    # from msct_image import Image
-    nii = nib.load(fname_in)
-    data = nii.get_data()
+    # Open file.
+    from msct_image import Image
+    nii = Image(fname_in)
+    data = nii.data
     sct.printv('data.shape (%d, %d, %d, %d)' % data.shape)
 
     # open bvecs/bvals
@@ -133,8 +132,8 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     if not file_mask == '':
         sct.printv('Open mask file...', param.verbose)
         # open mask file
-        nii_mask = nib.load(file_mask)
-        mask = nii_mask.get_data()
+        nii_mask = Image(file_mask)
+        mask = nii_mask.data
 
     # fit tensor model
     sct.printv('Computing tensor using "' + method + '" method...', param.verbose)
@@ -155,14 +154,29 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
 
     # Compute metrics
     sct.printv('Computing metrics...', param.verbose)
-    nib.save(nib.Nifti1Image(tenfit.fa, nii.affine), prefix + 'FA.nii.gz')
-    nib.save(nib.Nifti1Image(tenfit.md, nii.affine), prefix + 'MD.nii.gz')
-    nib.save(nib.Nifti1Image(tenfit.rd, nii.affine), prefix + 'RD.nii.gz')
-    nib.save(nib.Nifti1Image(tenfit.ad, nii.affine), prefix + 'AD.nii.gz')
+    # FA
+    nii.data = tenfit.fa
+    nii.setFileName(prefix + 'FA.nii.gz')
+    nii.save('float32')
+    # MD
+    nii.data = tenfit.md
+    nii.setFileName(prefix + 'MD.nii.gz')
+    nii.save('float32')
+    # RD
+    nii.data = tenfit.rd
+    nii.setFileName(prefix + 'RD.nii.gz')
+    nii.save('float32')
+    # AD
+    nii.data = tenfit.ad
+    nii.setFileName(prefix + 'AD.nii.gz')
+    nii.save('float32')
     if evecs:
+        data_evecs = tenfit.evecs
         # output 1st (V1), 2nd (V2) and 3rd (V3) eigenvectors as 4d data
         for idim in range(3):
-            nib.save(nib.Nifti1Image(tenfit.evecs[:, :, :, :, idim], nii.affine), prefix + 'V'+str(idim+1)+'.nii.gz')
+            nii.data = data_evecs[:, :, :, :, idim]
+            nii.setFileName(prefix + 'V' + str(idim+1) + '.nii.gz')
+            nii.save('float32')
 
     return True
 


### PR DESCRIPTION
This PR introduces a new feature output for `sct_dmri_compute_dti`, where users now have the possibility to output DTI eigenvectors, using a new boolean flag `-evecs`, which could be used e.g. for tractography applications.

Fixes #1974 