### PR TITLE
Now possible to output SNR map, removed requirement for inputing mask, and few other improvements

### DIFF
--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -18,6 +18,7 @@ import sys
 import numpy as np
 from msct_parser import Parser
 from spinalcordtoolbox.image import Image, empty_like
+from spinalcordtoolbox.utils import parse_num_list
 import sct_utils as sct
 
 
@@ -56,11 +57,11 @@ def get_parser():
                       default_value='diff',
                       example=['diff', 'mult'])
     parser.add_option(name='-vol',
-                      type_value=[[','], 'int'],
-                      description='List of volume numbers to use for computing SNR, separated with ",". Example: 0,31. '
-                                  'To select all volumes in series set to -1.',
+                      type_value='str',
+                      description='Volumes to compute SNR from. Separate with "," (e.g. -vol 0,1), or select range '
+                                  'using ":" (e.g. -vol 2:50). By default, all volumes in series are selected.',
                       mandatory=False,
-                      default_value=[-1])
+                      default_value='')
     parser.add_option(name="-r",
                       type_value="multiple_choice",
                       description='Remove temporary files.',
@@ -102,7 +103,10 @@ def main():
     else:
         fname_mask = ''
     method = arguments["-method"]
-    index_vol = arguments['-vol']
+    if '-vol' in arguments:
+        index_vol_user = arguments['-vol']
+    else:
+        index_vol_user = ''
 
     # Check parameters
     if method == 'diff':
@@ -115,8 +119,10 @@ def main():
     if fname_mask:
         mask = Image(fname_mask).change_orientation('RPI').data
 
-    # if user selected all 3d volumes from the input 4d volume ("-vol -1"), then assign index_vol
-    if index_vol[0] == -1:
+    # Retrieve selected volumes
+    if index_vol_user:
+        index_vol = parse_num_list(index_vol_user)
+    else:
         index_vol = range(data.shape[3])
 
     # Make sure user selected 2 volumes with diff method

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -26,7 +26,7 @@ import sct_utils as sct
 class Param(object):
     # The constructor
     def __init__(self):
-        self.almost_zero = 0.000000001
+        self.almost_zero = np.finfo(float).eps
 
 # PARSER
 # ==========================================================================================

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -23,7 +23,7 @@ import sct_utils as sct
 
 
 # PARAMETERS
-class Param:
+class Param(object):
     # The constructor
     def __init__(self):
         self.almost_zero = 0.000000001

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -10,8 +10,9 @@
 # Authors: Simon LEVY
 #
 # About the license: see the file LICENSE.TXT
-#########################################################################################
+########################################################################################
 
+# TODO: compute in float64
 
 from __future__ import division, absolute_import
 
@@ -19,11 +20,17 @@ import sys
 import operator
 import numpy as np
 from msct_parser import Parser
-from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.image import Image, empty_like
 from spinalcordtoolbox.utils import parse_num_list
 from spinalcordtoolbox.template import get_slices_from_vertebral_levels
 import sct_utils as sct
 
+
+# PARAMETERS
+class Param:
+    # The constructor
+    def __init__(self):
+        self.almost_zero = 0.000000001
 
 # PARSER
 # ==========================================================================================
@@ -31,7 +38,7 @@ def get_parser():
 
     # Initialize the parser
     parser = Parser(__file__)
-    parser.usage.set_description('Compute SNR in a given ROI using methods described in [Dietrich et al., Measurement of'
+    parser.usage.set_description('Compute SNR using methods described in [Dietrich et al., Measurement of'
                                  ' signal-to-noise ratios in MR images: Influence of multichannel coils, parallel '
                                  'imaging, and reconstruction filters. J Magn Reson Imaging 2007; 26(2): 375-385].')
     parser.add_option(name="-i",
@@ -41,13 +48,14 @@ def get_parser():
                       example="b0s.nii.gz")
     parser.add_option(name="-m",
                       type_value='image_nifti',
-                      description='ROI within which SNR will be averaged.',
-                      mandatory=True,
+                      description='Binary (or weighted) mask within which SNR will be averaged.',
+                      mandatory=False,
+                      default_value='',
                       example='dwi_moco_mean_seg.nii.gz')
     parser.add_option(name="-method",
                       type_value='multiple_choice',
                       description='Method to use to compute the SNR:\n'
-                      '- diff (default): Substract two volumes (defined by -vol) and estimate noise variance over space.\n'
+                      '- diff (default): Substract two volumes (defined by -vol) and estimate noise variance within the ROI (flag -m is required).\n'
                       '- mult: Estimate noise variance over time across volumes specified with -vol.',
                       mandatory=False,
                       default_value='diff',
@@ -90,24 +98,56 @@ def get_parser():
     return parser
 
 
-# MAIN
-# ==========================================================================================
+def weighted_avg_and_std(values, weights):
+    """
+    Return the weighted average and standard deviation.
+    values, weights -- Numpy ndarrays with the same shape.
+    Source: https://stackoverflow.com/questions/2413522/weighted-standard-deviation-in-numpy
+    """
+    average = np.average(values, weights=weights)
+    # Fast and numerically precise:
+    variance = np.average((values - average) ** 2, weights=weights)
+    return (average, np.sqrt(variance))
+
+
 def main():
+
+    # Default params
+    param = Param()
 
     # Get parser info
     parser = get_parser()
     arguments = parser.parse(sys.argv[1:])
     fname_data = arguments['-i']
-    fname_mask = arguments['-m']
+    if '-m' in arguments:
+        fname_mask = arguments['-m']
+    else:
+        fname_mask = ''
     vert_label_fname = arguments["-vertfile"]
     vert_levels = arguments["-vert"]
     slices_of_interest = arguments["-z"]
     index_vol = arguments['-vol']
     method = arguments["-method"]
 
+    # Check parameters
+    if method == 'diff':
+        if not fname_mask:
+            sct.printv('You need to provide a mask with -method diff. Exit.', 1, type='error')
+
     # Load data and orient to RPI
-    data = Image(fname_data).change_orientation('RPI').data
-    mask = Image(fname_mask).change_orientation('RPI').data
+    im_data = Image(fname_data).change_orientation('RPI')
+    data = im_data.data
+    if fname_mask:
+        mask = Image(fname_mask).change_orientation('RPI').data
+
+    # if user selected all 3d volumes from the input 4d volume ("-vol -1"), then assign index_vol
+    if index_vol[0] == -1:
+        index_vol = range(data.shape[3])
+
+    # Make sure user selected 2 volumes with diff method
+    if method == 'diff':
+        if not len(index_vol) == 2:
+            sct.printv('Method "diff" should be used with exactly two volumes (specify with flag "-vol").', 1, 'error')
 
     # Fetch slices to compute SNR on
     slices_list = []
@@ -127,39 +167,51 @@ def main():
         slices_list = np.arange(data.shape[2]).tolist()
 
     # Set to 0 all slices in the mask that are not includes in the slices_list
-    nz_to_exclude = [i for i in range(mask.shape[2]) if not i in slices_list]
-    mask[:, :, nz_to_exclude] = 0
+    # nz_to_exclude = [i for i in range(mask.shape[2]) if not i in slices_list]
+    # mask[:, :, nz_to_exclude] = 0
 
-    # if user selected all 3d volumes from the input 4d volume ("-vol -1"), then assign index_vol
-    if index_vol[0] == -1:
-        index_vol = range(data.shape[3])
-
-    # Get signal and noise
-    indexes_roi = np.where(mask == 1)
+    # Compute SNR map
+    # "time" is assumed to be the 4th dimension of the variable "data"
     if method == 'mult':
-        # get voxels in ROI to obtain a (x*y*z)*t 2D matrix
-        data_in_roi = data[indexes_roi]
-        # compute signal and STD across by averaging across time
-        signal = np.mean(data_in_roi[:, index_vol])
-        std_input_temporal = np.std(data_in_roi[:, index_vol], 1)
-        noise = np.mean(std_input_temporal)
+        # Compute mean and STD across time
+        data_mean = np.mean(data[:, :, :, index_vol], axis=3)
+        data_std = np.std(data[:, :, :, index_vol], axis=3)
+        # Generate mask where std is different from 0
+        mask_std_nonzero = np.where(data_std > param.almost_zero)
+        snr_map = np.zeros_like(data_mean)
+        snr_map[mask_std_nonzero] = data_mean[mask_std_nonzero] / data_std[mask_std_nonzero]
+        # Output SNR map
+        fname_snr = sct.add_suffix(fname_data, '_SNR-' + method)
+        im_snr = empty_like(im_data)
+        im_snr.data = snr_map
+        im_snr.save(fname_snr, dtype=np.float32)
+        # Output non-zero mask
+        fname_stdnonzero = sct.add_suffix(fname_data, '_mask-STD-nonzero' + method)
+        im_stdnonzero = empty_like(im_data)
+        data_stdnonzero = np.zeros_like(data_mean)
+        data_stdnonzero[mask_std_nonzero] = 1
+        im_stdnonzero.data = data_stdnonzero
+        im_stdnonzero.save(fname_stdnonzero, dtype=np.float32)
+        # Compute SNR in ROI
+        if fname_mask:
+            mean_in_roi = np.average(data_mean[mask_std_nonzero], weights=mask[mask_std_nonzero])
+            std_in_roi = np.average(data_std[mask_std_nonzero], weights=mask[mask_std_nonzero])
+            snr_roi = mean_in_roi / std_in_roi
+            # snr_roi = np.average(snr_map[mask_std_nonzero], weights=mask[mask_std_nonzero])
+
     elif method == 'diff':
-        # if user did not select two volumes, then exit with error
-        if not len(index_vol) == 2:
-            sct.printv('ERROR: ' + str(len(index_vol)) + ' volumes were specified. Method "diff" should be used with '
-                                                         'exactly two volumes (check flag "vol").', 1, 'error')
-        data_1 = data[:, :, :, index_vol[0]]
-        data_2 = data[:, :, :, index_vol[1]]
-        # compute voxel-average of voxelwise sum
-        signal = np.mean(np.add(data_1[indexes_roi], data_2[indexes_roi]))
-        # compute voxel-STD of voxelwise substraction, multiplied by sqrt(2) as described in equation 7 of Dietrich et al.
-        noise = np.std(np.subtract(data_1[indexes_roi], data_2[indexes_roi])) * np.sqrt(2)
+        data_2vol = np.take(data, index_vol, axis=3)
+        # Compute mean in ROI
+        data_mean = np.mean(data_2vol, axis=3)
+        mean_in_roi = np.average(data_mean, weights=mask)
+        data_sub = np.subtract(data_2vol[:, :, :, 1], data_2vol[:, :, :, 0])
+        _, std_in_roi = weighted_avg_and_std(data_sub, mask)
+        # Compute SNR, correcting for Rayleigh noise (see eq. 7 in Dietrich et al.)
+        snr_roi = (2/np.sqrt(2)) * mean_in_roi / std_in_roi
 
-    # compute SNR
-    SNR = signal / noise
-
-    # Display result
-    sct.printv('\nSNR_' + method + ' = ' + str(SNR) + '\n', type='info')
+    # Compute SNR in ROI and display result
+    if fname_mask:
+        sct.printv('\nSNR_' + method + ' = ' + str(snr_roi) + '\n', type='info')
 
 
 # START PROGRAM

--- a/testing/test_sct_compute_snr.py
+++ b/testing/test_sct_compute_snr.py
@@ -17,7 +17,7 @@ def init(param_test):
      Initialize class: param_test
      """
      # initialization
-     default_args = ['-i dmri/dwi.nii.gz -m dmri/dmri_T0001.nii.gz -vertfile template/template/PAM50_small_levels.nii.gz -vol 0,5']
+     default_args = ['-i dmri/dwi.nii.gz -m dmri/dmri_T0001.nii.gz  -method diff -vol 0,5']
 
     # assign default params
      if not param_test.args:


### PR DESCRIPTION
The following features/fixes were implemented:
- In case users need to discard the 3 first measurements, it is not possible to use ":" for selecting a range of volumes with flag "-vol", e.g., -vol 2:100
- Now possible to output an SNR map with `-method mult`
- With the previous point, the flag -m has been made optional
- Removed -z and -vert flags. It made the code heavy. If users want to compute within particular ROIs, then ROI generation should be wrapped outside of this function.
- Fixed Rayleigh correction for SNR_diff

Fixes #2078