### PR TITLE
sct_fmri_moco: Fixed regression bug related to the use of a mask

### DIFF
--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -45,13 +45,12 @@ def moco(param):
     folder_mat = param.mat_moco  # output folder of mat file
     todo = param.todo
     suffix = param.suffix
-    #file_schedule = param.file_schedule
     verbose = param.verbose
+
+    # other parameters
     ext = '.nii'
+    file_mask = 'mask.nii'
 
-    # get path of the toolbox
-
-    # sct.printv(arguments)
     sct.printv('\nInput parameters:', param.verbose)
     sct.printv('  Input file ............' + file_data, param.verbose)
     sct.printv('  Reference file ........' + file_target, param.verbose)
@@ -77,12 +76,8 @@ def moco(param):
     sct.printv('\nCopy file_target to a temporary file...', verbose)
     sct.copy(file_target + ext, 'target.nii')
     file_target = 'target'
-    if not param.fname_mask == '':
-        file_mask = 'mask.nii'
-        convert(param.fname_mask, file_mask, squeeze_data=False)
-        im_maskz_list = [file_mask]  # use a list with single element if not sagittal. Otherwise, will be updated.
 
-        # If scan is sagittal, split src and target along Z (slice)
+    # If scan is sagittal, split src and target along Z (slice)
     if param.is_sagittal:
         dim_sag = 2  # TODO: find it
         # z-split data (time series)
@@ -108,12 +103,17 @@ def moco(param):
         file_mat = np.chararray([nz, nt],
                                 itemsize=50)  # itemsize=50 is to accomodate relative path to matrix file name.
 
+    # axial orientation
     else:
         file_data_splitZ = [file_data + ext]  # TODO: make it absolute like above
         file_target_splitZ = [file_target + ext]  # TODO: make it absolute like above
         # initialize file list for output matrices
         file_mat = np.chararray([1, nt],
                                 itemsize=50)  # itemsize=50 is to accomodate relative path to matrix file name.
+        # deal with mask
+        if not param.fname_mask == '':
+            convert(param.fname_mask, file_mask, squeeze_data=False)
+            im_maskz_list = [Image(file_mask)]  # use a list with single element
 
     # Loop across file list, where each file is either a 2D volume (if sagittal) or a 3D volume (otherwise)
     # file_mat = tuple([[[] for i in range(nt)] for i in range(nz)])

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -168,8 +168,8 @@ def moco(param):
         # Replace failed transformation with the closest good one
         fT = [i for i, j in enumerate(failed_transfo) if j == 1]
         gT = [i for i, j in enumerate(failed_transfo) if j == 0]
-        for it in enumerate(fT):
-            abs_dist = [np.abs(gT[i] - fT[it]) for i in enumerate(gT)]
+        for it in range(len(fT)):
+            abs_dist = [np.abs(gT[i] - fT[it]) for i in range(len(gT))]
             if not abs_dist == []:
                 index_good = abs_dist.index(min(abs_dist))
                 sct.printv('  transfo #' + str(fT[it]) + ' --> use transfo #' + str(gT[index_good]), verbose)
@@ -177,10 +177,10 @@ def moco(param):
                 sct.copy(file_mat[iz][gT[index_good]] + 'Warp.nii.gz', file_mat[iz][fT[it]] + 'Warp.nii.gz')
                 # apply transformation
                 sct.run(["sct_apply_transfo",
-                 "-i", file_data_splitT_num[fT[it]] + ".nii",
+                 "-i", file_data_splitZ_splitT[fT[it]],
                  "-d", file_target + ".nii",
                  "-w", file_mat[iz][fT[it]] + 'Warp.nii.gz',
-                 "-o", file_data_splitZ_splitT_moco[fT[it]] + '.nii',
+                 "-o", file_data_splitZ_splitT_moco[fT[it]],
                  "-x", param.interp], verbose=0)
             else:
                 # exit program if no transformation exists.

--- a/scripts/msct_moco.py
+++ b/scripts/msct_moco.py
@@ -176,12 +176,11 @@ def moco(param):
                 # copy transformation
                 sct.copy(file_mat[iz][gT[index_good]] + 'Warp.nii.gz', file_mat[iz][fT[it]] + 'Warp.nii.gz')
                 # apply transformation
-                sct.run(["sct_apply_transfo",
-                 "-i", file_data_splitZ_splitT[fT[it]],
-                 "-d", file_target + ".nii",
-                 "-w", file_mat[iz][fT[it]] + 'Warp.nii.gz',
-                 "-o", file_data_splitZ_splitT_moco[fT[it]],
-                 "-x", param.interp], verbose=0)
+                sct_apply_transfo.main(args=['-i', file_data_splitZ_splitT[fT[it]],
+                                             '-d', file_target + ".nii",
+                                             '-w', file_mat[iz][fT[it]] + 'Warp.nii.gz',
+                                             '-o', file_data_splitZ_splitT_moco[fT[it]],
+                                             '-x', param.interp])
             else:
                 # exit program if no transformation exists.
                 sct.printv('\nERROR in ' + os.path.basename(__file__) + ': No good transformation exist. Exit program.\n', verbose, 'error')

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -47,7 +47,7 @@ class Param:
         self.plot_graph = 0
         self.suffix = '_moco'
         self.poly = '2'  # degree of polynomial function for moco
-        self.smooth = '2'  # smoothing sigma in mm
+        self.smooth = '0'  # smoothing sigma in mm
         self.gradStep = '1'  # gradientStep for searching algorithm
         self.iter = '10'  # number of iterations
         self.metric = 'MeanSquares'  # metric: MI, MeanSquares, CC


### PR DESCRIPTION
The main purpose of this PR is to fix a regression bug introduced in v3.2.6, which appears when using a mask with `sct_fmri_moco` and `sct_dmri_moco` (Fixes #2045)

It also fixes another regression bug (Fixes #2046)
