### PR TITLE
sct_fmri_moco: Generalize motion correction for sagittal acquisitions and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,3 @@ scripts/.idea/workspace.xml
 unit_testing/*.csv
 unit_testing/*.nii.gz
 unit_testing/*.roi
-
-

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -140,7 +140,7 @@ def moco(param):
 
         # Motion correction: Loop across T
         for indice_index in tqdm(range(nt), unit='iter', unit_scale=False,
-                                 desc="Z=" + str(iz) + "/" + str(len(file_data_splitZ)-1), ascii=False, ncols=80):
+                                 desc="Z=" + str(iz) + "/" + str(len(file_data_splitZ)-1), ascii=True, ncols=80):
 
             # create indices and display stuff
             it = index[indice_index]

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -139,9 +139,8 @@ def moco(param):
         failed_transfo = [0 for i in range(nt)]
 
         # Motion correction: Loop across T
-        tqdm_bar = tqdm(total=nt, unit='iter', unit_scale=False,
-                        desc="Z=" + str(iz) + "/" + str(len(file_data_splitZ)-1), ascii=True, ncols=80)
-        for indice_index in range(nt):
+        for indice_index in tqdm(range(nt), unit='iter', unit_scale=False,
+                                 desc="Z=" + str(iz) + "/" + str(len(file_data_splitZ)-1), ascii=False, ncols=80):
 
             # create indices and display stuff
             it = index[indice_index]
@@ -165,8 +164,6 @@ def moco(param):
                 data_targetz = (data_targetz * (indice_index + 1) + data_mocoz) / (indice_index + 2)
                 im_targetz.data = data_targetz
                 im_targetz.save(verbose=0)
-            tqdm_bar.update()
-        tqdm_bar.close()
 
         # Replace failed transformation with the closest good one
         fT = [i for i, j in enumerate(failed_transfo) if j == 1]

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -168,8 +168,8 @@ def moco(param):
         # Replace failed transformation with the closest good one
         fT = [i for i, j in enumerate(failed_transfo) if j == 1]
         gT = [i for i, j in enumerate(failed_transfo) if j == 0]
-        for it in range(len(fT)):
-            abs_dist = [abs(gT[i] - fT[it]) for i in range(len(gT))]
+        for it in enumerate(fT):
+            abs_dist = [abs(gT[i] - fT[it]) for i in enumerate(gT)]
             if not abs_dist == []:
                 index_good = abs_dist.index(min(abs_dist))
                 sct.printv('  transfo #' + str(fT[it]) + ' --> use transfo #' + str(gT[index_good]), verbose)

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -72,25 +72,13 @@ def moco(param):
     nx, ny, nz, nt, px, py, pz, pt = im_data.dim
     sct.printv(('  ' + str(nx) + ' x ' + str(ny) + ' x ' + str(nz) + ' x ' + str(nt)), verbose)
 
-    # Get orientation
-    sct.printv('\nData orientation: ' + im_data.orientation, verbose)
-    if im_data.orientation[2] in 'LR':
-        is_sagittal = True
-        sct.printv('  Treated as sagittal')
-    elif im_data.orientation[2] in 'IS':
-        is_sagittal = False
-        sct.printv('  Treated as axial')
-    else:
-        is_sagittal = False
-        sct.printv('WARNING: Orientation seems to be neither axial nor sagittal.')
-
     # copy file_target to a temporary file
     sct.printv('\nCopy file_target to a temporary file...', verbose)
     sct.copy(file_target + ext, 'target.nii')
     file_target = 'target'
 
     # If scan is sagittal, split src and target along Z (slice)
-    if is_sagittal:
+    if param.is_sagittal:
         dim_sag = 2  # TODO: find it
         # z-split data (time series)
         im_z_list = split_data(im_data, dim=dim_sag, squeeze_data=False)
@@ -199,7 +187,7 @@ def moco(param):
             im_out.save(file_data_splitZ_moco[iz])
 
     # If sagittal, merge along Z
-    if is_sagittal:
+    if param.is_sagittal:
         sct.printv('\nMerge data back along Z...', verbose)
         im_out = concat_data(file_data_splitZ_moco, 2)
         im_out.save(file_data + suffix + ext)

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -152,7 +152,7 @@ def moco(param):
 
             # average registered volume with target image
             # N.B. use weighted averaging: (target * nb_it + moco) / (nb_it + 1)
-            if param.iterative_averaging and indice_index < 10 and failed_transfo[it] == 0 and not param.todo == 'apply':
+            if param.iterAvg and indice_index < 10 and failed_transfo[it] == 0 and not param.todo == 'apply':
                 im_targetz = Image(file_target_splitZ[iz])
                 data_targetz = im_targetz.data
                 data_mocoz = Image(file_data_splitZ_splitT_moco[it]).data
@@ -263,7 +263,7 @@ def register(param, file_src, file_dest, file_mat, file_out):
                '--polydegree', param.poly,
                '--transform', 'Translation[%s]' %param.gradStep,
                '--metric', param.metric + '[' + file_dest + ',' + file_src + ',1,' + metric_radius + ',Regular,' + param.sampling + ']',
-               '--iterations', '5',
+               '--iterations', param.iter,
                '--shrinkFactors', '1',
                '--smoothingSigmas', param.smooth,
                '--verbose', '1',

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -169,7 +169,7 @@ def moco(param):
         fT = [i for i, j in enumerate(failed_transfo) if j == 1]
         gT = [i for i, j in enumerate(failed_transfo) if j == 0]
         for it in enumerate(fT):
-            abs_dist = [abs(gT[i] - fT[it]) for i in enumerate(gT)]
+            abs_dist = [np.abs(gT[i] - fT[it]) for i in enumerate(gT)]
             if not abs_dist == []:
                 index_good = abs_dist.index(min(abs_dist))
                 sct.printv('  transfo #' + str(fT[it]) + ' --> use transfo #' + str(gT[index_good]), verbose)

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -223,6 +223,7 @@ def register(param, file_src, file_dest, file_mat, file_out):
 
     # initialization
     failed_transfo = 0  # by default, failed matrix is 0 (i.e., no failure)
+    file_mask = param.fname_mask
 
     # get metric radius (if MeanSquares, CC) or nb bins (if MI)
     if param.metric == 'MI':
@@ -250,12 +251,21 @@ def register(param, file_src, file_dest, file_mat, file_out):
             im_dest.change_orientation('RPI')
             im_dest_concat = concat_data([im_dest, im_dest, im_dest, im_dest, im_dest], 0, squeeze_data=False)
             im_dest_concat.save(file_dest_concat)
+        # and the same thing with the mask (if there is one)
+        if not param.fname_mask == '':
+            file_mask_concat = 'mask_rpi_concat.nii.gz'
+            if not os.path.isfile(file_mask_concat):
+                im_mask = Image(param.fname_mask)
+                im_mask.change_orientation('RPI')
+                im_mask_concat = concat_data([im_mask, im_mask, im_mask, im_mask, im_mask], 0, squeeze_data=False)
+                im_mask_concat.save(file_mask_concat)
         # update variables
         file_src = file_src_concat
         file_dest = file_dest_concat
         file_out_concat = sct.add_suffix(file_src, '_moco')
     else:
         file_out_concat = file_out
+        file_mask_concat = file_mask
 
     # register file_src to file_dest
     if param.todo == 'estimate' or param.todo == 'estimate_and_apply':
@@ -269,8 +279,8 @@ def register(param, file_src, file_dest, file_mat, file_out):
                '--verbose', '1',
                '--output', '[' + file_mat + ',' + file_out_concat + ']']
         cmd += sct.get_interpolation('isct_antsSliceRegularizedRegistration', param.interp)
-        if not param.fname_mask == '':
-            cmd += ['--mask', param.fname_mask]
+        if not file_mask_concat == '':
+            cmd += ['--mask', file_mask_concat]
         status, output = sct.run(cmd, param.verbose)
 
     if param.todo == 'apply':

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -273,16 +273,16 @@ def register(param, file_src, file_dest, file_mat, file_out, im_mask=None):
     if param.todo == 'estimate' or param.todo == 'estimate_and_apply':
         im_data = Image(file_src)  # TODO: pass argument to use antsReg instead of opening Image each time
         # If orientation is sagittal, use antsRegistration in 2D mode
+        # Note: the parameter --restrict-deformation is irrelevant with affine transfo
         if im_data.orientation[2] in 'LR':
             cmd = ['isct_antsRegistration',
                    '-d', '2',
-                   '--transform', 'affine[%s]' %param.gradStep,
+                   '--transform', 'Affine[%s]' %param.gradStep,
                    '--metric', param.metric + '[' + file_dest + ',' + file_src + ',1,' + metric_radius + ',Regular,' + param.sampling + ']',
                    '--convergence', param.iter,
                    '--shrink-factors', '1',
                    '--smoothing-sigmas', param.smooth,
                    '--verbose', '1',
-                   '--restrict-deformation', '0x1',  # restrict deformation along A-P axis
                    '--output', '[' + file_mat + ',' + file_out_concat + ']']
             cmd += sct.get_interpolation('isct_antsRegistration', param.interp)
             if im_mask is not None:

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -17,9 +17,6 @@
 # TODO: add tests with sag and ax orientation, with -g 1 and 3
 # TODO: make it a spinalcordtoolbox module with im as input
 # TODO: params for ANTS: CC/MI, shrink fact, nb_it
-# TODO: use mask
-# TODO: unpad after applying transfo
-# TODO: do not output inverse warp for ants
 # TODO: ants: explore optin  --float  for faster computation
 
 from __future__ import absolute_import
@@ -161,7 +158,7 @@ def moco(param):
                 data_mocoz = Image(file_data_splitZ_splitT_moco[it]).data
                 data_targetz = (data_targetz * (indice_index + 1) + data_mocoz) / (indice_index + 2)
                 im_targetz.data = data_targetz
-                im_targetz.save()
+                im_targetz.save(verbose=0)
                 # sct.run(["sct_maths", "-i", file_target_splitZ[iz], "-mul", str(indice_index + 1), "-o", file_target_splitZ[iz]])
                 # sct.run(["sct_maths", "-i", file_target_splitZ[iz], "-add", file_data_splitZ_splitT_moco[it], "-o", file_target_splitZ[iz]])
                 # sct.run(["sct_maths", "-i", file_target_splitZ[iz], "-div", str(indice_index + 2), "-o", file_target_splitZ[iz]])
@@ -294,7 +291,12 @@ def register(param, file_src, file_dest, file_mat, file_out):
     # check if output file exists
     if not os.path.isfile(file_out_concat):
         # sct.printv(output, verbose, 'error')
-        sct.printv('WARNING in ' + os.path.basename(__file__) + ': No output. Maybe related to improper calculation of mutual information. Either the mask you provided is too small, or the subject moved a lot. If you see too many messages like this try with a bigger mask. Using previous transformation for this volume.', param.verbose, 'warning')
+        sct.printv('WARNING in ' + os.path.basename(__file__) + ': No output. Maybe related to improper calculation of '
+                                                                'mutual information. Either the mask you provided is '
+                                                                'too small, or the subject moved a lot. If you see too '
+                                                                'many messages like this try with a bigger mask. '
+                                                                'Using previous transformation for this volume (if it'
+                                                                'exists).', param.verbose, 'warning')
         failed_transfo = 1
 
     # TODO: if sagittal, remove x values from mat, remove concat and put back in original orientation

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -37,7 +37,6 @@ path_sct = os.environ.get("SCT_DIR", os.path.dirname(os.path.dirname(__file__)))
 def moco(param):
 
     # retrieve parameters
-    fsloutput = 'export FSLOUTPUTTYPE=NIFTI; '  # for faster processing, all outputs are in NIFTI
     file_data = param.file_data
     file_target = param.file_target
     folder_mat = param.mat_moco  # output folder of mat file

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -459,7 +459,7 @@ def dmri_moco(param):
     # Copy DWI registration matrices
     sct.printv('\nCopy DWI registration matrices...', param.verbose)
     for iGroup in range(nb_groups):
-        for dwi in enumerate(group_indexes[iGroup]):
+        for dwi in range(len(group_indexes[iGroup])):  # we cannot use enumerate because group_indexes has 2 dim.
             sct.copy('mat_dwigroups/' + 'mat.Z0000T' + str(iGroup).zfill(4) + ext_mat,
                      mat_final + 'mat.Z0000T' + str(group_indexes[iGroup][dwi]).zfill(4) + ext_mat)
 

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -75,7 +75,7 @@ class Param:
         self.swapXY = 0
         self.bval_min = 100  # in case user does not have min bvalues at 0, set threshold (where csf disapeared).
         self.otsu = 0  # use otsu algorithm to segment dwi data for better moco. Value coresponds to data threshold. For no segmentation set to 0.
-        self.iterative_averaging = 1  # iteratively average target image for more robust moco
+        self.iterAvg = 1  # iteratively average target image for more robust moco
 
     # update constructor with user's parameters
     def update(self, param_user):

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -76,6 +76,8 @@ class Param:
         self.bval_min = 100  # in case user does not have min bvalues at 0, set threshold (where csf disapeared).
         self.otsu = 0  # use otsu algorithm to segment dwi data for better moco. Value coresponds to data threshold. For no segmentation set to 0.
         self.iterAvg = 1  # iteratively average target image for more robust moco
+        self.is_sagittal = False  # if True, then split along Z (right-left) and register each 2D slice (vs. 3D volume)
+# Note: this feature is currently ONLY supported by sct_fmri_moco (not here).
 
     # update constructor with user's parameters
     def update(self, param_user):

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -372,7 +372,7 @@ def dmri_moco(param):
 
     # DWI groups
     file_dwi_mean = []
-    for iGroup in tqdm(range(nb_groups), unit='iter', unit_scale=False, desc="Merge within groups", ascii=False, ncols=80):
+    for iGroup in tqdm(range(nb_groups), unit='iter', unit_scale=False, desc="Merge within groups", ascii=True, ncols=80):
         # get index
         index_dwi_i = group_indexes[iGroup]
         nb_dwi_i = len(index_dwi_i)

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -372,8 +372,7 @@ def dmri_moco(param):
 
     # DWI groups
     file_dwi_mean = []
-    tqdm_bar = tqdm(total=nb_groups, unit='iter', unit_scale=False, desc="Merge within groups", ascii=True, ncols=80)
-    for iGroup in range(nb_groups):
+    for iGroup in tqdm(range(nb_groups), unit='iter', unit_scale=False, desc="Merge within groups", ascii=False, ncols=80):
         # get index
         index_dwi_i = group_indexes[iGroup]
         nb_dwi_i = len(index_dwi_i)
@@ -386,8 +385,6 @@ def dmri_moco(param):
         # Average DW Images
         file_dwi_mean.append(file_dwi + '_mean_' + str(iGroup))
         sct.run(["sct_maths", "-i", file_dwi_merge_i + ext_data, "-o", file_dwi_mean[iGroup] + ext_data, "-mean", "t"], 0)
-        tqdm_bar.update()
-    tqdm_bar.close()
 
     # Merge DWI groups means
     sct.printv('\nMerging DW files...', param.verbose)

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -459,7 +459,7 @@ def dmri_moco(param):
     # Copy DWI registration matrices
     sct.printv('\nCopy DWI registration matrices...', param.verbose)
     for iGroup in range(nb_groups):
-        for dwi in range(len(group_indexes[iGroup])):
+        for dwi in enumerate(group_indexes[iGroup]):
             sct.copy('mat_dwigroups/' + 'mat.Z0000T' + str(iGroup).zfill(4) + ext_mat,
                      mat_final + 'mat.Z0000T' + str(group_indexes[iGroup][dwi]).zfill(4) + ext_mat)
 

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -291,8 +291,7 @@ def fmri_moco(param):
         group_indexes.append(index_fmri[len(index_fmri) - nb_remaining:len(index_fmri)])
 
     # groups
-    for iGroup in tqdm(range(nb_groups), unit='iter', unit_scale=False, desc="Merge within groups", ascii=False, ncols=80):
-
+    for iGroup in tqdm(range(nb_groups), unit='iter', unit_scale=False, desc="Merge within groups", ascii=True, ncols=80):
         # get index
         index_fmri_i = group_indexes[iGroup]
         nt_i = len(index_fmri_i)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -352,7 +352,7 @@ def fmri_moco(param):
         # Copy registration matrices
         sct.printv('\nCopy transformations...', param.verbose)
         for iGroup in range(nb_groups):
-            for data in enumerate(group_indexes[iGroup]):
+            for data in range(len(group_indexes[iGroup])):  # we cannot use enumerate because group_indexes has 2 dim.
                 # fetch all file_mat_z for given t-group
                 list_file_mat_z = file_mat[:, iGroup]
                 # loop across file_mat_z and copy to mat_final folder

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -197,6 +197,7 @@ def main(args=None):
     path_tmp = sct.tmp_create(basename="fmri_moco", verbose=param.verbose)
 
     # Copying input data to tmp folder and convert to nii
+    # TODO: no need to do that (takes time for nothing)
     sct.printv('\nCopying input data to tmp folder and convert to nii...', param.verbose)
     convert(param.fname_data, os.path.join(path_tmp, "fmri.nii"), squeeze_data=False)
 

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -323,28 +323,28 @@ def fmri_moco(param):
     param_moco.mat_moco = 'mat_groups'
     file_mat = moco.moco(param_moco)
 
-    # create final mat folder
-    sct.create_folder(mat_final)
-
-    # Copy registration matrices
-    sct.printv('\nCopy transformations...', param.verbose)
-    for iGroup in range(nb_groups):
-        for data in range(len(group_indexes[iGroup])):
-            # fetch all file_mat_z for given t-group
-            list_file_mat_z = file_mat[:, iGroup]
-            # loop across file_mat_z and copy to mat_final folder
-            for file_mat_z in list_file_mat_z:
-                # we want to copy 'mat_groups/mat.ZXXXXTYYYYWarp.nii.gz' --> 'mat_final/mat.ZXXXXTYYYZWarp.nii.gz'
-                # Notice the Y->Z in the under the T index: the idea here is to use the single matrix from each group,
-                # and apply it to all images belonging to the same group.
-                sct.copy(file_mat_z + ext_mat,
-                         mat_final + file_mat_z[11:20] + 'T' + str(group_indexes[iGroup][data]).zfill(4) + ext_mat)
-
     # TODO: if g=1, no need to run the block below (already applied)
     if param.group_size == 1:
         # if flag g=1, it means that all images have already been corrected, so we just need to rename the file
         sct.mv('fmri_averaged_groups_moco.nii', 'fmri_moco.nii')
     else:
+        # create final mat folder
+        sct.create_folder(mat_final)
+
+        # Copy registration matrices
+        sct.printv('\nCopy transformations...', param.verbose)
+        for iGroup in range(nb_groups):
+            for data in range(len(group_indexes[iGroup])):
+                # fetch all file_mat_z for given t-group
+                list_file_mat_z = file_mat[:, iGroup]
+                # loop across file_mat_z and copy to mat_final folder
+                for file_mat_z in list_file_mat_z:
+                    # we want to copy 'mat_groups/mat.ZXXXXTYYYYWarp.nii.gz' --> 'mat_final/mat.ZXXXXTYYYZWarp.nii.gz'
+                    # Notice the Y->Z in the under the T index: the idea here is to use the single matrix from each group,
+                    # and apply it to all images belonging to the same group.
+                    sct.copy(file_mat_z + ext_mat,
+                             mat_final + file_mat_z[11:20] + 'T' + str(group_indexes[iGroup][data]).zfill(4) + ext_mat)
+
         # Apply moco on all fmri data
         sct.printv('\n-------------------------------------------------------------------------------', param.verbose)
         sct.printv('  Apply moco', param.verbose)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -18,6 +18,7 @@ import os
 import time
 import math
 import shutil
+from tqdm import tqdm
 import numpy as np
 import sct_utils as sct
 import msct_moco as moco
@@ -291,9 +292,9 @@ def fmri_moco(param):
         group_indexes.append(index_fmri[len(index_fmri) - nb_remaining:len(index_fmri)])
 
     # groups
-    sct.printv('Merge consecutive volumes within groups...', param.verbose)
+    tqdm_bar = tqdm(total=nb_groups, unit='iter', unit_scale=False, desc="Merge within groups", ascii=True, ncols=80)
     for iGroup in range(nb_groups):
-        sct.printv('\nGroup: ' + str((iGroup + 1)) + '/' + str(nb_groups), param.verbose)
+        # sct.printv('\nGroup: ' + str((iGroup + 1)) + '/' + str(nb_groups), param.verbose)
 
         # get index
         index_fmri_i = group_indexes[iGroup]
@@ -317,12 +318,14 @@ def fmri_moco(param):
             shutil.copy(file_data_merge_i + '.nii', file_data_mean + '.nii')
         else:
             # Average Images
-            sct.run(['sct_maths', '-i', file_data_merge_i + '.nii', '-o', file_data_mean + '.nii', '-mean', 't'], verbose=param.verbose)
+            sct.run(['sct_maths', '-i', file_data_merge_i + '.nii', '-o', file_data_mean + '.nii', '-mean', 't'], verbose=0)
         # if not average_data_across_dimension(file_data_merge_i+'.nii', file_data_mean+'.nii', 3):
         #     sct.printv('ERROR in average_data_across_dimension', 1, 'error')
         # cmd = fsloutput + 'fslmaths ' + file_data_merge_i + ' -Tmean ' + file_data_mean
         # sct.run(cmd, param.verbose)
+        tqdm_bar.update()
 
+    tqdm_bar.close()
     # Merge groups means. The output 4D volume will be used for motion correction.
     sct.printv('\nMerging volumes...', param.verbose)
     file_data_groups_means_merge = 'fmri_averaged_groups'

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -292,9 +292,7 @@ def fmri_moco(param):
         group_indexes.append(index_fmri[len(index_fmri) - nb_remaining:len(index_fmri)])
 
     # groups
-    tqdm_bar = tqdm(total=nb_groups, unit='iter', unit_scale=False, desc="Merge within groups", ascii=True, ncols=80)
-    for iGroup in range(nb_groups):
-        # sct.printv('\nGroup: ' + str((iGroup + 1)) + '/' + str(nb_groups), param.verbose)
+    for iGroup in tqdm(range(nb_groups), unit='iter', unit_scale=False, desc="Merge within groups", ascii=False, ncols=80):
 
         # get index
         index_fmri_i = group_indexes[iGroup]
@@ -323,9 +321,7 @@ def fmri_moco(param):
         #     sct.printv('ERROR in average_data_across_dimension', 1, 'error')
         # cmd = fsloutput + 'fslmaths ' + file_data_merge_i + ' -Tmean ' + file_data_mean
         # sct.run(cmd, param.verbose)
-        tqdm_bar.update()
 
-    tqdm_bar.close()
     # Merge groups means. The output 4D volume will be used for motion correction.
     sct.printv('\nMerging volumes...', param.verbose)
     file_data_groups_means_merge = 'fmri_averaged_groups'

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -352,7 +352,7 @@ def fmri_moco(param):
         # Copy registration matrices
         sct.printv('\nCopy transformations...', param.verbose)
         for iGroup in range(nb_groups):
-            for data in range(len(group_indexes[iGroup])):
+            for data in enumerate(group_indexes[iGroup]):
                 # fetch all file_mat_z for given t-group
                 list_file_mat_z = file_mat[:, iGroup]
                 # loop across file_mat_z and copy to mat_final folder

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -311,7 +311,7 @@ def fmri_moco(param):
     param_moco.path_out = ''
     param_moco.todo = 'estimate_and_apply'
     param_moco.mat_moco = 'mat_groups'
-    moco.moco(param_moco)
+    file_mat = moco.moco(param_moco)
 
     # create final mat folder
     sct.create_folder(mat_final)
@@ -320,8 +320,11 @@ def fmri_moco(param):
     sct.printv('\nCopy transformations...', param.verbose)
     for iGroup in range(nb_groups):
         for data in range(len(group_indexes[iGroup])):
-            sct.copy(os.path.join('mat_groups', 'mat.T' + str(iGroup) + ext_mat), mat_final + 'mat.T' + str(group_indexes[iGroup][data]) + ext_mat, verbose=param.verbose)
+            list_file = file_mat[:, iGroup]
+            for file in list_file:
+                sct.copy(file + ext_mat, file.replace('mat_groups', 'mat_final') + ext_mat)  # TODO: remove hardcode
 
+    # TODO: if g=1, no need to run the block below (already applied)
     # Apply moco on all fmri data
     sct.printv('\n-------------------------------------------------------------------------------', param.verbose)
     sct.printv('  Apply moco', param.verbose)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -41,7 +41,7 @@ class Param:
         self.fname_mask = ''
         self.mat_final = ''
         self.todo = ''
-        self.group_size = 3  # number of images averaged for 'dwi' method.
+        self.group_size = 1  # number of images averaged for 'dwi' method.
         self.spline_fitting = 0
         self.remove_temp_files = 1
         self.verbose = 1

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -49,7 +49,7 @@ class Param:
         self.poly = '2'  # degree of polynomial function for moco
         self.smooth = '2'  # smoothing sigma in mm
         self.gradStep = '1'  # gradientStep for searching algorithm
-        self.iter = '5'  # number of iterations
+        self.iter = '10'  # number of iterations
         self.metric = 'MeanSquares'  # metric: MI, MeanSquares, CC
         self.sampling = '0.2'  # sampling rate used for registration metric
         self.interp = 'spline'  # nn, linear, spline

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -17,7 +17,6 @@ import sys
 import os
 import time
 import math
-import shutil
 from tqdm import tqdm
 import numpy as np
 import sct_utils as sct
@@ -313,7 +312,7 @@ def fmri_moco(param):
         if param.group_size == 1:
             # copy to new file name instead of averaging (faster)
             # note: this is a bandage. Ideally we should skip this entire for loop if g=1
-            shutil.copy(file_data_merge_i + '.nii', file_data_mean + '.nii')
+            sct.copy(file_data_merge_i + '.nii', file_data_mean + '.nii')
         else:
             # Average Images
             sct.run(['sct_maths', '-i', file_data_merge_i + '.nii', '-o', file_data_mean + '.nii', '-mean', 't'], verbose=0)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -49,6 +49,7 @@ class Param:
         self.poly = '2'  # degree of polynomial function for moco
         self.smooth = '2'  # smoothing sigma in mm
         self.gradStep = '1'  # gradientStep for searching algorithm
+        self.iter = '5'  # number of iterations
         self.metric = 'MeanSquares'  # metric: MI, MeanSquares, CC
         self.sampling = '0.2'  # sampling rate used for registration metric
         self.interp = 'spline'  # nn, linear, spline
@@ -58,7 +59,7 @@ class Param:
         self.swapXY = 0
         self.bval_min = 100  # in case user does not have min bvalues at 0, set threshold (where csf disapeared).
         self.otsu = 0  # use otsu algorithm to segment dwi data for better moco. Value coresponds to data threshold. For no segmentation set to 0.
-        self.iterative_averaging = 1  # iteratively average target image for more robust moco
+        self.iterAvg = 1  # iteratively average target image for more robust moco
         self.num_target = '0'
 
     # update constructor with user's parameters
@@ -68,7 +69,15 @@ class Param:
             if len(object) < 2:
                 sct.printv('ERROR: Wrong usage.', 1, type='error')
             obj = object.split('=')
-            setattr(self, obj[0], obj[1])
+            # set type based on default param field
+            # isinstance(i, int)
+            # isinstance(f, float)
+            # isinstance(s, str)
+
+            field = obj[1]
+            if isinstance(getattr(self, obj[0]), int):
+                field = int(field)
+            setattr(self, obj[0], field)
 
 # PARSER
 # ==========================================================================================
@@ -104,10 +113,12 @@ def get_parser():
                       description="Advanced parameters. Assign value with \"=\"; Separate arguments with \",\"\n"
                                   "poly [int]: Degree of polynomial function used for regularization along Z. For no regularization set to 0. Default=" + param_default.poly + ".\n"
                                   "smooth [mm]: Smoothing kernel. Default=" + param_default.smooth + ".\n"
+                                  "iter [int]: Number of iterations. Default=" + param_default.iter + ".\n"
                                   "metric {MI, MeanSquares, CC}: Metric used for registration. Default=" + param_default.metric + ".\n"
                                   "gradStep [float]: Searching step used by registration algorithm. The higher the more deformation allowed. Default=" + param_default.gradStep + ".\n"
-                                  "sample [0-1]: Sampling rate used for registration metric. Default=" + param_default.sampling + ".\n"
-                                  "numTarget [int]: Target volume or group (starting with 0). Default=" + param_default.num_target + ".\n",
+                                  "sampling [0-1]: Sampling rate used for registration metric. Default=" + param_default.sampling + ".\n"
+                                  "numTarget [int]: Target volume or group (starting with 0). Default=" + param_default.num_target + ".\n"
+                                  "iterAvg [int]: Iterative averaging: Target volume is a weighted average of the previously-registered volumes. Default=" + str(param_default.iterAvg) + ".\n",
                       mandatory=False)
     parser.add_option(name='-ofolder',
                       type_value='folder_creation',

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -319,10 +319,15 @@ def fmri_moco(param):
     sct.printv('\nCopy transformations...', param.verbose)
     for iGroup in range(nb_groups):
         for data in range(len(group_indexes[iGroup])):
-            list_file = file_mat[:, iGroup]
-            for file in list_file:
-                sct.copy(file + ext_mat,
-                         mat_final + 'mat.T' + str(group_indexes[iGroup][data]).zfill(4) + ext_mat)
+            # fetch all file_mat_z for given t-group
+            list_file_mat_z = file_mat[:, iGroup]
+            # loop across file_mat_z and copy to mat_final folder
+            for file_mat_z in list_file_mat_z:
+                # we want to copy 'mat_groups/mat.ZXXXXTYYYYWarp.nii.gz' --> 'mat_final/mat.ZXXXXTYYYZWarp.nii.gz'
+                # Notice the Y->Z in the under the T index: the idea here is to use the single matrix from each group,
+                # and apply it to all images belonging to the same group.
+                sct.copy(file_mat_z + ext_mat,
+                         mat_final + file_mat_z[11:20] + 'T' + str(group_indexes[iGroup][data]).zfill(4) + ext_mat)
 
     # TODO: if g=1, no need to run the block below (already applied)
     if param.group_size == 1:

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -185,7 +185,7 @@ def main(args=None):
 
     # Copying input data to tmp folder and convert to nii
     sct.printv('\nCopying input data to tmp folder and convert to nii...', param.verbose)
-    convert(param.fname_data, os.path.join(path_tmp, "fmri.nii"))
+    convert(param.fname_data, os.path.join(path_tmp, "fmri.nii"), squeeze_data=False)
 
     # go to tmp folder
     curdir = os.getcwd()

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -6,7 +6,6 @@
 # ---------------------------------------------------------------------------------------
 # Copyright (c) 2013 Polytechnique Montreal <www.neuro.polymtl.ca>
 # Authors: Karun Raju, Tanguy Duval, Julien Cohen-Adad
-# Modified: 2014-10-06
 #
 # About the license: see the file LICENSE.TXT
 #########################################################################################
@@ -17,18 +16,14 @@ from __future__ import absolute_import, division
 
 import sys
 import os
-import getopt
 import time
 import math
-
 import numpy as np
-
 import sct_utils as sct
 import msct_moco as moco
 from sct_convert import convert
 from spinalcordtoolbox.image import Image
 from sct_image import split_data, concat_data
-# from sct_average_data_across_dimension import average_data_across_dimension
 from msct_parser import Parser
 
 
@@ -232,7 +227,6 @@ def fmri_moco(param):
     file_data = 'fmri'
     ext_data = '.nii'
     mat_final = 'mat_final/'
-    fsloutput = 'export FSLOUTPUTTYPE=NIFTI; '  # for faster processing, all outputs are in NIFTI
     ext_mat = 'Warp.nii.gz'  # warping field
 
     # Get dimensions of data

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -335,7 +335,7 @@ def pad_image(im, pad_x_i=0, pad_x_f=0, pad_y_i=0, pad_y_f=0, pad_z_i=0, pad_z_f
     return im_out
 
 
-def split_data(im_in, dim):
+def split_data(im_in, dim, squeeze_data=True):
     """
     Split data
     :param im_in: input image.
@@ -352,7 +352,10 @@ def split_data(im_in, dim):
         data = data[..., np.newaxis]
     # in case splitting along the last dim, make sure to remove the last dim to avoid singleton
     if dim + 1 == len(np.shape(data)):
-        do_reshape = True
+        if squeeze_data:
+            do_reshape = True
+        else:
+            do_reshape = False
     else:
         do_reshape = False
     # Split data into list
@@ -381,7 +384,7 @@ def concat_data(fname_in_list, dim, pixdim=None, squeeze_data=False):
     :return im_out: concatenated image
     """
     # WARNING: calling concat_data in python instead of in command line causes a non understood issue (results are different with both options)
-    from numpy import concatenate, expand_dims
+    # from numpy import concatenate, expand_dims
 
     dat_list = []
     data_concat_list = []
@@ -396,12 +399,12 @@ def concat_data(fname_in_list, dim, pixdim=None, squeeze_data=False):
     for i, fname in enumerate(fname_in_list):
         # if there is more than 100 images to concatenate, then it does it iteratively to avoid memory issue.
         if i != 0 and i % 100 == 0:
-            data_concat_list.append(concatenate(dat_list, axis=dim))
+            data_concat_list.append(np.concatenate(dat_list, axis=dim))
             im = Image(fname)
             dat = im.data
             # if image shape is smaller than asked dim, then expand dim
             if len(dat.shape) <= dim:
-                dat = expand_dims(dat, dim)
+                dat = np.expand_dims(dat, dim)
             dat_list = [dat]
             del im
             del dat
@@ -410,15 +413,15 @@ def concat_data(fname_in_list, dim, pixdim=None, squeeze_data=False):
             dat = im.data
             # if image shape is smaller than asked dim, then expand dim
             if len(dat.shape) <= dim:
-                dat = expand_dims(dat, dim)
+                dat = np.expand_dims(dat, dim)
             dat_list.append(dat)
             del im
             del dat
     if data_concat_list:
-        data_concat_list.append(concatenate(dat_list, axis=dim))
-        data_concat = concatenate(data_concat_list, axis=dim)
+        data_concat_list.append(np.concatenate(dat_list, axis=dim))
+        data_concat = np.concatenate(data_concat_list, axis=dim)
     else:
-        data_concat = concatenate(dat_list, axis=dim)
+        data_concat = np.concatenate(dat_list, axis=dim)
     # write file
     im_out = msct_image.empty_like(Image(fname_in_list[0]))
     im_out.data = data_concat

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -434,7 +434,8 @@ def concat_data(fname_in_list, dim, pixdim=None, squeeze_data=False):
     if pixdim is not None:
         im_out.hdr['pixdim'] = pixdim
 
-    if squeeze_data:
+    if squeeze_data and data_concat.shape[dim] == 1:
+        # remove the last dim if it is a singleton.
         im_out.data = data_concat.reshape(tuple([ x for (idx_shape, x) in enumerate(data_concat.shape) if idx_shape != dim]))
     else:
         im_out.data = data_concat

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -84,7 +84,7 @@ def get_parser():
     parser.usage.addSection('\nHeader operations:')
     parser.add_option(name="-copy-header",
                       type_value="file",
-                      description='Copy the header of the input image (specified in -i) to the destination image (specified here)',
+                      description='Copy the header of the source image (specified in -i) to the destination image (specified here)',
                       mandatory=False,
                       example='data_dest.nii.gz')
 
@@ -162,8 +162,12 @@ def main(args=None):
     elif "-copy-header" in arguments:
         im_in = Image(fname_in[0])
         im_dest = Image(arguments["-copy-header"])
-        im_dest.header = im_in.header
-        im_out = [im_dest]
+        im_dest_new = im_in.copy()
+        im_dest_new.data = im_dest.data.copy()
+        # im_dest.header = im_in.header
+        im_dest_new.absolutepath = im_dest.absolutepath
+        im_out = [im_dest_new]
+        fname_out = arguments["-copy-header"]
 
     elif '-display-warp' in arguments:
         im_in = fname_in[0]

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -371,12 +371,13 @@ def split_data(im_in, dim):
     return im_out_list
 
 
-def concat_data(fname_in_list, dim, pixdim=None):
+def concat_data(fname_in_list, dim, pixdim=None, squeeze_data=False):
     """
     Concatenate data
     :param im_in_list: list of Images or image filenames
     :param dim: dimension: 0, 1, 2, 3.
     :param pixdim: pixel resolution to join to image header
+    :param squeeze_data: bool: if True, remove the last dim if it is a singleton.
     :return im_out: concatenated image
     """
     # WARNING: calling concat_data in python instead of in command line causes a non understood issue (results are different with both options)
@@ -429,6 +430,11 @@ def concat_data(fname_in_list, dim, pixdim=None):
 
     if pixdim is not None:
         im_out.hdr['pixdim'] = pixdim
+
+    if squeeze_data:
+        im_out.data = data_concat.reshape(tuple([ x for (idx_shape, x) in enumerate(data_concat.shape) if idx_shape != dim]))
+    else:
+        im_out.data = data_concat
 
     return im_out
 

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -347,16 +347,24 @@ def split_data(im_in, dim):
     # Parse file name
     # Open first file.
     data = im_in.data
-    if dim + 1 > len(np.shape(data)):  # in case input volume is 3d and dim=t
+    # in case input volume is 3d and dim=t, create new axis
+    if dim + 1 > len(np.shape(data)):
         data = data[..., np.newaxis]
+    # in case splitting along the last dim, make sure to remove the last dim to avoid singleton
+    if dim + 1 == len(np.shape(data)):
+        do_reshape = True
+    else:
+        do_reshape = False
     # Split data into list
     data_split = np.array_split(data, data.shape[dim], dim)
     # Write each file
     im_out_list = []
     for idx_img, dat in enumerate(data_split):
         im_out = msct_image.empty_like(im_in)
-        # im_out.data = dat.reshape(tuple([ x for (idx_shape, x) in enumerate(data.shape) if idx_shape != dim]))
-        im_out.data = dat
+        if do_reshape:
+            im_out.data = dat.reshape(tuple([ x for (idx_shape, x) in enumerate(data.shape) if idx_shape != dim]))
+        else:
+            im_out.data = dat
         im_out.absolutepath = sct.add_suffix(im_in.absolutepath, "_{}{}".format(dim_list[dim].upper(), str(idx_img).zfill(4)))
         im_out_list.append(im_out)
 

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -355,7 +355,8 @@ def split_data(im_in, dim):
     im_out_list = []
     for idx_img, dat in enumerate(data_split):
         im_out = msct_image.empty_like(im_in)
-        im_out.data = dat.reshape(tuple([ x for (idx_shape,x) in enumerate(data.shape) if idx_shape != dim]))
+        # im_out.data = dat.reshape(tuple([ x for (idx_shape, x) in enumerate(data.shape) if idx_shape != dim]))
+        im_out.data = dat
         im_out.absolutepath = sct.add_suffix(im_in.absolutepath, "_{}{}".format(dim_list[dim].upper(), str(idx_img).zfill(4)))
         im_out_list.append(im_out)
 

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -372,7 +372,7 @@ def main(args = None):
 
     # display message
     if data_out is not None:
-        sct.display_viewer_syntax([fname_out])
+        sct.display_viewer_syntax([fname_out], verbose=verbose)
     else:
         printv('\nDone! File created: ' + fname_out, verbose, 'info')
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -1093,10 +1093,13 @@ def delete_nifti(fname_in):
         os.system('rm ' + os.path.join(path_in, file_in + '.nii.gz'))
 
 
-#=======================================================================================================================
-# get_interpolation: get correct interpolation field depending on program used. Supported programs: ants, flirt, WarpImageMultiTransform
-#=======================================================================================================================
 def get_interpolation(program, interp):
+    """
+    Get syntax on interpolation field depending on program. Supported programs: ants, flirt, WarpImageMultiTransform
+    :param program:
+    :param interp:
+    :return:
+    """
     # TODO: check if field and program exists
     interp_program = ''
     # FLIRT
@@ -1108,7 +1111,8 @@ def get_interpolation(program, interp):
         elif interp == 'spline':
             interp_program = ' -interp spline'
     # ANTs
-    elif program == 'ants' or program == 'ants_affine' or program == 'isct_antsApplyTransforms' or program == 'isct_antsSliceRegularizedRegistration':
+    elif program == 'ants' or program == 'ants_affine' or program == 'isct_antsApplyTransforms' \
+            or program == 'isct_antsSliceRegularizedRegistration' or program == 'isct_antsRegistration':
         if interp == 'nn':
             interp_program = ' -n NearestNeighbor'
         elif interp == 'linear':


### PR DESCRIPTION
Currently, sct_fmri_moco is designed such that the input image is assumed to be in axial orientation (i.e. 3rd dimension is S-I), and the algorithm estimates a set of Tx,Ty for each slice, regularized using polynom functions along the S-I direction.

However, for images acquired sagitally (or coronally), this approach does not work anymore. Beyond the simple orientation issue described in #1983, the type of motion-related corruption is not addressed by the current algorithm. More specifically, if motion occurs between sagittal slices, then the cord is non-linearly distorted in the axial plane and a simple translation within the axial plane is not sufficient. This is shown in the animation below. Without motion correction (left), a few slices are translated in the AP direction, leaving ugly distortion of the cord in the axial plane. With motion correction (right), the algorithm tries to find an average translation, but this is of course not sufficient for this type of motion.

![anim](https://user-images.githubusercontent.com/2482071/43677483-8cbbfd4e-97d0-11e8-8ba1-3d035b9fa283.gif)

The implemented solution is to split the data along Z (R-L dimension) and use `antsRegistration` in 2D mode for each slice independently. For now we use affine transfo, which is fast and robust, but later we could investigate the use of other transfo. What helps in particular is to use a mask to focus on a region of interest for registration (esp. because motion is non-affine). See below a comparison without (left) and with the new moco algorithm (right):

![anim](https://user-images.githubusercontent.com/2482071/45380000-8d671180-b5cf-11e8-8ea2-345aba7a8439.gif)

This PR also provides a few other fixes, refactoring and improvements (runs faster).

Fixes #1984, Fixes #820, Fixes #2017, Fixes #1878