### PR TITLE
sct_extract_metric: Do not zero negative values

### DIFF
--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -169,10 +169,11 @@ sct_register_multimodal -i t1w.nii.gz -d mt1_crop.nii.gz -param step=1,type=im,a
 # Compute MTsat
 # Tips: Check your TR and Flip Angle from the Dicom data
 sct_compute_mtsat -mt mt1_crop.nii.gz -pd mt0_reg.nii.gz -t1 t1w_reg.nii.gz -trmt 30 -trpd 30 -trt1 15 -famt 9 -fapd 9 -fat1 15
-# Extract MTR, T1 and MTsat within the white matter between C2 and C5
-sct_extract_metric -i mtr.nii.gz -method map -o mtr_in_wm.txt -l 51 -vert 2:5
-sct_extract_metric -i mtsat.nii.gz -method map -o mtsat_in_wm.txt -l 51 -vert 2:5
-sct_extract_metric -i t1map.nii.gz -method map -o t1_in_wm.txt -l 51 -vert 2:5
+# Extract MTR, T1 and MTsat within the white matter between C2 and C5.
+# Tips: Here we use "-discard-neg-val 1" to discard inconsistent negative values in MTR calculation which are caused by noise.
+sct_extract_metric -i mtr.nii.gz -method map -o mtr_in_wm.txt -l 51 -vert 2:5 -discard-neg-val 1
+sct_extract_metric -i mtsat.nii.gz -method map -o mtsat_in_wm.txt -l 51 -vert 2:5 -discard-neg-val 1
+sct_extract_metric -i t1map.nii.gz -method map -o t1_in_wm.txt -l 51 -vert 2:5 -discard-neg-val 1
 # Bring MTR to template space (e.g. for group mapping)
 sct_apply_transfo -i mtr.nii.gz -d $SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz -w warp_mt2template.nii.gz
 # Go back to root folder
@@ -206,7 +207,7 @@ sct_warp_template -d dwi_moco_mean.nii.gz -w warp_template2dmri.nii.gz
 # Tips: The flag -method "restore" allows you to estimate the tensor with robust fit (see: sct_dmri_compute_dti -h)
 sct_dmri_compute_dti -i dmri_crop_moco.nii.gz -bval bvals.txt -bvec bvecs.txt
 # Compute FA within right and left lateral corticospinal tracts from slices 2 to 14 using weighted average method
-sct_extract_metric -i dti_FA.nii.gz -z 2:14 -method wa -l 4,5 -o fa_in_cst.txt
+sct_extract_metric -i dti_FA.nii.gz -z 2:14 -method wa -l 4,5 -o fa_in_cst.txt -discard-neg-val 1
 # Bring metric to template space (e.g. for group mapping)
 sct_apply_transfo -i dti_FA.nii.gz -d $SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz -w warp_dmri2template.nii.gz
 # Go back to root folder

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -362,10 +362,12 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
 
     # Change metric data type into floats for future manipulations (normalization)
     data = np.float64(data)
-    data[np.isneginf(data)] = 0.0
-    # data[data < 0.0] = 0.0
-    data[np.isnan(data)] = 0.0
-    data[np.isposinf(data)] = np.nanmax(data)
+    # loop across labels and set voxel to zero if...
+    for i_label in range(nb_labels):
+        labels[i_label][np.isneginf(data)] = 0  # ...data voxel is -inf
+        labels[i_label][np.isnan(data)] = 0  # ...data voxel is nan
+        labels[i_label][data < 0.0] = 0  # ...data voxel is negative
+        labels[i_label][np.isposinf(data)] = 0  # ...data voxel is +inf
 
     # Get dimensions of data and labels
     nx, ny, nz = data.shape

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -363,7 +363,7 @@ def main(fname_data, path_label, method, slices_of_interest, vertebral_levels, f
     # Change metric data type into floats for future manipulations (normalization)
     data = np.float64(data)
     data[np.isneginf(data)] = 0.0
-    data[data < 0.0] = 0.0
+    # data[data < 0.0] = 0.0
     data[np.isnan(data)] = 0.0
     data[np.isposinf(data)] = np.nanmax(data)
 

--- a/testing/test_sct_extract_metric.py
+++ b/testing/test_sct_extract_metric.py
@@ -21,7 +21,7 @@ def init(param_test):
     """
     # initialization
     default_args = ['-i mt/mtr.nii.gz -f mt/label/atlas -method wa -vert 4:5 -l 51 -o quantif_mtr.pickle']
-    param_test.mtr_groundtruth = 32.7919  # ground truth value
+    param_test.mtr_groundtruth = 32.6404  # ground truth value
     param_test.threshold_diff = 0.001  # threshold for computing difference between result and ground truth
 
     # assign default params


### PR DESCRIPTION
`sct_extract_metric` function currently assumes that metrics are positive (see: https://github.com/neuropoly/spinalcordtoolbox/blob/master/scripts/sct_extract_metric.py#L366) and there is no good reason for doing that. This PR now enables negative metrics and introduces a new flag `-discard-neg-val` to enable/disable negative values. Default=0.

Fixes #2048
