### PR TITLE
QC now scales images based on physical dimensions (previously based on voxels)

### DIFF
--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -100,7 +100,7 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
     fn_in_r = os.path.join(tmp_folder.path_tmp, 'img_r.nii.gz')
     # Orient to RPI and retrieve pixel size in IS direction (z)
     im_fn = Image(fn_in).change_orientation('RPI').save(fn_in_r)
-    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'linear', 0)
+    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)
     fn_seg_r = os.path.join(tmp_folder.path_tmp, 'seg_r.nii.gz')
     Image(fn_seg).change_orientation('RPI').save(fn_seg_r)
     resample_file(fn_seg_r, fn_seg_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -93,6 +93,17 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
     import spinalcordtoolbox.reports.qc as qc
     import spinalcordtoolbox.reports.slice as qcslice
     from spinalcordtoolbox.image import Image
+    from spinalcordtoolbox.resample.nipy_resample import resample_file
+
+    # Resample to fixed resolution (see #2063)
+    tmp_folder = sct.TempFolder()
+    fn_in_r = os.path.join(tmp_folder.path_tmp, 'img_r.nii.gz')
+    # Orient to RPI and retrieve pixel size in IS direction (z)
+    im_fn = Image(fn_in).change_orientation('RPI').save(fn_in_r)
+    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'linear', 0)
+    fn_seg_r = os.path.join(tmp_folder.path_tmp, 'seg_r.nii.gz')
+    Image(fn_seg).change_orientation('RPI').save(fn_seg_r)
+    resample_file(fn_seg_r, fn_seg_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)
 
     qc.add_entry(
      src=fn_in,
@@ -100,7 +111,7 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
      args=args,
      path_qc=path_qc,
      plane='Axial',
-     qcslice=qcslice.Axial([Image(fn_in), Image(fn_seg)]),
+     qcslice=qcslice.Axial([Image(fn_in_r), Image(fn_seg_r)]),
      qcslice_operations=[qc.QcImage.listed_seg],
      qcslice_layout=lambda x: x.mosaic(),
     )

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -782,7 +782,7 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
     fn_in_r = os.path.join(tmp_folder.path_tmp, 'img_r.nii.gz')
     # Orient to RPI and retrieve pixel size in IS direction (z)
     im_fn = Image(fn_in).change_orientation('RPI').save(fn_in_r)
-    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'linear', 0)
+    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)
     fn_seg_r = os.path.join(tmp_folder.path_tmp, 'seg_r.nii.gz')
     Image(fn_seg).change_orientation('RPI').save(fn_seg_r)
     resample_file(fn_seg_r, fn_seg_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)
@@ -854,14 +854,14 @@ def main():
     algo_config_stg += '\n\tDimension of the segmentation kernel convolutions: ' + kernel_size + '\n'
     sct.printv(algo_config_stg)
 
-    fname_seg = deep_segmentation_spinalcord(fname_image, contrast_type, output_folder,
-                                            ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
-                                            brain_bool=brain_bool, kernel_size=kernel_size,
-                                            remove_temp_files=remove_temp_files, verbose=verbose)
+    # fname_seg = deep_segmentation_spinalcord(fname_image, contrast_type, output_folder,
+    #                                         ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
+    #                                         brain_bool=brain_bool, kernel_size=kernel_size,
+    #                                         remove_temp_files=remove_temp_files, verbose=verbose)
 
     if path_qc is not None:
