### PR TITLE
msct_nurbs: fixes singular matrix error

### DIFF
--- a/scripts/msct_nurbs.py
+++ b/scripts/msct_nurbs.py
@@ -559,7 +559,6 @@ class NURBS():
         global Nik_temp
         m = len(P_x)
 
-
         # Calcul des chords
         di = 0.0
         for k in range(m - 1):

--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -270,7 +270,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             PC_z = [p[2] for p in PC]
 
         import matplotlib
-        # matplotlib.use('Agg')  # prevent display figure
+        matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
         if not twodim:
             plt.figure(1)
@@ -292,7 +292,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.xlabel('z')
             plt.ylabel('y')
             plt.legend(["centerline", "NURBS", "control points"],loc=4)
-            plt.show()
+            # plt.show()
         else:
             plt.figure(1)
             plt.plot(y, x, 'r.')
@@ -302,7 +302,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.xlabel('y')
             plt.ylabel('x')
             plt.legend(["centerline", "NURBS", "control points"])
-            plt.show()
+            # plt.show()
         plt.savefig(os.path.join(path_qc, 'b_spline_nurbs.png'))
         plt.close()
 

--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -303,7 +303,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.ylabel('x')
             plt.legend(["centerline", "NURBS", "control points"])
             # plt.show()
-        plt.savefig(os.path.join(path_qc, 'b_spline_nurbs.png'))
+        plt.savefig(os.path.join(path_qc, 'fig_b_spline_nurbs.png'))
         plt.close()
 
     if not twodim:
@@ -542,7 +542,10 @@ def smoothing_window(x, window_len=11, window='hanning', verbose = 0, robust=0, 
 
     # Display smoothing
     if verbose == 2:
+        import matplotlib
+        matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
+        import random  # to prevent overwriting of figure
         from copy import copy
         z = [i + size_padding - remove_edge_points for i in range(x.shape[0])]
         z_extended = [i for i in range(x_extended.shape[0])]
@@ -556,7 +559,8 @@ def smoothing_window(x, window_len=11, window='hanning', verbose = 0, robust=0, 
         plt.xlabel('z')
         plt.ylabel('x')
         plt.legend([pltx_ext, pltx, pltx_fit], ['Extended', 'Normal', 'Smoothed'])
-        plt.show()
+        plt.savefig('fig_smoothing_window_'+str(random.randint(100, 100000))+'.png')
+        plt.close()
 
     return y
 

--- a/scripts/msct_smooth.py
+++ b/scripts/msct_smooth.py
@@ -270,7 +270,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             PC_z = [p[2] for p in PC]
 
         import matplotlib
-        matplotlib.use('Agg')  # prevent display figure
+        # matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
         if not twodim:
             plt.figure(1)
@@ -279,19 +279,19 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             plt.plot(z, x, 'r.')
             plt.plot(z_fit, x_fit)
             plt.plot(PC_z, PC_x, 'go')
-            plt.title("X")
             # ax.set_aspect('equal')
             plt.xlabel('z')
             plt.ylabel('x')
+            plt.legend(["centerline", "NURBS", "control points"])
             #ay = plt.subplot(212)
             plt.subplot(212)
             plt.plot(z, y, 'r.')
             plt.plot(z_fit, y_fit)
             plt.plot(PC_z, PC_y, 'go')
-            plt.title("Y")
             # ay.set_aspect('equal')
             plt.xlabel('z')
             plt.ylabel('y')
+            plt.legend(["centerline", "NURBS", "control points"],loc=4)
             plt.show()
         else:
             plt.figure(1)
@@ -301,6 +301,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
             # ax.set_aspect('equal')
             plt.xlabel('y')
             plt.ylabel('x')
+            plt.legend(["centerline", "NURBS", "control points"])
             plt.show()
         plt.savefig(os.path.join(path_qc, 'b_spline_nurbs.png'))
         plt.close()

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -156,7 +156,7 @@ def run_main():
 
     if method == 'viewer':
         fname_labels_viewer = _call_viewer_centerline(fname_in=fname_data, interslice_gap=interslice_gap)
-        centerline_filename = extract_centerline(fname_labels_viewer, remove_temp_files=True, algo_fitting='nurbs', nurbs_pts_number=8000)
+        centerline_filename = extract_centerline(fname_labels_viewer, remove_temp_files=remove_temp_files, algo_fitting='nurbs', nurbs_pts_number=8000)
 
     else:
         # condition on verbose when using OptiC

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -99,7 +99,7 @@ def get_parser():
                       type_value="multiple_choice",
                       description="1: display on, 0: display off (default)",
                       mandatory=False,
-                      example=["0", "1"],
+                      example=["0", "1", "2"],
                       default_value="1")
     return parser
 
@@ -156,7 +156,8 @@ def run_main():
 
     if method == 'viewer':
         fname_labels_viewer = _call_viewer_centerline(fname_in=fname_data, interslice_gap=interslice_gap)
-        centerline_filename = extract_centerline(fname_labels_viewer, remove_temp_files=remove_temp_files, algo_fitting='nurbs', nurbs_pts_number=8000)
+        centerline_filename = extract_centerline(fname_labels_viewer, remove_temp_files=remove_temp_files,
+                                                 verbose=verbose, algo_fitting='nurbs', nurbs_pts_number=8000)
 
     else:
         # condition on verbose when using OptiC

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -505,7 +505,7 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
     # extract centerline and smooth it
     if use_phys_coord:
         # fit centerline, smooth it and return the first derivative (in physical space)
-        x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=nurbs_pts_number, phys_coordinates=True, verbose=1, all_slices=False)
+        x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=nurbs_pts_number, phys_coordinates=True, verbose=verbose, all_slices=False)
         centerline = Centerline(x_centerline_fit, y_centerline_fit, z_centerline, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv)
 
         # average centerline coordinates over slices of the image
