### PR TITLE
Updated PAM50 template header to be in the same coordinate system as the MNI template

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -87,7 +87,7 @@ def main(args=None):
                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
         'sct_testing_data': ['https://osf.io/z8gaj/?action=download',
                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180125_sct_testing_data.zip'],
-        'PAM50': ['https://osf.io/jmfpw/?action=download',
+        'PAM50': ['https://osf.io/kc3jx/?action=download',
                   'https://www.neuro.polymtl.ca/_media/downloads/sct/20181214_PAM50.zip'],
         'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -88,7 +88,7 @@ def main(args=None):
         'sct_testing_data': ['https://osf.io/z8gaj/?action=download',
                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180125_sct_testing_data.zip'],
         'PAM50': ['https://osf.io/jmfpw/?action=download',
-                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20180813_PAM50.zip'],
+                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20181214_PAM50.zip'],
         'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
         'gm_model': ['https://osf.io/ugscu/?action=download',


### PR DESCRIPTION
The PAM50 template was modified as follows:
- Aligned the PAM05 template with the ICBM152-MNI template using translation. Note: only the header of the PAM50 files was updated for this operation.
- Cropped the template just above C1 vertebral label. The rationale is that the brainstem already exists in the MNI template, so there is no need to duplicate this structure. 
- Updated the file info_label.txt in the folder template/ to take new files into account
- Shifted the value of the labels in the file PAM50_label_discPosterior.nii.gz by one (previous version was wrong).

**WARNING:** Cross-compatibility broken for studies that map metrics to the PAM50 template (not from the PAM50 to the native space), because the q/sform of the PAM50 has changed. 

Fixes #2085 