-        generate_qc(fname_image, fname_seg, args, os.path.abspath(path_qc))
-        # generate_qc(fname_image, 't2_r_seg.nii.gz', args, os.path.abspath(path_qc))
+        # generate_qc(fname_image, fname_seg, args, os.path.abspath(path_qc))
+        generate_qc(fname_image, 't2_seg.nii.gz', args, os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -854,14 +854,13 @@ def main():
     algo_config_stg += '\n\tDimension of the segmentation kernel convolutions: ' + kernel_size + '\n'
     sct.printv(algo_config_stg)
 
-    # fname_seg = deep_segmentation_spinalcord(fname_image, contrast_type, output_folder,
-    #                                         ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
-    #                                         brain_bool=brain_bool, kernel_size=kernel_size,
-    #                                         remove_temp_files=remove_temp_files, verbose=verbose)
+    fname_seg = deep_segmentation_spinalcord(fname_image, contrast_type, output_folder,
+                                            ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
+                                            brain_bool=brain_bool, kernel_size=kernel_size,
+                                            remove_temp_files=remove_temp_files, verbose=verbose)
 
     if path_qc is not None:
-        # generate_qc(fname_image, fname_seg, args, os.path.abspath(path_qc))
-        generate_qc(fname_image, 't2_seg.nii.gz', args, os.path.abspath(path_qc))
+        generate_qc(fname_image, fname_seg, args, os.path.abspath(path_qc))
 
     sct.display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -207,10 +207,6 @@ def main(args=None):
     fname_seg = os.path.abspath(arguments['-s'])
     contrast = arguments['-c']
     path_template = arguments['-t']
-    # if '-o' in arguments:
-    #     file_out = arguments["-o"]
-    # else:
-    #     file_out = ''
     if '-ofolder' in arguments:
         path_output = arguments['-ofolder']
     else:
@@ -243,12 +239,6 @@ def main(args=None):
     remove_temp_files = int(arguments['-r'])
     denoise = int(arguments['-denoise'])
     laplacian = int(arguments['-laplacian'])
-
-    # Generate QC report  # JULIEN
-    if param.path_qc is not None:
-        path_qc = os.path.abspath(param.path_qc)
-        generate_qc(fname_in, sct.add_suffix(fname_seg, '_labeled'), args, path_qc)
-
 
     path_tmp = sct.tmp_create(basename="label_vertebrae", verbose=verbose)
 

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -244,6 +244,12 @@ def main(args=None):
     denoise = int(arguments['-denoise'])
     laplacian = int(arguments['-laplacian'])
 
+    # Generate QC report  # JULIEN
+    if param.path_qc is not None:
+        path_qc = os.path.abspath(param.path_qc)
+        generate_qc(fname_in, sct.add_suffix(fname_seg, '_labeled'), args, path_qc)
+
+
     path_tmp = sct.tmp_create(basename="label_vertebrae", verbose=verbose)
 
     # Copying input data to tmp folder
@@ -416,14 +422,15 @@ def generate_qc(fn_in, fn_labeled, args, path_qc):
                     ax.text(x, y, label, color=color, clip_on=True)
 
     qc.add_entry(
-     src=fn_in,
-     process='sct_label_vertebrae',
-     args=args,
-     path_qc=path_qc,
-     plane='Sagittal',
-     qcslice=qcslice.Sagittal([Image(fn_in), Image(fn_labeled)]),
-     qcslice_operations=[label_vertebrae],
-     qcslice_layout=lambda x: x.single(),
+        src=fn_in,
+        process='sct_label_vertebrae',
+        args=args,
+        path_qc=path_qc,
+        plane='Sagittal',
+        dpi=100,
+        qcslice=qcslice.Sagittal([Image(fn_in), Image(fn_labeled)]),
+        qcslice_operations=[label_vertebrae],
+        qcslice_layout=lambda x: x.single(),
     )
 
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -347,6 +347,17 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
 
     import spinalcordtoolbox.reports.qc as qc
     import spinalcordtoolbox.reports.slice as qcslice
+    from spinalcordtoolbox.resample.nipy_resample import resample_file
+
+    # Resample to fixed resolution (see #2063)
+    tmp_folder = sct.TempFolder()
+    fn_in_r = os.path.join(tmp_folder.path_tmp, 'img_r.nii.gz')
+    # Orient to RPI and retrieve pixel size in IS direction (z)
+    im_fn = Image(fn_in).change_orientation('RPI').save(fn_in_r)
+    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'linear', 0)
+    fn_seg_r = os.path.join(tmp_folder.path_tmp, 'seg_r.nii.gz')
+    Image(fn_seg).change_orientation('RPI').save(fn_seg_r)
+    resample_file(fn_seg_r, fn_seg_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)
 
     qc.add_entry(
         src=fn_in,
@@ -354,7 +365,7 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
         args=args,
         path_qc=path_qc,
         plane='Axial',
-        qcslice=qcslice.Axial([Image(fn_in), Image(fn_seg)]),
+        qcslice=qcslice.Axial([Image(fn_in_r), Image(fn_seg_r)]),
         qcslice_operations=[qc.QcImage.listed_seg],
         qcslice_layout=lambda x: x.mosaic(),
     )

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -354,7 +354,7 @@ def generate_qc(fn_in, fn_seg, args, path_qc):
     fn_in_r = os.path.join(tmp_folder.path_tmp, 'img_r.nii.gz')
     # Orient to RPI and retrieve pixel size in IS direction (z)
     im_fn = Image(fn_in).change_orientation('RPI').save(fn_in_r)