@@ -521,32 +521,32 @@ def extract_centerline(fname_segmentation, remove_temp_files, verbose = 0, algo_
         # fit centerline, smooth it and return the first derivative (in voxel space but FITTED coordinates)
         x_centerline_voxel, y_centerline_voxel, z_centerline_voxel, x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = smooth_centerline('segmentation_RPI.nii.gz', algo_fitting=algo_fitting, type_window=type_window, window_length=window_length, nurbs_pts_number=nurbs_pts_number, phys_coordinates=False, verbose=verbose, all_slices=True)
 
-    if verbose == 2:
-        import matplotlib.pyplot as plt
-
-        # Creation of a vector x that takes into account the distance between the labels
-        nz_nonz = len(z_centerline_voxel)
-        x_display = [0 for i in range(x_centerline_voxel.shape[0])]
-        y_display = [0 for i in range(y_centerline_voxel.shape[0])]
-        for i in range(0, nz_nonz, 1):
-            x_display[int(z_centerline_voxel[i] - z_centerline_voxel[0])] = x_centerline[i]
-            y_display[int(z_centerline_voxel[i] - z_centerline_voxel[0])] = y_centerline[i]
-
-        plt.figure(1)
-        plt.subplot(2, 1, 1)
-        plt.plot(z_centerline_voxel, x_display, 'ro')
-        plt.plot(z_centerline_voxel, x_centerline_voxel)
-        plt.xlabel("Z")
-        plt.ylabel("X")
-        plt.title("x and x_fit coordinates")
-
-        plt.subplot(2, 1, 2)
-        plt.plot(z_centerline_voxel, y_display, 'ro')
-        plt.plot(z_centerline_voxel, y_centerline_voxel)
-        plt.xlabel("Z")
-        plt.ylabel("Y")
-        plt.title("y and y_fit coordinates")
-        plt.show()
+    # if verbose == 2:
+    #     import matplotlib.pyplot as plt
+    #
+    #     # Creation of a vector x that takes into account the distance between the labels
+    #     nz_nonz = len(z_centerline_voxel)
+    #     x_display = [0 for i in range(x_centerline_voxel.shape[0])]
+    #     y_display = [0 for i in range(y_centerline_voxel.shape[0])]
+    #     for i in range(0, nz_nonz, 1):
+    #         x_display[int(z_centerline_voxel[i] - z_centerline_voxel[0])] = x_centerline[i]
+    #         y_display[int(z_centerline_voxel[i] - z_centerline_voxel[0])] = y_centerline[i]
+    #
+    #     plt.figure(1)
+    #     plt.subplot(2, 1, 1)
+    #     plt.plot(z_centerline_voxel, x_display, 'ro')
+    #     plt.plot(z_centerline_voxel, x_centerline_voxel)
+    #     plt.xlabel("Z")
+    #     plt.ylabel("X")
+    #     plt.title("x and x_fit coordinates")
+    #
+    #     plt.subplot(2, 1, 2)
+    #     plt.plot(z_centerline_voxel, y_display, 'ro')
+    #     plt.plot(z_centerline_voxel, y_centerline_voxel)
+    #     plt.xlabel("Z")
+    #     plt.ylabel("Y")
+    #     plt.title("y and y_fit coordinates")
+    #     plt.show()
 
     # Create an image with the centerline
     min_z_index, max_z_index = int(np.round(min(z_centerline_voxel))), int(np.round(max(z_centerline_voxel)))


### PR DESCRIPTION
This PR attends to fix #2038 (which fixes #1863 and fixes #2031 ) by intercepting the exception caused by a singular matrix. That way the testing of the number of control points can continue and the NURBS fitting can be done even if a singular matrix is encountered.
Thus, the hanning filtering will not be necessary anymore (if the number of slices if sufficient). Moving away from the hanning filtering is something @benjamindeleener suggested when discussing this problem.
However, no change in the method has been done, should I search for methods to improve the NURBS fitting ?