### PR TITLE
(WIP) sct_image: Does not reshape on split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ scripts/.idea/modules.xml
 scripts/.idea/scripts.iml
 scripts/.idea/vcs.xml
 scripts/.idea/workspace.xml
+
+.pytest_cache/
+unit_testing/*.csv
+unit_testing/*.nii.gz
+unit_testing/*.roi

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -355,7 +355,8 @@ def split_data(im_in, dim):
     im_out_list = []
     for idx_img, dat in enumerate(data_split):
         im_out = msct_image.empty_like(im_in)
-        im_out.data = dat.reshape(tuple([ x for (idx_shape,x) in enumerate(data.shape) if idx_shape != dim]))
+        # im_out.data = dat.reshape(tuple([ x for (idx_shape, x) in enumerate(data.shape) if idx_shape != dim]))
+        im_out.data = dat
         im_out.absolutepath = sct.add_suffix(im_in.absolutepath, "_{}{}".format(dim_list[dim].upper(), str(idx_img).zfill(4)))
         im_out_list.append(im_out)
 


### PR DESCRIPTION
When splitting along Z (or X or Y) a 4D file (with time: dim=4), each output (e.g. data_Z0002.nii.gz) is a 3D file, with the time dimension becoming dim=3 instead of dim=4, and the Z dimension being removed instead of keeping it as a singleton. This PR fixes is.

Fixes #2017