### PR TITLE
sct_dmri_separate_b0_and_dwi: Now append suffix to input file name to prevent conflicts

### DIFF
--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -39,7 +39,7 @@ import numpy as np
 
 import sct_utils as sct
 import msct_moco as moco
-from sct_dmri_separate_b0_and_dwi import identify_b0
+import sct_dmri_separate_b0_and_dwi
 from sct_convert import convert
 from spinalcordtoolbox.image import Image
 from sct_image import split_data, concat_data
@@ -282,18 +282,27 @@ def main(args=None):
         param.fname_mask = mask_name + ext_mask
 
     # run moco
-    dmri_moco(param)
+    fname_data_moco_tmp = dmri_moco(param)
+
+    # generate b0_moco_mean and dwi_moco_mean
+    args = ['-i', fname_data_moco_tmp, '-bvec', 'bvecs.txt', '-a', '1', '-v', '0']
+    if not param.fname_bvals == '':
+        # if bvals file is provided
+        args += ['-bval', param.fname_bvals]
+    fname_b0, fname_b0_mean, fname_dwi, fname_dwi_mean = sct_dmri_separate_b0_and_dwi.main(args=args)
 
     # come back
     os.chdir(curdir)
 
     # Generate output files
     fname_dmri_moco = os.path.join(path_out, file_data + param.suffix + ext_data)
+    fname_dmri_moco_b0_mean = sct.add_suffix(fname_dmri_moco, '_b0_mean')
+    fname_dmri_moco_dwi_mean = sct.add_suffix(fname_dmri_moco, '_dwi_mean')
     sct.create_folder(path_out)
     sct.printv('\nGenerate output files...', param.verbose)
-    sct.generate_output_file(os.path.join(path_tmp, dmri_name + param.suffix + ext), os.path.join(path_out, file_data + param.suffix + ext_data), param.verbose)
-    sct.generate_output_file(os.path.join(path_tmp, "b0_mean.nii"), os.path.join(path_out, 'b0' + param.suffix + '_mean' + ext_data), param.verbose)
-    sct.generate_output_file(os.path.join(path_tmp, "dwi_mean.nii"), os.path.join(path_out, 'dwi' + param.suffix + '_mean' + ext_data), param.verbose)
+    sct.generate_output_file(fname_data_moco_tmp, fname_dmri_moco, param.verbose)
+    sct.generate_output_file(fname_b0_mean, fname_dmri_moco_b0_mean, param.verbose)
+    sct.generate_output_file(fname_dwi, fname_dmri_moco_dwi_mean, param.verbose)
 
     # Delete temporary files
     if param.remove_temp_files == 1:
@@ -327,7 +336,7 @@ def dmri_moco(param):
     sct.printv('  ' + str(nx) + ' x ' + str(ny) + ' x ' + str(nz), param.verbose)
 
     # Identify b=0 and DWI images
-    index_b0, index_dwi, nb_b0, nb_dwi = identify_b0('bvecs.txt', param.fname_bvals, param.bval_min, param.verbose)
+    index_b0, index_dwi, nb_b0, nb_dwi = sct_dmri_separate_b0_and_dwi.identify_b0('bvecs.txt', param.fname_bvals, param.bval_min, param.verbose)
 
     # check if dmri and bvecs are the same size
     if not nb_b0 + nb_dwi == nt:
@@ -347,8 +356,7 @@ def dmri_moco(param):
     im_b0_list = []
     for it in range(nb_b0):
         im_b0_list.append(im_data_split_list[index_b0[it]])
-    im_b0_out = concat_data(im_b0_list, 3) \
-     .save(file_b0 + ext_data)
+    im_b0_out = concat_data(im_b0_list, 3).save(file_b0 + ext_data)
     sct.printv(('  File created: ' + file_b0), param.verbose)
 
     # Average b=0 images
@@ -487,20 +495,14 @@ def dmri_moco(param):
     # copy geometric information from header
     # NB: this is required because WarpImageMultiTransform in 2D mode wrongly sets pixdim(3) to "1".
     im_dmri = Image(file_data + ext_data)
-    im_dmri_moco = Image(file_data + param.suffix + ext_data)
+    fname_data_moco = os.path.abspath(file_data + param.suffix + ext_data)
+    im_dmri_moco = Image(fname_data_moco)
     im_dmri_moco.header = im_dmri.header
     im_dmri_moco.save()
 
-    # generate b0_moco_mean and dwi_moco_mean
-    cmd = ['sct_dmri_separate_b0_and_dwi', '-i', file_data + param.suffix + ext_data, '-bvec', 'bvecs.txt', '-a', '1']
-    if not param.fname_bvals == '':
-        cmd += ['-m', param.fname_bvals]
-    sct.run(cmd, param.verbose)
+    return fname_data_moco
 
 
-#=======================================================================================================================
-# Start program
-#=======================================================================================================================
 if __name__ == "__main__":
     sct.init_sct()
     main()

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -226,7 +226,7 @@ def main(args=None):
     elapsed_time = time.time() - start_time
     sct.printv('\nFinished! Elapsed time: ' + str(int(np.round(elapsed_time))) + 's', verbose)
 
