### PR TITLE
Updated documention on how to create vertebral and disc labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ Each repository is a pipeline dedicated to a specific research project.
 
 ## Courses
 
-We organize **free** SCT courses, each year after the ISMRM conference. If you'd like to be added to the mailing list, please send an email to `spinalcordtoolbox@gmail.com`. The past courses handouts are available hereafter:
+We organize **free** SCT courses, each year after the ISMRM conference. If you'd like to be added to the mailing list, please send an email to `spinalcordtoolbox@gmail.com`. The latest course is embeded below. The past courses handouts are listed after the slides below.
 
+<iframe src="https://www.slideshare.net/slideshow/embed_code/key/gQEQp7aQN99wd4" width="427" height="356" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="https://www.slideshare.net/secret/gQEQp7aQN99wd4" title="SCT course 2019-01-21" target="_blank">SCT course 2019-01-21</a> </strong> from <strong><a href="https://www.slideshare.net/neuropoly" target="_blank">NeuroPoly </a></strong> </div>
+
+* [SCT course, London, 2019-01-18](https://www.slideshare.net/secret/gQEQp7aQN99wd4)
 * [SCT course, Paris, 2018-06-12](https://osf.io/386h7/)
 * [SCT course, Honolulu, 2017-04-28](https://osf.io/fvnjq/)
 * [SCT course, Geneva, 2016-06-28](https://sourceforge.net/p/spinalcordtoolbox/wiki/Home/attachment/SCT_Course_20160628.pdf)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Each repository is a pipeline dedicated to a specific research project.
 
 We organize **free** SCT courses, each year after the ISMRM conference. If you'd like to be added to the mailing list, please send an email to `spinalcordtoolbox@gmail.com`. The latest course is embeded below. The past courses handouts are listed after the slides below.
 
+<iframe src="https://www.slideshare.net/slideshow/embed_code/key/gQEQp7aQN99wd4" width="800" height="594" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+
+
 <iframe src="https://www.slideshare.net/slideshow/embed_code/key/gQEQp7aQN99wd4" width="427" height="356" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="https://www.slideshare.net/secret/gQEQp7aQN99wd4" title="SCT course 2019-01-21" target="_blank">SCT course 2019-01-21</a> </strong> from <strong><a href="https://www.slideshare.net/neuropoly" target="_blank">NeuroPoly </a></strong> </div>
 
 * [SCT course, London, 2019-01-18](https://www.slideshare.net/secret/gQEQp7aQN99wd4)

--- a/README.md
+++ b/README.md
@@ -111,14 +111,9 @@ Each repository is a pipeline dedicated to a specific research project.
 
 ## Courses
 
-We organize **free** SCT courses, each year after the ISMRM conference. If you'd like to be added to the mailing list, please send an email to `spinalcordtoolbox@gmail.com`. The latest course is embeded below. The past courses handouts are listed after the slides below.
+We organize **free** SCT courses, each year after the ISMRM conference. If you'd like to be added to the mailing list, please send an email to `spinalcordtoolbox@gmail.com`. The past courses handouts are listed below:
 
-<iframe src="https://www.slideshare.net/slideshow/embed_code/key/gQEQp7aQN99wd4" width="800" height="594" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
-
-
-<iframe src="https://www.slideshare.net/slideshow/embed_code/key/gQEQp7aQN99wd4" width="427" height="356" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="https://www.slideshare.net/secret/gQEQp7aQN99wd4" title="SCT course 2019-01-21" target="_blank">SCT course 2019-01-21</a> </strong> from <strong><a href="https://www.slideshare.net/neuropoly" target="_blank">NeuroPoly </a></strong> </div>
-
-* [SCT course, London, 2019-01-18](https://www.slideshare.net/secret/gQEQp7aQN99wd4)
+* [SCT course, London, 2019-01-18](https://www.slideshare.net/neuropoly/sct-course-20190121)
 * [SCT course, Paris, 2018-06-12](https://osf.io/386h7/)
 * [SCT course, Honolulu, 2017-04-28](https://osf.io/fvnjq/)
 * [SCT course, Geneva, 2016-06-28](https://sourceforge.net/p/spinalcordtoolbox/wiki/Home/attachment/SCT_Course_20160628.pdf)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -101,7 +101,7 @@ def get_parser():
                       default_value=os.path.join(path_sct, "data", "PAM50"))
     parser.add_option(name="-initz",
                       type_value=[[','], 'int'],
-                      description='Initialize using slice number and disc value. Example: 68,3 (slice 68 corresponds to disc C3/C4). WARNING: Slice number should correspond to superior-inferior direction (e.g. Z in RPI orientation, but Y in LIP orientation).',
+                      description='Initialize using slice number and disc value. Example: 68,4 (slice 68 corresponds to disc C3/C4). WARNING: Slice number should correspond to superior-inferior direction (e.g. Z in RPI orientation, but Y in LIP orientation).',
                       mandatory=False,
                       example=['125,3'])
     parser.add_option(name="-initcenter",

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -82,7 +82,7 @@ def get_parser():
                                  'If only one label is provided, a simple translation will be applied between the subject label and the template label. No scaling will be performed. \n\n'
                                  'If two labels are provided, a linear transformation (translation + rotation + superior-inferior linear scaling) will be applied. The strategy here is to defined labels that cover the region of interest. For example, if you are interested in studying C2 to C6 levels, then provide one label at C2 and another at C6. However, note that if the two labels are very far apart (e.g. C2 and T12), there might be a mis-alignment of discs because a subject''s intervertebral discs distance might differ from that of the template.\n\n'
                                  'If more than two labels (only with the parameter "-disc") are used, a non-linear registration will be applied to align the each intervertebral disc between the subject and the template, as described in sct_straighten_spinalcord. This the most accurate and preferred method. This feature does not work with the parameter "-ref subject".\n\n'
-                                 'More information about label creation can be found at http://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/'
+                                 'More information about label creation can be found at https://www.slideshare.net/neuropoly/sct-course-20190121/42'
       )
     parser.add_option(name="-i",
                       type_value="file",
@@ -98,7 +98,7 @@ def get_parser():
                       type_value="file",
                       description="One or two labels (preferred) located at the center of the spinal cord, on the "
                                   "mid-vertebral slice. For more information about label creation, please see: "
-                                  "http://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/",
+                                  "https://www.slideshare.net/neuropoly/sct-course-20190121/42",
                       mandatory=False,
                       default_value='',
                       example="anat_labels.nii.gz")
@@ -108,7 +108,7 @@ def get_parser():
                                   "more than 2 labels, all disc covering the region of interest should be provided. "
                                   "E.g., if you are interested in levels C2 to C7, then you should provide disc labels "
                                   "2,3,4,5,6,7). For more information about label creation, please refer to "
-                                  "http://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/.",  # TODO: update URL
+                                  "https://www.slideshare.net/neuropoly/sct-course-20190121/42",  # TODO: update URL
                       mandatory=False,
                       default_value='',
                       example="anat_labels.nii.gz")
@@ -452,7 +452,7 @@ def main(args=None):
             try:
                 register_landmarks(ftmp_label, ftmp_template_label, paramreg.steps['0'].dof, fname_affine='straight2templateAffine.txt', verbose=verbose)
             except Exception:
-                sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/', verbose=verbose, type='error')
+                sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://www.slideshare.net/neuropoly/sct-course-20190121/42', verbose=verbose, type='error')
 
             # Concatenate transformations: curve --> straight --> affine
             sct.printv('\nConcatenate transformations: curve --> straight --> affine...', verbose)
@@ -595,7 +595,7 @@ def main(args=None):
         try:
             register_landmarks(ftmp_template_label, ftmp_label, paramreg.steps['0'].dof, fname_affine=warp_forward[0], verbose=verbose, path_qc="./")
         except Exception:
-            sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/', verbose=verbose, type='error')
+            sct.printv('ERROR: input labels do not seem to be at the right place. Please check the position of the labels. See documentation for more details: https://www.slideshare.net/neuropoly/sct-course-20190121/42', verbose=verbose, type='error')
 
         # loop across registration steps
         for i_step in range(1, len(paramreg.steps)):


### PR DESCRIPTION
[This page](https://sourceforge.net/p/spinalcordtoolbox/wiki/create_labels/) is obsolete because (i) it uses fslview instead of `sct_label_utils -create-viewer` and (ii) it does not describe label values for the discs.

Since we want to slowly move away from sourceforge, the proposed fix:
- implements the labeling documentation in the next SCT course (London, January 21st 2019)
- puts the slides in slideshare and add link in README
- redirect to the appropriate slideshare page in SCT functions and in sourceforge.

Such documentation is important for `sct_register_to_template` and `sct_label_vertebrae`.

Related to https://github.com/neuropoly/spinalcordtoolbox/pull/1451
Fixes #1721, Fixes #699