### PR TITLE
sct_flatten_sagittal: Fixes bug related to image scaling

### DIFF
--- a/scripts/sct_flatten_sagittal.py
+++ b/scripts/sct_flatten_sagittal.py
@@ -42,10 +42,10 @@ def main(fname_anat, fname_centerline, degree_poly, centerline_fitting, interp, 
 
     # load input image
     im_anat = Image(fname_anat)
-    nx, ny, nz, nt, px, py, pz, pt = im_anat.dim
     # re-oriente to RPI
     orientation_native = im_anat.orientation
     im_anat.change_orientation("RPI")
+    nx, ny, nz, nt, px, py, pz, pt = im_anat.dim
 
     # load centerline
     im_centerline = Image(fname_centerline).change_orientation("RPI")


### PR DESCRIPTION
On some images a scaling problem was causing the error `ValueError: Images of type float must be between -1 and 1.`. It is now fixed by making sure the input to `img_as_float()` is properly scaled.

Fixes #2069