### PR TITLE
optic: convert data to float before intensity rescaling

### DIFF
--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -99,7 +99,7 @@ def detect_centerline(image_fname, contrast_type,
     max_out = np.iinfo('uint16').max
     min_in = np.nanmin(img.data)
     max_in = np.nanmax(img.data)
-    data_rescaled = img.data * (max_out - min_out) / (max_in - min_in)
+    data_rescaled = img.data.astype('float') * (max_out - min_out) / (max_in - min_in)
     img_int16.data = data_rescaled - (data_rescaled.min() - min_out)
 
     # change data type


### PR DESCRIPTION
This PR aims at fixing the issue #2064.

Proposed solution: convert data to float before intensity rescaling: [here](https://github.com/neuropoly/spinalcordtoolbox/blob/master/spinalcordtoolbox/centerline/optic.py#L102)

To test:

1. Re-install the toolbox (changes in `spinalcordtoolbox/centerline/optic`).
2. Run:
```
cd sct_testing/large/nyu_2017-shepherd_027/t2_sag/
sct_get_centerline -i t2_sag.nii.gz -c t2
```