### PR TITLE
Minor contribution guideline & PR template fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 Hi, thank you for submitting a Pull Request, please take some time to consider the guidelines:
-https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#contributing-code
+https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#when-submitting-your-pull-request
 prior to documenting/reviewing the PR and deleting this blurb when about to submit the PR.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -410,20 +410,24 @@ for each new release.
 Filling-out the PR Body
 =======================
 
-- If the PR relates to open issue(s) don't forget to indicate that you are
-  fixing them, referring to their number in the PR introduction
-  (eg. “This PR fixes #1234”).
+- If the PR relates to open issue(s):
 
-  If the PR fixes several issues, please write it as follows: “*Fixes
-  #XXXX, Fixes #YYYY, Fixes #ZZZZ*”.
+  - Don't forget to indicate that you are fixing them, referring to their
+    number in the PR introduction (eg. “This PR fixes #1234”).
 
-  That syntax will allow to automatically close all the related
-  issues upon merging.
+    If the PR fixes several issues, please write it as follows:
+    “*Fixes #XXXX, Fixes #YYYY, Fixes #ZZZZ*”.
 
-  If the issue was opened by a non-core developer, you may elect to
-  not use the “fixes #id” syntax to avoid to close the corresponding
-  issue automatically, rather request the reporter to confirm
-  resolution then close.
+    That syntax will allow to automatically close all the related
+    issues upon merging.
+
+    If the issue was opened by a non-core developer, you may elect to
+    not use the “fixes #id” syntax to avoid to close the corresponding
+    issue automatically, rather request the reporter to confirm
+    resolution then close.
+
+  - Review the issue according to our documentation in
+    `When Submitting an Issue`_.
 
 
 - Explain the benefit of merging the PR.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,13 +98,7 @@ Filling-out Other Fields
 
   To help assigning reviewers and organizing the Changelog, add labels
   that describe the `category <https://github.com/neuropoly/spinalcordtoolbox/wiki/Label-definition#issue-category>`_
-  and type of the change.
-  A change can have multiple types if it is appropriate but **it can only have one
-  category**.
-
-  `Here <https://github.com/neuropoly/spinalcordtoolbox/pull/1637>`_
-  is an example of PR with proper labels and description.
-
+  and type of issue.
 
 
 More Examples
@@ -476,6 +470,18 @@ Other PR Fields
   If that's the case and you don't know better, add all of these suggestions.
 
   The reviewers will be notified when you add them.
+
+- SCT Core Developers must add **Labels** to issues, external developers
+  should try to add them.
+
+  To help assigning reviewers and organizing the Changelog, add labels
+  that describe the `category <https://github.com/neuropoly/spinalcordtoolbox/wiki/Label-definition#issue-category>`_
+  and type of the change.
+  A change can have multiple types if it is appropriate but **it can only have one
+  category**.
+
+  `Here <https://github.com/neuropoly/spinalcordtoolbox/pull/1637>`_
+  is an example of PR with proper labels and description.
 
 
 After Submitting a PR


### PR DESCRIPTION
This PR fixes #1964 and adds a small sentence about performing an issue review pass during creation of a corresponding PR.