### PR TITLE
Few fixes in sct_extract_metric and batch processing outputs

### DIFF
--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -65,7 +65,7 @@ cd sct_example_data
 # ===========================================================================================
 cd t2
 # Segment spinal cord
-sct_propseg -i t2.nii.gz -c t2
+sct_propseg -i t2.nii.gz -c t2 -qc "$SCT_BP_QC_FOLDER"
 # Tips: If you are not satisfied with the results you can try with another algorithm:
 # sct_deepseg_sc -i t2.nii.gz -c t2 -qc "$SCT_BP_QC_FOLDER"
 # Vertebral labeling
@@ -247,11 +247,11 @@ cd ..
 echo "Ended at: $(date +%x_%r)"
 echo
 echo "t2/CSA:  " `grep -v '^#' t2/csa_mean.txt | grep -v '^$'`
-echo "mt/MTR:  " `awk -F"," ' {print $9}' mtr_in_wm.txt | tail -1`
+echo "mt/MTR(WM):  " `awk -F"," ' {print $9}' mtr_in_wm.txt | tail -1`
 echo "t2s/CSA_GM:  " `grep -v '^#' t2s/csa_gm/csa_mean.txt | grep -v '^$'`
 echo "t2s/CSA_WM:  " `grep -v '^#' t2s/csa_wm/csa_mean.txt | grep -v '^$'`
-echo "dmri/FA: " `grep -v '^#' dmri/fa_in_cst.txt | grep -v 'right'`
-echo "dmri/FA: " `grep -v '^#' dmri/fa_in_cst.txt | grep -v 'left'`
+echo "dmri/FA(CST_r): " `awk -F"," ' {print $9}' dmri/fa_in_cst.txt | tail -1`
+echo "dmri/FA(CST_l): " `awk -F"," ' {print $9}' dmri/fa_in_cst.txt | tail -2 | head -1`
 echo
 
 # Display syntax to open QC report on web browser

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -246,10 +246,10 @@ cd ..
 # ===========================================================================================
 echo "Ended at: $(date +%x_%r)"
 echo
-echo "t2/CSA:  " `grep -v '^#' t2/csa_mean.txt | grep -v '^$'`
-echo "mt/MTR(WM):  " `awk -F"," ' {print $9}' mtr_in_wm.txt | tail -1`
-echo "t2s/CSA_GM:  " `grep -v '^#' t2s/csa_gm/csa_mean.txt | grep -v '^$'`
-echo "t2s/CSA_WM:  " `grep -v '^#' t2s/csa_wm/csa_mean.txt | grep -v '^$'`
+echo "t2/CSA:         " `grep -v '^#' t2/csa_mean.txt | grep -v '^$'`
+echo "mt/MTR(WM):     " `awk -F"," ' {print $9}' mt/mtr_in_wm.txt | tail -1`
+echo "t2s/CSA_GM:     " `grep -v '^#' t2s/csa_gm/csa_mean.txt | grep -v '^$'`
+echo "t2s/CSA_WM:     " `grep -v '^#' t2s/csa_wm/csa_mean.txt | grep -v '^$'`
 echo "dmri/FA(CST_r): " `awk -F"," ' {print $9}' dmri/fa_in_cst.txt | tail -1`
 echo "dmri/FA(CST_l): " `awk -F"," ' {print $9}' dmri/fa_in_cst.txt | tail -2 | head -1`
 echo

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -247,7 +247,7 @@ cd ..
 echo "Ended at: $(date +%x_%r)"
 echo
 echo "t2/CSA:  " `grep -v '^#' t2/csa_mean.txt | grep -v '^$'`
