### PR TITLE
sct_straighten_spinalcord: Fixed AttributeError related to conversion of numpy array to list

### DIFF
--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -449,7 +449,7 @@ class SpinalCordStraightener(object):
                     coord = discs_input_image.getNonZeroCoordinates(sorting='z', reverse_coord=True)
                     coord_physical = []
                     for c in coord:
-                        c_p = discs_input_image.transfo_pix2phys([[c.x, c.y, c.z]])[0]
+                        c_p = discs_input_image.transfo_pix2phys([[c.x, c.y, c.z]]).tolist()[0]
                         c_p.append(c.value)
                         coord_physical.append(c_p)
                     centerline.compute_vertebral_distribution(coord_physical)
@@ -459,7 +459,7 @@ class SpinalCordStraightener(object):
                     coord = discs_ref_image.getNonZeroCoordinates(sorting='z', reverse_coord=True)
                     coord_physical = []
                     for c in coord:
-                        c_p = discs_ref_image.transfo_pix2phys([[c.x, c.y, c.z]])[0]
+                        c_p = discs_ref_image.transfo_pix2phys([[c.x, c.y, c.z]]).tolist()[0]
                         c_p.append(c.value)
                         coord_physical.append(c_p)
                     centerline_straight.compute_vertebral_distribution(coord_physical)


### PR DESCRIPTION
**Context:**
`transfo_pix2phys` returns a numpy array while the following lines of `sct_straighten_spinalcord` are expecting a list:
- https://github.com/neuropoly/spinalcordtoolbox/blob/master/scripts/sct_straighten_spinalcord.py#L452
- https://github.com/neuropoly/spinalcordtoolbox/blob/master/scripts/sct_straighten_spinalcord.py#L462

It leads to a AttributeError, as illustrated in the issue #2023.

**Proposed solution:**
Replace:
```c_p = discs_input_image.transfo_pix2phys([[c.x, c.y, c.z]])[0]```
by:
```c_p = discs_input_image.transfo_pix2phys([[c.x, c.y, c.z]]).tolist()[0]```

***To reproduce***
```
cd example_data/t2
sct_get_centerline -i t2.nii.gz -c t2
sct_label_utils -i t2.nii.gz -create-viewer 2,3,4,5,6,7,8,9,10
sct_straighten_spinalcord -i t2.nii.gz -s t2_centerline_optic.nii.gz -dest $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz -ldisc_input labels.nii.gz -ldisc_dest $SCT_DIR/data/PAM50/template/PAM50_label_discPosterior.nii.gz -disable-straight2curved -param threshold_distance=1
```