### PR TITLE
sct_deepseg_sc/lesion -- ValueError and IndexError fixes

### DIFF
--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -47,7 +47,7 @@ def get_parser():
                       example="t1.nii.gz")
     parser.add_option(name="-c",
                       type_value="multiple_choice",
-                      description="type of image contrast. For 't2_like' contrast images, a specific model for images with axial orientation is available: 't2_ax'.",
+                      description="type of image contrast. \nt2: T2w scan with isotropic or anisotropic resolution. \nt2_ax: T2w scan with axial orientation and thick slices. \nt2s: T2*w scan with axial orientation and thick slices.",
                       mandatory=True,
                       example=['t2', 't2_ax', 't2s'])
     parser.add_option(name="-centerline",

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -358,7 +358,7 @@ def main():
                                             ctr_algo=ctr_algo, ctr_file=manual_centerline_fname, brain_bool=brain_bool,
                                             remove_temp_files=remove_temp_files, verbose=verbose)
 
-    sct.display_viewer_syntax([fname_image, os.path.join(output_folder, fname_seg)], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    sct.display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
 if __name__ == "__main__":

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -47,7 +47,7 @@ def get_parser():
                       example="t1.nii.gz")
     parser.add_option(name="-c",
                       type_value="multiple_choice",
-                      description="type of image contrast.",
+                      description="type of image contrast. For 't2_like' contrast images, a specific model for images with axial orientation is available: 't2_ax'.",
                       mandatory=True,
                       example=['t2', 't2_ax', 't2s'])
     parser.add_option(name="-centerline",

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -799,8 +799,6 @@ def main():
     contrast_type = arguments['-c']
 
     ctr_algo = arguments["-centerline"]
-    if "-centerline" not in args and contrast_type == 't1':
-        ctr_algo = 'cnn'
 
     if "-brain" not in args:
         if contrast_type in ['t2s', 'dwi']:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -383,6 +383,10 @@ def heatmap(filename_in, filename_out, model, patch_shape, mean_train, std_train
         data[:, :, zz][np.where(data[:, :, zz] < 0.5)] = 0
         data[:, :, zz] = distance_transform_edt(data[:, :, zz])
 
+    if not np.any(data):
+        sct.log.error('\nSpinal cord was not detected using "-centerline cnn". Please try another "-centerline" method.\n')
+        sys.exit(1)
+
     im_out.data = data
     im_out.save(filename_out)
     del im_out
@@ -817,7 +821,7 @@ def main():
         output_folder = arguments["-ofolder"]
 
     if ctr_algo == 'manual' and "-file_centerline" not in args:
-		sct.log.error('Please use the flag -file_centerline to indicate the centerline filename.')
+		sct.log.warning('Please use the flag -file_centerline to indicate the centerline filename.')
 		sys.exit(1)
     
     if "-file_centerline" in args:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -574,7 +574,7 @@ def post_processing_slice_wise(z_slice, x_cOm, y_cOm):
     """Keep the largest connected obejct per z_slice and fill little holes."""
     labeled_obj, num_obj = label(z_slice)
     if num_obj > 1:
-        if x_cOm is None:  # slice 0
+        if x_cOm is None or np.isnan(x_cOm):  # slice 0 or empty slice
             z_slice = (labeled_obj == (np.bincount(labeled_obj.flat)[1:].argmax() + 1))
         else:
             idx_z_minus_1 = np.bincount(labeled_obj.flat)[1:].argmax() + 1

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -848,7 +848,7 @@ def main():
     if path_qc is not None:
         generate_qc(fname_image, fname_seg, args, os.path.abspath(path_qc))
 
-    sct.display_viewer_syntax([fname_image, os.path.join(output_folder, fname_seg)], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    sct.display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR aimed at fixing some ValueError or IndexError errors that have been reported to occur when using `sct_deepseg_sc` or `sct_deepseg_lesion`.

## #2016
**To reproduce the error:**
```
cd example_data/mt
sct_image -i mt1.nii.gz -split z
sct_deepseg_sc -i mt1_Z0005.nii.gz -c t2 -centerline cnn
```

**Error:**
```
charley@charley:~/data/example_data/mt$ sct_deepseg_sc -i mt1_Z0005.nii.gz -c t2 -centerline cnn

--
Spinal Cord Toolbox (cg_deepseg_valueError_indexError_i1921_i2015_i2016/9d9b320757fc4a1db5bac3f706a01817c6b351c7)
Running /home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py -i mt1_Z0005.nii.gz -c t2 -centerline cnn
/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/h5py/__init__.py:34: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters

Method:
	Centerline algorithm: cnn
	Assumes brain section included in the image: True
	Dimension of the segmentation kernel convolutions: 2d

Creating temporary folder...
cp mt1_Z0005.nii.gz /tmp/sct-20181108144431.270174-WGI6gM
Reorient the image to RPI, if necessary...
Resample the image to 0.5 mm isotropic resolution...
/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/nipy/io/files.py:145: FutureWarning: Default `strict` currently False; this will change to True in a future version of nipy
  ni_img = nipy2nifti(img, data_dtype = io_dtype)
Finding the spinal cord centerline...
WARNING: To avoid intensity overflow due to convertion to uint8, intensity will be rescaled to the maximum quantization scale.
Traceback (most recent call last):
  File "/home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py", line 853, in <module>
    main()
  File "/home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py", line 844, in main
    remove_temp_files=remove_temp_files, verbose=verbose)
  File "/home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py", line 677, in deep_segmentation_spinalcord
    centerline_fname=file_ctr)
  File "/home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py", line 478, in find_centerline
    brain_bool=brain_bool)
  File "/home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py", line 391, in heatmap
    z_max = np.max(list(set(np.where(data)[2])))
  File "/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/numpy/core/fromnumeric.py", line 2334, in amax
    initial=initial)
  File "/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/numpy/core/fromnumeric.py", line 83, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
ValueError: zero-size array to reduction operation maximum which has no identity
Sentry is attempting to send 1 pending error messages
Waiting up to 10 seconds
Press Ctrl-C to quit
Total processing time: 0 min 6 s
```

It should be noted that this error did not occur when using `-centerline svm`. Also, this is not related to the fact that the input image is a single axial slice, since recent improvements (see [PR_2012](https://github.com/neuropoly/spinalcordtoolbox/pull/2012)) allow to handle this kind of input.
For instance, the below command works:
```
sct_deepseg_sc -i mt1_Z0005.nii.gz -c t2 -centerline cnn
```

**Proposed solution:**
The reported error occurs when the spinal cord was not detected (here on the single axial slice). There is no much that we can do about it. Consequently, I proposed in the PR to invite the user to use another `-centerline` method, such as `svm` or `viewer`:
```
charley@charley:~/data/example_data/mt$ sct_deepseg_sc -i mt1_Z0005.nii.gz -c t2 -centerline cnn

--
Spinal Cord Toolbox (cg_deepseg_valueError_indexError_i1921_i2015_i2016/9d9b320757fc4a1db5bac3f706a01817c6b351c7)
Running /home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py -i mt1_Z0005.nii.gz -c t2 -centerline cnn
/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/h5py/__init__.py:34: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters

Method:
	Centerline algorithm: cnn
	Assumes brain section included in the image: True
	Dimension of the segmentation kernel convolutions: 2d

Creating temporary folder...
cp mt1_Z0005.nii.gz /tmp/sct-20181108163141.602759-T16TNs
Reorient the image to RPI, if necessary...
Resample the image to 0.5 mm isotropic resolution...
/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/nipy/io/files.py:145: FutureWarning: Default `strict` currently False; this will change to True in a future version of nipy
  ni_img = nipy2nifti(img, data_dtype = io_dtype)
Finding the spinal cord centerline...
WARNING: To avoid intensity overflow due to convertion to uint8, intensity will be rescaled to the maximum quantization scale.

Spinal cord was not detected using "-centerline cnn". Please try another "-centerline" method.

Sentry is attempting to send 1 pending error messages
Waiting up to 10 seconds
Press Ctrl-C to quit
Total processing time: 0 min 6 s
```
## #2015 & #1921
**To reproduce:**
```
cd example_data/t2
sct_deepseg_sc -i t2.nii.gz -c t2 -kernel 3d
```

**Error:**
It raised an IndexError when an empty slice segmentation is encountered by the function `post_processing_slice_wise`.

**Proposed solution:**
Use the center of mass of the neighbour slices to perform the slice wise post processing. If the neighbours are also empty (ie all the slices of a 3D patches are not segmented), then no post-processing is performed.

--> Tested on the example_data and it fixes the present error without impacting the output segmentation.

## #2001 
This issue suggests to correct the Usage of `sct_deepseg_lesion` since `-c t2_ax` is not a type of contrast but a contrast_orientation.

**Proposed solution:**
Clarify the usage:
```
 -c {t2,t2_ax,t2s}            type of image contrast. For 't2_like' contrast images, a specific 
                              model for images with axial orientation is available: 't2_ax'.
```

## #2057 
`svm` is now the `-centerline` default value for all contrasts , as indicated in the Usage.
```
charley@charley:~/data/example_data/t1$ sct_deepseg_sc -i t1.nii.gz -c t1

--
Spinal Cord Toolbox (cg_deepseg_valueError_indexError_i1921_i2015_i2016/d2f524f877add0fa59cbfc0d78e27db69afc390b)
Running /home/charley/spinalcordtoolbox/scripts/sct_deepseg_sc.py -i t1.nii.gz -c t1
/home/charley/spinalcordtoolbox/python/lib/python2.7/site-packages/h5py/__init__.py:34: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters

Method:
	Centerline algorithm: svm
	Assumes brain section included in the image: True
	Dimension of the segmentation kernel convolutions: 2d
```

## #1825 
**To reproduce:**
```
cd example_data/t2s
sct_deepseg_sc -i t2s.nii.gz -c t2s -ofolder test_folder
```

**Error:**
Duplication of output_folder in the `display_syntax_viewer`:
```
fsleyes t2s.nii.gz -cm greyscale test_folder/test_folder/t2s_seg.nii.gz -cm red -a 70.0 &
```

This is now fixed:
```
fsleyes t2s.nii.gz -cm greyscale test_folder/t2s_seg.nii.gz -cm red -a 70.0 &
```