-    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'linear', 0)
+    resample_file(fn_in_r, fn_in_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)
     fn_seg_r = os.path.join(tmp_folder.path_tmp, 'seg_r.nii.gz')
     Image(fn_seg).change_orientation('RPI').save(fn_seg_r)
     resample_file(fn_seg_r, fn_seg_r, '0.5x0.5x'+str(im_fn.dim[6]), 'mm', 'nn', 0)

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -9,6 +9,8 @@
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
+# TODO: Sort out the use of Image.hdr and Image.header --> they seem to carry duplicated information.
+
 from __future__ import division, absolute_import
 
 import sys, io, os, math, itertools, warnings

--- a/spinalcordtoolbox/reports/assets/_assets/css/style.css
+++ b/spinalcordtoolbox/reports/assets/_assets/css/style.css
@@ -35,7 +35,7 @@
 
 .Sagittal, .Axial{
     max-width: 100%;
-    max-height: 80vh;
+    max-height: 400vh;
     overflow-y: hidden;
 }
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -168,7 +168,7 @@ class QcImage(object):
             """
             self.qc_report.slice_name = sct_slice.get_name()
 
-            # consider only the first 2 slices
+            # Get the aspect ratio (height/width) based on pixel size. Consider only the first 2 slices.
             aspect_img, self.aspect_mask = sct_slice.aspect()[:2]
 
             self.qc_report.make_content_path()
@@ -393,6 +393,19 @@ def add_entry(src, process, args, path_qc, plane, background=None, foreground=No
               qcslice_layout=None,
               ):
     """
+    Starting point to QC report creation.
+
+    :param src: Path to input file (only used to populate report metadata)
+    :param process:
+    :param args:
+    :param path_qc:
+    :param plane:
+    :param background:
+    :param foreground:
+    :param qcslice: spinalcordtoolbox.reports.slice:Axial
+    :param qcslice_operations:
+    :param qcslice_layout:
+    :return:
     """
 
     qc_param = Params(src, process, args, plane, path_qc)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -207,7 +207,7 @@ class QcImage(object):
             fig = plt.imshow(img, cmap=plt.cm.gray, interpolation=self.interpolation, aspect=float(aspect_img))
             fig.axes.get_xaxis().set_visible(False)
             fig.axes.get_yaxis().set_visible(False)
-            self._save(self.qc_report.qc_params.abs_bkg_img_path())
+            self._save(self.qc_report.qc_params.abs_bkg_img_path(), dpi=self.qc_report.qc_params.dpi)
 
             for action in self.action_list:
                 logger.debug('Action List %s', action.__name__)
@@ -217,25 +217,22 @@ class QcImage(object):
                     print("Mask type %s" % mask.dtype)
                     mask = equalized(mask)
                 action(self, mask)
-                self._save(self.qc_report.qc_params.abs_overlay_img_path())
+                self._save(self.qc_report.qc_params.abs_overlay_img_path(), dpi=self.qc_report.qc_params.dpi)
             plt.close()
 
             self.qc_report.update_description_file(img.shape)
 
         return wrapped_f
 
-    def _save(self, img_path, format='png', bbox_inches='tight', pad_inches=0.00):
-        """ Save the current figure into an image.
-
-        Parameters
-        ----------
-        img_path : str
-            path of the folder where the image is saved
-        format : str
-            image format
-        bbox_inches : str
-        pad_inches : float
-
+    def _save(self, img_path, format='png', bbox_inches='tight', pad_inches=0.00, dpi=300):
+        """
+        Save the current figure into an image.
+        :param img_path: str: path of the folder where the image is saved
+        :param format: str: image format
+        :param bbox_inches: str
+        :param pad_inches: float
+        :param dpi: int: Output resolution of the image
+        :return:
         """
         logger.debug('Save image %s', img_path)
         plt.savefig(img_path,
@@ -243,7 +240,7 @@ class QcImage(object):
                     bbox_inches=bbox_inches,
                     pad_inches=pad_inches,
                     transparent=True,
-                    dpi=600)
+                    dpi=dpi)
 
 
 class Params(object):
@@ -253,20 +250,15 @@ class Params(object):
     by splitting it into `[subject]/[contrast]/input_file`
     """
 
-    def __init__(self, input_file, command, args, orientation, dest_folder):
+    def __init__(self, input_file, command, args, orientation, dest_folder, dpi=300):
         """
         Parameters
