### PR TITLE
sct_deepseg_sc, sct_deepseg_lesion: Allow to input image with one axial slice

### DIFF
--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -458,56 +458,6 @@ def deep_segmentation_MSlesion(fname_image, contrast_type, output_folder, ctr_al
                                       brain_bool=brain_bool,
                                       folder_output=tmp_folder_path,
                                       remove_temp_files=remove_temp_files)
-    # if ctr_algo == 'svm':
-    #     # run optic on a heatmap computed by a trained SVM+HoG algorithm
-    #     optic_models_fname = os.path.join(path_sct, 'data', 'optic_models', '{}_model'.format(contrast_type_ctr))
-    #     _, centerline_filename = optic.detect_centerline(image_fname=fname_res,
-    #                                                      contrast_type=contrast_type_ctr,
-    #                                                      optic_models_path=optic_models_fname,
-    #                                                      folder_output=tmp_folder_path,
-    #                                                      remove_temp_files=remove_temp_files,
-    #                                                      output_roi=False,
-    #                                                      verbose=0)
-    # elif ctr_algo == 'cnn':
-    #     # CNN parameters
-    #     dct_patch_ctr = {'t2': {'size': (80, 80), 'mean': 51.1417, 'std': 57.4408},
-    #                         't2s': {'size': (80, 80), 'mean': 68.8591, 'std': 71.4659}}
-    #     dct_params_ctr = {'t2': {'features': 16, 'dilation_layers': 2},
-    #                         't2s': {'features': 8, 'dilation_layers': 3}}
-
-    #     # load model
-    #     ctr_model_fname = os.path.join(path_sct, 'data', 'deepseg_sc_models', '{}_ctr.h5'.format(contrast_type_ctr))
-    #     ctr_model = nn_architecture_ctr(height=dct_patch_ctr[contrast_type_ctr]['size'][0],
-    #                                     width=dct_patch_ctr[contrast_type_ctr]['size'][1],
-    #                                     channels=1,
-    #                                     classes=1,
-    #                                     features=dct_params_ctr[contrast_type_ctr]['features'],
-    #                                     depth=2,
-    #                                     temperature=1.0,
-    #                                     padding='same',
-    #                                     batchnorm=True,
-    #                                     dropout=0.0,
-    #                                     dilation_layers=dct_params_ctr[contrast_type_ctr]['dilation_layers'])
-    #     ctr_model.load_weights(ctr_model_fname)
-
-    #     # compute the heatmap
-    #     fname_heatmap = sct.add_suffix(fname_res, "_heatmap")
-    #     img_filename = ''.join(sct.extract_fname(fname_heatmap)[:2])
-    #     fname_heatmap_nii = img_filename + '.nii'
-    #     z_max = heatmap(filename_in=fname_res,
-    #                     filename_out=fname_heatmap_nii,
-    #                     model=ctr_model,
-    #                     patch_shape=dct_patch_ctr[contrast_type_ctr]['size'],
-    #                     mean_train=dct_patch_ctr[contrast_type_ctr]['mean'],
-    #                     std_train=dct_patch_ctr[contrast_type_ctr]['std'],
-    #                     brain_bool=brain_bool)
-
-    #     # run optic on the heatmap
-    #     centerline_filename = sct.add_suffix(fname_heatmap, "_ctr")
-    #     heatmap2optic(fname_heatmap=fname_heatmap_nii,
-    #                   lambda_value=7 if contrast_type_ctr == 't2s' else 1,
-    #                   fname_out=centerline_filename,
-    #                   z_max=z_max if brain_bool else None)
 
     # crop image around the spinal cord centerline
     sct.log.info("\nCropping the image around the spinal cord...")

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -393,22 +393,15 @@ def heatmap2optic(fname_heatmap, lambda_value, fname_out, z_max, algo='dpdt'):
     import nibabel as nib
     os.environ["FSLOUTPUTTYPE"] = "NIFTI_PAIR"
 
-    if Image(fname_heatmap).dim[2] > 1:  # isct_spine_detect requires nz>1
-        optic_input = fname_heatmap.split('.nii')[0]
+    optic_input = fname_heatmap.split('.nii')[0]
 
-        cmd_optic = 'isct_spine_detect -ctype="%s" -lambda="%s" "%s" "%s" "%s"' % \
-                    (algo, str(lambda_value), "NONE", optic_input, optic_input)
-        sct.run(cmd_optic, verbose=1)
+    cmd_optic = 'isct_spine_detect -ctype="%s" -lambda="%s" "%s" "%s" "%s"' % \
+                (algo, str(lambda_value), "NONE", optic_input, optic_input)
+    sct.run(cmd_optic, verbose=1)
 
