### PR TITLE
sct_propseg: Reordered variable assignment

### DIFF
--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -33,7 +33,6 @@ def _call_viewer_centerline(fname_in, interslice_gap=20.0):
     params.starting_slice = 'top'
 
     im_mask_viewer = msct_image.zeros_like(im_data)
-    im_mask_viewer.absolutepath = sct.add_suffix(fname_in, '_viewer')
     controller = launch_centerline_dialog(im_data, im_mask_viewer, params)
     fname_labels_viewer = sct.add_suffix(fname_in, '_viewer')
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -538,9 +538,9 @@ def propseg(img_input, options_dict):
         im_data = Image(fname_data_propseg)
 
         im_mask_viewer = msct_image.zeros_like(im_data)
-        im_mask_viewer.absolutepath = sct.add_suffix(fname_data_propseg, '_labels_viewer')
+        # im_mask_viewer.absolutepath = sct.add_suffix(fname_data_propseg, '_labels_viewer')
         controller = launch_centerline_dialog(im_data, im_mask_viewer, params)
-        fname_labels_viewer = im_mask_viewer.absolutepath
+        fname_labels_viewer = sct.add_suffix(fname_data_propseg, '_labels_viewer')
 
         if not controller.saved:
             sct.log.error('The viewer has been closed before entering all manual points. Please try again.')


### PR DESCRIPTION
This PR fixes an IOError that appears when using `-init-centerline viewer` in `sct_propseg`. 

Workaround: assign output label file after running "controller = launch_centerline_dialog().

Workaround for #2037 (does not "really" fixes the cause of the problem)