-    return fname_b0, fname_dwi, fname_b0_mean, fname_dwi_mean
+    return fname_b0, fname_b0_mean, fname_dwi, fname_dwi_mean
 
 
 # ==========================================================================================

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -201,10 +201,10 @@ def main(args=None):
     os.chdir(curdir)
 
     # Generate output files
-    fname_b0 = os.path.join(path_out, b0_name + ext_data)
-    fname_dwi = os.path.join(path_out, dwi_name + ext_data)
-    fname_b0_mean = os.path.join(path_out, b0_mean_name + ext_data)
-    fname_dwi_mean = os.path.join(path_out, dwi_mean_name + ext_data)
+    fname_b0 = os.path.abspath(os.path.join(path_out, b0_name + ext_data))
+    fname_dwi = os.path.abspath(os.path.join(path_out, dwi_name + ext_data))
+    fname_b0_mean = os.path.abspath(os.path.join(path_out, b0_mean_name + ext_data))
+    fname_dwi_mean = os.path.abspath(os.path.join(path_out, dwi_mean_name + ext_data))
     sct.printv('\nGenerate output files...', verbose)
     sct.generate_output_file(os.path.join(path_tmp, b0_name + ext), fname_b0, verbose)
     sct.generate_output_file(os.path.join(path_tmp, dwi_name + ext), fname_dwi, verbose)

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -206,12 +206,16 @@ def main(args=None):
     os.chdir(curdir)
 
     # Generate output files
+    fname_b0 = os.path.join(path_out, b0_name + ext_data)
+    fname_dwi = os.path.join(path_out, dwi_name + ext_data)
+    fname_b0_mean = os.path.join(path_out, b0_mean_name + ext_data)
+    fname_dwi_mean = os.path.join(path_out, dwi_mean_name + ext_data)
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join(path_tmp, b0_name + ext), os.path.join(path_out, b0_name + ext_data), verbose)
-    sct.generate_output_file(os.path.join(path_tmp, dwi_name + ext), os.path.join(path_out, dwi_name + ext_data), verbose)
+    sct.generate_output_file(os.path.join(path_tmp, b0_name + ext), fname_b0, verbose)
+    sct.generate_output_file(os.path.join(path_tmp, dwi_name + ext), fname_dwi, verbose)
     if average:
-        sct.generate_output_file(os.path.join(path_tmp, b0_mean_name + ext), os.path.join(path_out, b0_mean_name + ext_data), verbose)
-        sct.generate_output_file(os.path.join(path_tmp, dwi_mean_name + ext), os.path.join(path_out, dwi_mean_name + ext_data), verbose)
+        sct.generate_output_file(os.path.join(path_tmp, b0_mean_name + ext), fname_b0_mean, verbose)
+        sct.generate_output_file(os.path.join(path_tmp, dwi_mean_name + ext), fname_dwi_mean, verbose)
 
     # Remove temporary files
     if remove_temp_files == 1:
@@ -221,6 +225,8 @@ def main(args=None):
     # display elapsed time
     elapsed_time = time.time() - start_time
     sct.printv('\nFinished! Elapsed time: ' + str(int(np.round(elapsed_time))) + 's', verbose)
+
+    return fname_b0, fname_dwi, fname_b0_mean, fname_dwi_mean
 
 
 # ==========================================================================================

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -222,13 +222,6 @@ def main(args=None):
     elapsed_time = time.time() - start_time
     sct.printv('\nFinished! Elapsed time: ' + str(int(np.round(elapsed_time))) + 's', verbose)
 
-    # to view results
-    sct.printv('\nTo view results, type: ', verbose)
-    if average:
-        sct.display_viewer_syntax(['b0', 'b0_mean', 'dwi', 'dwi_mean'])
-    else:
-        sct.display_viewer_syntax(['b0', 'dwi'])
-
 
 # ==========================================================================================
 # identify b=0 and DW images

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -42,18 +42,12 @@ def get_parser():
     parser = Parser(__file__)
 
     # Mandatory arguments
-    parser.usage.set_description("Separate b=0 and DW images from diffusion dataset.")
+    parser.usage.set_description("Separate b=0 and DW images from diffusion dataset. The output files will have a suffix (_b0 and _dwi) appended to the input file name.")
     parser.add_option(name='-i',
                       type_value='image_nifti',
                       description='Diffusion data',
                       mandatory=True,
                       example='dmri.nii.gz')
-    parser.add_option(name='-b',
-                      type_value='file',
-                      description='bvecs file',
-                      mandatory=False,
-                      example='bvecs.txt',
-                      deprecated_by='-bvec')
     parser.add_option(name='-bvec',
                       type_value='file',
                       description='bvecs file',

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -62,11 +62,6 @@ def get_parser():
                       mandatory=False,
                       example=['0', '1'],
                       default_value=str(param_default.average))