-        optic_hdr_filename = optic_input + '_ctr.hdr'
-        img = nib.load(optic_hdr_filename)
-        nib.save(img, fname_out)
-    else:
-        img_heatmap = Image(fname_heatmap)
-        img_ctr = msct_image.zeros_like(img_heatmap, dtype=np.uint8)
-        x_cOm, y_cOm, _ = center_of_mass(np.array(img_heatmap.data))
-        img_ctr.data[int(np.round(x_cOm)), int(np.round(y_cOm)), 0] = 1
-        img_ctr.save(fname_out)
+    optic_hdr_filename = optic_input + '_ctr.hdr'
+    img = nib.load(optic_hdr_filename)
+    nib.save(img, fname_out)
 
     # crop the centerline if z_max < data.shape[2] and -brain == 1
     if z_max is not None:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -129,7 +129,6 @@ def _find_crop_start_end(coord_ctr, crop_size, im_dim):
 def crop_image_around_centerline(filename_in, filename_ctr, filename_out, crop_size):
     """Crop the input image around the input centerline file."""
     im_in, data_ctr = Image(filename_in), Image(filename_ctr).data
-
     im_new = msct_image.empty_like(im_in) # but in fact we're going to crop it
 
     x_lst, y_lst = [], []
@@ -392,15 +391,22 @@ def heatmap2optic(fname_heatmap, lambda_value, fname_out, z_max, algo='dpdt'):
     import nibabel as nib
     os.environ["FSLOUTPUTTYPE"] = "NIFTI_PAIR"
 
-    optic_input = fname_heatmap.split('.nii')[0]
+    if Image(fname_heatmap).dim[2] > 1:  # isct_spine_detect requires nz>1
+        optic_input = fname_heatmap.split('.nii')[0]
 
-    cmd_optic = 'isct_spine_detect -ctype="%s" -lambda="%s" "%s" "%s" "%s"' % \
-                (algo, str(lambda_value), "NONE", optic_input, optic_input)
-    sct.run(cmd_optic, verbose=1)
+        cmd_optic = 'isct_spine_detect -ctype="%s" -lambda="%s" "%s" "%s" "%s"' % \
+                    (algo, str(lambda_value), "NONE", optic_input, optic_input)
+        sct.run(cmd_optic, verbose=1)
 