-        ----------
-        input_file : str
-            the input nifti file name
-        command : str
-            the command name
-        args : str
-            the command's arguments
-        orientation : str
-            The anatomical orientation
-        dest_folder : str
-            The absolute path of the QC root
+        :param input_file: str: the input nifti file name
+        :param command: str: command name
+        :param args: str: the command's arguments
+        :param orientation: str: The anatomical orientation
+        :param dest_folder: str: The absolute path of the QC root
+        :param dpi: int: Output resolution of the image
         """
         abs_input_path = os.path.dirname(os.path.abspath(input_file))
         abs_input_path, contrast = os.path.split(abs_input_path)
@@ -280,9 +272,9 @@ class Params(object):
         self.command = command
         self.args = args
         self.orientation = orientation
+        self.dpi = dpi
         self.root_folder = dest_folder
         self.mod_date = datetime.datetime.strftime(datetime.datetime.now(), '%Y_%m_%d_%H%M%S')
-
         self.qc_results = os.path.join(dest_folder, 'qc_results.json')
         self.bkg_img_path = os.path.join(subject, contrast, command, self.mod_date, 'bkg_img.png')
         self.overlay_img_path = os.path.join(subject, contrast, command, self.mod_date, 'overlay_img.png')
@@ -303,15 +295,8 @@ class QcReport(object):
     def __init__(self, qc_params, usage):
         """
         Parameters
-        ----------
-        tool_name : str
-            name of the sct tool being used. Is used to name the image file.
-        qc_params : Params
-            arguments of the "-param-qc" option in Terminal
-        cmd_args : list of str
-            the commands of the process being used to generate the images
-        usage : str
-             description of the process
+        :param qc_params: arguments of the "-param-qc" option in Terminal
+        :param usage: str: description of the process
         """
         self.tool_name = qc_params.command
         self.slice_name = qc_params.orientation
@@ -391,7 +376,7 @@ def add_entry(src, process, args, path_qc, plane, background=None, foreground=No
               qcslice=None,
               qcslice_operations=[],
               qcslice_layout=None,
-              ):
+              dpi=300):
     """
     Starting point to QC report creation.
 