-echo "mt/MTR:  " `grep -v '^#' mt/mtr_in_wm.txt | grep -v '^$'`
+echo "mt/MTR:  " `awk -F"," ' {print $9}' mtr_in_wm.txt | tail -1`
 echo "t2s/CSA_GM:  " `grep -v '^#' t2s/csa_gm/csa_mean.txt | grep -v '^$'`
 echo "t2s/CSA_WM:  " `grep -v '^#' t2s/csa_wm/csa_mean.txt | grep -v '^$'`
 echo "dmri/FA: " `grep -v '^#' dmri/fa_in_cst.txt | grep -v 'right'`

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -572,7 +572,7 @@ def save_metrics(labels_id_user, indiv_labels_ids, combined_labels_ids, indiv_la
     :param combined_labels_ids:
     :param indiv_labels_names:
     :param combined_labels_names:
-    :param slices_of_interest:
+    :param slices_of_interest: str
     :param indiv_labels_value:
     :param indiv_labels_std:
     :param indiv_labels_fract_vol:
@@ -585,20 +585,11 @@ def save_metrics(labels_id_user, indiv_labels_ids, combined_labels_ids, indiv_la
     :param overwrite:
     :param fname_normalizing_label:
     :param fixed_label:
-    :param vert_levels: int, list of int, or None
+    :param vert_levels: str
     :return:
     """
 
     sct.printv('\nSaving results in: ' + fname_output + ' ...')
-
-    # Format vertebral levels
-    if isinstance(vert_levels, int):
-        display_level = str(vert_levels)
-    elif isinstance(vert_levels, list):
-        display_level = ','.join([str(i) for i in vert_levels])
-    else:
-        # must be None
-        display_level = 'Unknown'
 
     # Note: Because of the pressing issue #1963 and the current refactoring of metric_saving (see PR #1931), a quick-
     # -and-dirty workaround here is to always save as xsl file, and if user asked for a .txt file, then the .xls will
@@ -652,7 +643,7 @@ def save_metrics(labels_id_user, indiv_labels_ids, combined_labels_ids, indiv_la
             sh.write(row_index, 0, time.strftime('%Y/%m/%d - %H:%M:%S'))
             sh.write(row_index, 1, os.path.abspath(fname_data))
             sh.write(row_index, 2, method)
-            sh.write(row_index, 3, display_level)
+            sh.write(row_index, 3, vert_levels)
             sh.write(row_index, 4, slices_of_interest)
             if fname_normalizing_label:
                 sh.write(row_index, 10, fname_normalizing_label)
@@ -682,7 +673,7 @@ def save_metrics(labels_id_user, indiv_labels_ids, combined_labels_ids, indiv_la
         sh.write(row_index, 0, time.strftime('%Y/%m/%d - %H:%M:%S'))
         sh.write(row_index, 1, os.path.abspath(fname_data))
         sh.write(row_index, 2, method)
-        sh.write(row_index, 3, display_level)
+        sh.write(row_index, 3, vert_levels)
         sh.write(row_index, 4, slices_of_interest)
         if fname_normalizing_label:
             sh.write(row_index, 10, fname_normalizing_label)
@@ -722,7 +713,7 @@ def save_metrics(labels_id_user, indiv_labels_ids, combined_labels_ids, indiv_la
         # fid_metric.write('\n' + '# Extraction method: ' + method)
         #
         # # Write selected vertebral levels
-        # fid_metric.write('\n# Vertebral levels: ' + display_level)
+        # fid_metric.write('\n# Vertebral levels: ' + vert_levels)
         #
         # # Write selected slices
         # fid_metric.write('\n' + '# Slices (z): ' + slices_of_interest)
@@ -767,7 +758,7 @@ def save_metrics(labels_id_user, indiv_labels_ids, combined_labels_ids, indiv_la
         metric_extraction_results['Date - Time'] = time.strftime('%Y/%m/%d - %H:%M:%S')
         metric_extraction_results['Metric file'] = os.path.abspath(fname_data)
         metric_extraction_results['Extraction method'] = method
-        metric_extraction_results['Vertebral levels'] = display_level
+        metric_extraction_results['Vertebral levels'] = vert_levels
         metric_extraction_results['Slices (z)'] = slices_of_interest
         if fname_normalizing_label:
             metric_extraction_results['Label used to normalize the metric estimation slice-by-slice'] = fname_normalizing_label

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -394,7 +394,7 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
     slicegroups = [str(i) for i in slices_list]
     if not perslice and not perlevel:
         # ['1,2,3,4,5,6']
-        slicegroups = [','.join(slicegroups)]
+        slicegroups = [';'.join(slicegroups)]
 
     # if user selected vertebral levels and asked for each separate levels
     # slicegroups = ['1,2', '3,4']
@@ -409,16 +409,16 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
         for group in slices_of_interest:
             # for each group: [1, 2, 3, 4] --> ['1,2,3,4']
             # so that slicegroups looks like: ['1,2,3,4','5,6,7,8','9,10,11,12']
-            slicegroups.append([','.join([str(i) for i in group])][0])
+            slicegroups.append([';'.join([str(i) for i in group])][0])
         # if user wants to concatenate all slices of interest into a single slicegroups
         if not perlevel:
-            slicegroups = [",".join(slicegroups)]
+            slicegroups = [";".join(slicegroups)]
 
     # loop across slicegroups
     for slicegroup in slicegroups:
         try:
             # convert list of strings into list of int to use as index
-            ind_slicegroup = [int(i) for i in slicegroup.split(',')]
+            ind_slicegroup = [int(i) for i in slicegroup.split(';')]
             # select portion of data and labels based on slicegroup
             dataz = data[:, :, ind_slicegroup]
             labelsz = np.copy(labels)
@@ -455,6 +455,8 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
                     vert_levels = get_vertebral_level_from_slice(im_vertebral_labeling, ind_slicegroup[0])
                 else:
                     vert_levels = list_levels
+                    # replace "," with ";" for easier CSV parsing
+                vert_levels = ';'.join([str(level) for level in vert_levels])
             else:
                 vert_levels = None
 


### PR DESCRIPTION
This PR brings a few cosmetic updates:
- Fixes #1987: `batch_processing` final output caused by recent modifications on `sct_extract_metric`
- Fixes #1961: Now running QC on the t2 segmentation with propseg

In addition, `sct_extract_metric` had to be modified because of some recently-introduced bugs in relation to the `perslice` and `perlevel` flags. Moreover, the separation of slice and levels is now done using ";" instead of ",", for better parsing of CSV output. 

Note to @zougloub: the current implementation/fix in `sct_extract_metric` might cause you a heart attack, but this is only a temporary bandage. Full healing will be provided by #1931.