-    optic_hdr_filename = optic_input + '_ctr.hdr'
-    img = nib.load(optic_hdr_filename)
-    nib.save(img, fname_out)
+        optic_hdr_filename = optic_input + '_ctr.hdr'
+        img = nib.load(optic_hdr_filename)
+        nib.save(img, fname_out)
+    else:
+        img_heatmap = Image(fname_heatmap)
+        img_ctr = msct_image.zeros_like(img_heatmap, dtype=np.uint8)
+        x_cOm, y_cOm, _ = center_of_mass(np.array(img_heatmap.data))
+        img_ctr.data[int(np.round(x_cOm)), int(np.round(y_cOm)), 0] = 1
+        img_ctr.save(fname_out)
 
     # crop the centerline if z_max < data.shape[2] and -brain == 1
     if z_max is not None:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -642,7 +642,7 @@ def deep_segmentation_spinalcord(fname_image, contrast_type, output_folder, ctr_
     # crop image around the spinal cord centerline
     sct.log.info("Cropping the image around the spinal cord...")
     fname_crop = sct.add_suffix(fname_res, '_crop')
-    crop_size = 64 if kernel_size == '2d' else 96
+    crop_size = 96 if (kernel_size == '3d' and contrast_type == 't2s') else 64
     X_CROP_LST, Y_CROP_LST = crop_image_around_centerline(filename_in=fname_res,
                                                           filename_ctr=centerline_filename,
                                                           filename_out=fname_crop,
@@ -758,8 +758,8 @@ def main():
     contrast_type = arguments['-c']
 
     ctr_algo = arguments["-centerline"]
-    # if "-centerline" not in args and contrast_type == 't2s':
-    #     ctr_algo = 'cnn'
+    if "-centerline" not in args and contrast_type == 't1':
+        ctr_algo = 'cnn'
 
     if "-brain" not in args:
         if contrast_type in ['t2s', 'dwi']:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -563,7 +563,7 @@ def deep_segmentation_spinalcord(fname_image, contrast_type, output_folder, ctr_
 
     # find the spinal cord centerline - execute OptiC binary
     sct.log.info("Finding the spinal cord centerline...")
-    if ctr_algo == 'svm':
+    if ctr_algo == 'svm' and Image(fname_res).dim[2] > 1:  # isct_spine_detect requires nz > 1
         # run optic on a heatmap computed by a trained SVM+HoG algorithm
         optic_models_fname = os.path.join(path_sct, 'data', 'optic_models', '{}_model'.format(contrast_type))
         _, centerline_filename = optic.detect_centerline(image_fname=fname_res,
@@ -617,6 +617,8 @@ def deep_segmentation_spinalcord(fname_image, contrast_type, output_folder, ctr_
                       lambda_value=7 if contrast_type == 't2s' else 1,
                       fname_out=centerline_filename,
                       z_max=z_max if brain_bool else None)
+    else:
+        sct.log.error("\nYour image contains only one axial slice, please re-run the function using -centerline cnn.\n")
 
     # crop image around the spinal cord centerline
     sct.log.info("Cropping the image around the spinal cord...")

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -128,7 +128,9 @@ def _find_crop_start_end(coord_ctr, crop_size, im_dim):
 
 def crop_image_around_centerline(filename_in, filename_ctr, filename_out, crop_size):
     """Crop the input image around the input centerline file."""
-    im_in, data_ctr = Image(filename_in), Image(filename_ctr).data
+    im_in, data_ctr = Image(filename_in), Image(filename_ctr).data.astype(np.int8)
+    data_ctr = data_ctr if len(data_ctr.shape) >= 3 else np.expand_dims(data_ctr, 2)
+    data_in = im_in.data.astype(np.float32)
     im_new = msct_image.empty_like(im_in) # but in fact we're going to crop it
 
     x_lst, y_lst = [], []
@@ -141,8 +143,8 @@ def crop_image_around_centerline(filename_in, filename_ctr, filename_out, crop_s
             y_start, y_end = _find_crop_start_end(y_ctr, crop_size, im_in.dim[1])
 
             crop_im = np.zeros((crop_size, crop_size))
-            x_shape, y_shape = im_in.data[x_start:x_end, y_start:y_end, zz].shape
-            crop_im[:x_shape, :y_shape] = im_in.data[x_start:x_end, y_start:y_end, zz]
+            x_shape, y_shape = data_in[x_start:x_end, y_start:y_end, zz].shape
+            crop_im[:x_shape, :y_shape] = data_in[x_start:x_end, y_start:y_end, zz]
 
             data_im_new[:, :, zz] = crop_im
 
@@ -418,7 +420,16 @@ def heatmap2optic(fname_heatmap, lambda_value, fname_out, z_max, algo='dpdt'):
 
 def find_centerline(algo, image_fname, path_sct, contrast_type, brain_bool, folder_output, remove_temp_files):
 
-    if algo == 'svm' and Image(image_fname).dim[2] > 1:  # isct_spine_detect requires nz > 1
+    if Image(image_fname).dim[2] == 1:  # isct_spine_detect requires nz > 1
+        from sct_image import concat_data
+        im_concat = concat_data([image_fname, image_fname], dim=2)
+        im_concat.save(sct.add_suffix(image_fname, '_concat'))
+        image_fname = sct.add_suffix(image_fname, '_concat')
+        bool_2d = True
+    else:
+        bool_2d = False
+
+    if algo == 'svm':
         # run optic on a heatmap computed by a trained SVM+HoG algorithm
         optic_models_fname = os.path.join(path_sct, 'data', 'optic_models', '{}_model'.format(contrast_type))
         _, centerline_filename = optic.detect_centerline(image_fname=image_fname,
@@ -472,8 +483,11 @@ def find_centerline(algo, image_fname, path_sct, contrast_type, brain_bool, fold
                       lambda_value=7 if contrast_type == 't2s' else 1,
                       fname_out=centerline_filename,
                       z_max=z_max if brain_bool else None)
-    else:
-        sct.log.error("\nYour image contains only one axial slice, please re-run the function using -centerline cnn.\n")
+
+    if bool_2d:
+        from sct_image import split_data
+        im_split_lst = split_data(Image(centerline_filename), dim=2)
+        im_split_lst[0].save(centerline_filename)
 
     return centerline_filename
 
@@ -564,7 +578,6 @@ def segment_3d(model_fname, contrast_type, fname_in, fname_out):
     out = msct_image.zeros_like(im, dtype=np.uint8)
 
     # segment the spinal cord
-    sct.log.info("Segmenting the spinal cord using deep learning on 3D patches...")
     z_patch_size = dct_patch_sc_3d[contrast_type]['size'][2]
     z_step_keep = list(range(0, im.data.shape[2], z_patch_size))
     for zz in z_step_keep:


### PR DESCRIPTION
**Goal:** Allow to input image with only one axial slice.

**Issue:** `isct_spine_detect` requires ```nz>1```.

**Solution:** If ```nz==1```, then ask the user to use `-centerline cnn` instead of `-centerline svm` (default).

To test:
```
cd sct_example_data/t2s
sct_crop_image -i t2s.nii.gz -dim 2 -start 2 -end 2 -o t2s_Z010.nii.gz
sct_deepseg_sc -i t2s_Z010.nii.gz -c t2s
```
Raises an error message:
```
Your image contains only one axial slice, please re-run the function using -centerline cnn.
```
Then,
```
sct_deepseg_sc -i t2s_Z010.nii.gz -c t2s -centerline cnn
```

Same for `sct_deepseg_lesion`.

Note that I have remove some duplicated code: The centerline detection is now done by a function in `sct_deepseg_sc` named `find_centerline`, which is called by `sct_deepseg_lesion`.