-    parser.add_option(name='-m',
-                      type_value='file',
-                      description='bvals file. Used to identify low b-values (in case different from 0).',
-                      mandatory=False,
-                      deprecated_by='-bval')
     parser.add_option(name='-bval',
                       type_value='file',
                       description='bvals file. Used to identify low b-values (in case different from 0).',

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -25,6 +25,7 @@ import sct_utils as sct
 from spinalcordtoolbox.image import Image
 from sct_image import split_data
 from msct_parser import Parser
+from sct_convert import convert
 
 
 class Param:
@@ -141,10 +142,6 @@ def main(args=None):
     # Extract path, file and extension
     path_data, file_data, ext_data = sct.extract_fname(fname_data)
 
-    # # get output folder
-    # if path_out == '':
-    #     path_out = ''
-
     # create temporary folder
     path_tmp = sct.tmp_create(basename="dmri_separate", verbose=verbose)
 
@@ -152,12 +149,11 @@ def main(args=None):
     sct.printv('\nCopy files into temporary folder...', verbose)
     ext = '.nii'
     dmri_name = 'dmri'
-    b0_name = 'b0'
+    b0_name = file_data + '_b0'
     b0_mean_name = b0_name + '_mean'
-    dwi_name = 'dwi'
+    dwi_name = file_data + '_dwi'
     dwi_mean_name = dwi_name + '_mean'
 
-    from sct_convert import convert
     if not convert(fname_data, os.path.join(path_tmp, dmri_name + ext)):
         sct.printv('ERROR in convert.', 1, 'error')
     sct.copy(fname_bvecs, os.path.join(path_tmp, "bvecs"), verbose=verbose)
@@ -205,9 +201,6 @@ def main(args=None):
     if average:
         sct.printv('\nAverage DWI...', verbose)
         sct.run(['sct_maths', '-i', dwi_name + ext, '-o', dwi_mean_name + ext, '-mean', 't'], verbose)
-        # if not average_data_across_dimension('dwi.nii', 'dwi_mean.nii', 3):
-        #     sct.printv('ERROR in average_data_across_dimension', 1, 'error')
-        # sct.run(fsloutput + 'fslmaths dwi -Tmean dwi_mean', verbose)
 
     # come back
     os.chdir(curdir)
@@ -250,7 +243,6 @@ def identify_b0(fname_bvecs, fname_bvals, bval_min, verbose):
     # if bval is not provided
     if not fname_bvals:
         # Open bvecs file
-        #sct.printv('\nOpen bvecs file...', verbose)
         bvecs = []
         with open(fname_bvecs) as f:
             for line in f:

--- a/testing/test_sct_dmri_separate_b0_and_dwi.py
+++ b/testing/test_sct_dmri_separate_b0_and_dwi.py
@@ -11,11 +11,8 @@
 #########################################################################################
 
 from __future__ import absolute_import
-
-import sys, io, os
-
+import os
 import numpy as np
-
 from spinalcordtoolbox.image import Image
 
 
@@ -39,7 +36,7 @@ def test_integrity(param_test):
     # check DWI
     param_test.output += 'Checking DWI\n'
     ref_dwi = Image(os.path.join(param_test.path_data, 'dmri', 'dwi.nii.gz'))
-    new_dwi = Image(os.path.join(param_test.path_output, 'dwi.nii.gz'))
+    new_dwi = Image(os.path.join(param_test.path_output, 'dmri_dwi.nii.gz'))
     diff_dwi = ref_dwi.data - new_dwi.data
     if np.sum(diff_dwi) > param_test.threshold:
         param_test.status = 99
@@ -49,7 +46,7 @@ def test_integrity(param_test):
     # check b=0
     param_test.output += '\n\nChecking b=0\n'
     ref_b0 = Image(os.path.join(param_test.path_data, 'dmri', 'dmri_T0000.nii.gz'))
-    new_b0 = Image(os.path.join(param_test.path_output, 'b0.nii.gz'))
+    new_b0 = Image(os.path.join(param_test.path_output, 'dmri_b0.nii.gz'))
     diff_b0 = ref_b0.data - new_b0.data
     if np.sum(diff_b0) > param_test.threshold:
         param_test.status = 99


### PR DESCRIPTION
Currently the function `sct_dmri_separate_b0_and_dwi` outputs by default the files `dwi.nii.gz` and `b0.nii.gz`, assuming that the input file is not called like that (or assuming local files with those names don't exist). This is a problem, especially with the BIDS convention, where the input file is called `dwi.nii.gz`. 

This PR changes the default output names, and automatically append suffix "_dwi" and "_b0" to the input file name. 

WARNING: This PR breaks compatibility with v3.2.7 for pipeline that assumed output name is `dwi.nii.gz` (no more the case).

This does not concern `batch_processing.sh`, which does not use this function. However, many pipelines in [sct-pipeline](https://github.com/sct-pipeline) will be affected. 

Fixes #2074 