@@ -405,10 +390,11 @@ def add_entry(src, process, args, path_qc, plane, background=None, foreground=No
     :param qcslice: spinalcordtoolbox.reports.slice:Axial
     :param qcslice_operations:
     :param qcslice_layout:
+    :param dpi: int: Output resolution of the image
     :return:
     """
 
-    qc_param = Params(src, process, args, plane, path_qc)
+    qc_param = Params(src, process, args, plane, path_qc, dpi)
     report = QcReport(qc_param, '')
 
     if qcslice is not None:

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -227,9 +227,6 @@ class Slice(object):
 
         nb_row = math.ceil(dim // nb_column) + 1
 
-        # Get shape of input image
-        length, width = self.get_slice(image.data, 1).shape
-
         # Compute the matrix size of the final mosaic image
         matrix_sz = (int(size * 2 * nb_row), int(size * 2 * nb_column))
 

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -297,7 +297,6 @@ class Axial(Slice):
         return self._axial_center(image)
 
 
-
 class Sagittal(Slice):
     """The sagittal representation of a slice"""
 

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# TODO: Replace slice by spinalcordtoolbox.image.Slicer
+
+
 from __future__ import print_function, absolute_import, division
 
 import abc
@@ -89,10 +92,10 @@ class Slice(object):
 
     @staticmethod
     def crop(matrix, x, y, width, height):
-        """Crops the matrix to width and heigth from the center
+        """Crops the matrix to width and height from the center
 
-        Select the size of the matrix if the calulated crop `width` or `height`
-        are larger then the size of the matrix.
+        Select the size of the matrix if the calculated crop `width` or `height`
+        are larger than the size of the matrix.
 
         TODO : Move this into the Axial class
 
@@ -205,7 +208,6 @@ class Slice(object):
             raise
         return centers_x, centers_y
 
-
     def mosaic(self, nb_column=0, size=15):
         """Obtain matrices of the mosaics
 
@@ -218,16 +220,21 @@ class Slice(object):
         """
         image = self._images[0]
 
-        dim = self.get_dim(image)
+        # Calculate number of columns to display on the report
+        dim = self.get_dim(image)  # dim represents the 3rd dimension of the 3D matrix
         if nb_column == 0:
             nb_column = 600 // (size * 2)
 
         nb_row = math.ceil(dim // nb_column) + 1
 
+        # Get shape of input image
         length, width = self.get_slice(image.data, 1).shape
 
+        # Compute the matrix size of the final mosaic image
         matrix_sz = (int(size * 2 * nb_row), int(size * 2 * nb_column))
 
+        # Get center of mass of the image. If the input is the cord segmentation, these coordinates are used to center
+        # the image on each panel of the mosaid.
         centers_x, centers_y = self.get_center()
 
         matrices = list()
@@ -236,9 +243,8 @@ class Slice(object):
             for i in range(dim):
                 x = int(centers_x[i])
                 y = int(centers_y[i])
-
-                self.add_slice(matrix, i, nb_column, size,
-                 self.crop(self.get_slice(image.data, i), x, y, size, size))
+                # crop slice around center of mass and add slice to the matrix layout
+                self.add_slice(matrix, i, nb_column, size, self.crop(self.get_slice(image.data, i), x, y, size, size))
 
             matrices.append(matrix)
 

--- a/spinalcordtoolbox/resample/nipy_resample.py
+++ b/spinalcordtoolbox/resample/nipy_resample.py
@@ -8,6 +8,10 @@
 #
 # About the license: see the file LICENSE.TXT
 #########################################################################################
+
+# TODO: Ultimately replace resample_image (based on nipy) with Image, to avoid confusion.
+
+
 from __future__ import division, absolute_import
 
 import copy
@@ -21,9 +25,8 @@ import sct_utils as sct
 
 def resample_image(input_image, new_size, new_size_type,
                    interpolation='linear', verbose=1):
-    """This function will resample the specified input
-    image to the target size.
-
+    """This function will resample the specified input nipy image object to the target size.
+    Can deal with 2d, 3d or 4d image objects.
     :param input_image: The input image.
     :param new_size: The target size, i.e. '0.25x0.25'
     :param new_size_type: Unit of resample (mm, vox, factor)
@@ -85,7 +88,8 @@ def resample_image(input_image, new_size, new_size_type,
     if len(p) == 4:
         transfo = np.delete(transfo, 3, 0)
         transfo = np.delete(transfo, 3, 1)
-    # translate to account for voxel size (otherwise resulting image will be shifted by half a voxel). Modify the three first rows of the last column, corresponding to the translation.
+    # translate to account for voxel size (otherwise resulting image will be shifted by half a voxel). Modify the three
+    # first rows of the last column, corresponding to the translation.
     transfo[:3, -1] = np.array(((R[0, 0] - 1) / 2, (R[1, 1] - 1) / 2, (R[2, 2] - 1) / 2), dtype='f8')
     sct.printv('  transfo: \n' + str(transfo), verbose)
 
@@ -138,7 +142,7 @@ def resample_file(fname_data, fname_out, new_size, new_size_type,
                   interpolation, verbose):
     """This function will resample the specified input
     image file to the target size.
-
+    Can deal with 2d, 3d or 4d image objects.
     :param fname_data: The input image filename.
     :param fname_out: The output image filename.
     :param new_size: The target size, i.e. 0.25x0.25


### PR DESCRIPTION
This PR fixes the way QC mosaic pictures are scaled and cropped: previously, the scaling was based on number of voxels, which made the scaling dependent to the native resolution of the image. This PR fixes it by resampling the image to a fixed resolution (in-plane: 0.5x0.5mm) before launching the QC. 

Note: The result can still be "ugly" if the native resolution is low (~1mm or higher), because the output segmentation will look "squary". The way to properly address that in the future is to:
- output non-binary segmentations (in `sct_propseg`, `sct_deepseg_sc`, `sct_deepseg_gm`)
- adapt the code in `spinalcordtoolbox.reports.slice` so that overlays can be non-binary

Also: the current implementation is "ugly" because:
- the orientation+interpolation of the output data is done with i/o, whereas a more elegant way would be to do it using the Image() class, however the resampling is currently done using nipy.nibabel (not Image), so this needs to be modified in the future (TODO added). 
- the orientation+interpolation is done within each function. A more elegant way would be to move this data processing within the qc module (not within each function). This has to be done because in the current implementation, the qc module inputs slice object (which don't contain image information, such as dim, etc.). 

Fixes #2063 