### PR TITLE
Fixed crash caused by wrong estimation of centerline length in case of incomplete segmentation

### DIFF
--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -109,11 +109,12 @@ def run_main():
     if method == 'viewer':
         im_labels = _call_viewer_centerline(Image(fname_data), interslice_gap=interslice_gap)
         im_centerline, arr_centerline, _ = \
-            get_centerline(im_labels, algo_fitting='polyfit', param=ParamCenterline(degree=3), verbose=verbose)
+            get_centerline(im_labels, algo_fitting='polyfit', param=ParamCenterline(degree=3), minmax=True,
+                           verbose=verbose)
     else:
         im_centerline, arr_centerline, _ = \
             get_centerline(Image(fname_data), algo_fitting='optic', param=ParamCenterline(contrast=contrast_type),
-                           verbose=verbose)
+                           minmax=True, verbose=verbose)
 
     # save centerline as nifti (discrete) and csv (continuous) files
     im_centerline.save(file_output + '.nii.gz')

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -323,6 +323,8 @@ def pad_image(im, pad_x_i=0, pad_x_f=0, pad_y_i=0, pad_y_f=0, pad_z_i=0, pad_z_f
 
     padded_data[pad_x_i:pad_x_f, pad_y_i:pad_y_f, pad_z_i:pad_z_f] = im.data
     im_out = im.copy()
+    # TODO: Do not copy the Image(), because the dim field and hdr.get_data_shape() will not be updated properly.
+    #   better to just create a new Image() from scratch.
     im_out.data = padded_data  # done after the call of the function
     im_out.absolutepath = sct.add_suffix(im_out.absolutepath, "_pad")
 

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -204,7 +204,7 @@ class SpinalCordStraightener(object):
 
             # 2. extract bspline fitting of the centerline, and its derivatives
             img_ctl = Image('centerline_rpi.nii.gz')
-            _, arr_ctl, arr_ctl_der = get_centerline(img_ctl, algo_fitting=algo_fitting, verbose=verbose)
+            _, arr_ctl, arr_ctl_der = get_centerline(img_ctl, algo_fitting=algo_fitting, minmax=True, verbose=verbose)
             # Transform centerline and derivatives to physical coordinate system
             arr_ctl_phys = img_ctl.transfo_pix2phys(
                 [[arr_ctl[0][i], arr_ctl[1][i], arr_ctl[2][i]] for i in range(len(arr_ctl[0]))])
@@ -286,7 +286,7 @@ class SpinalCordStraightener(object):
                 nx_s, ny_s, nz_s, nt_s, px_s, py_s, pz_s, pt_s = image_centerline_straight.dim
                 # TODO: update this chunk below to work with physical coordinates
                 _, arr_ctl, arr_ctl_der = get_centerline(image_centerline_straight, algo_fitting=algo_fitting,
-                                                         verbose=verbose)
+                                                         minmax=True, verbose=verbose)
                 x_centerline, y_centerline, z_centerline = arr_ctl
                 x_centerline_deriv, y_centerline_deriv = arr_ctl_der
                 centerline_straight = Centerline(x_centerline.tolist(), y_centerline.tolist(), z_centerline.tolist(),

--- a/spinalcordtoolbox/centerline/core.py
+++ b/spinalcordtoolbox/centerline/core.py
@@ -40,7 +40,7 @@ def find_and_sort_coord(img):
     return np.array(arr_sorted_avg)
 
 
-def get_centerline(im_seg, algo_fitting='polyfit', minmax=False, param=ParamCenterline(), verbose=1):
+def get_centerline(im_seg, algo_fitting='polyfit', minmax=True, param=ParamCenterline(), verbose=1):
     """
     Extract centerline from an image (using optic) or from a binary or weighted segmentation (using the center of mass).
     :param im_seg: Image(): Input segmentation or series of points along the centerline.
@@ -48,7 +48,7 @@ def get_centerline(im_seg, algo_fitting='polyfit', minmax=False, param=ParamCent
         polyfit: Polynomial fitting
         nurbs:
         optic: Automatic segmentation using SVM and HOG. See [Gros et al. MIA 2018].
-    :param minmax: Crop output centerline to where the segmentation starts/end
+    :param minmax: Crop output centerline where the segmentation starts/end. If False, centerline will span all slices.
     :param param: ParamCenterline()
     :param verbose: int: verbose level
     :return: im_centerline: Image: Centerline in discrete coordinate (int)

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -16,7 +16,7 @@ from spinalcordtoolbox.centerline.core import get_centerline, ParamCenterline, f
 from spinalcordtoolbox.image import Image
 import sct_utils as sct
 
-VERBOSE = 2
+VERBOSE = 0
 
 
 @pytest.fixture(scope="session")
@@ -76,7 +76,7 @@ def test_get_centerline_polyfit(img_ctl, expected):
     deg = 3
     img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
     img_out, arr_out, _ = get_centerline(img_sub, algo_fitting='polyfit', param=ParamCenterline(degree=deg),
-                                         verbose=VERBOSE)
+                                         minmax=False, verbose=VERBOSE)
 
     assert np.linalg.norm(find_and_sort_coord(img) - find_and_sort_coord(img_out)) < expected
     # check arr_out and arr_out_deriv only if input orientation is RPI (because the output array is always in RPI)
@@ -91,7 +91,7 @@ def test_get_centerline_bspline(img_ctl, expected):
     deg = 3
     img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
     img_out, arr_out, _ = get_centerline(img_sub, algo_fitting='bspline', param=ParamCenterline(degree=deg),
-                                         verbose=VERBOSE)
+                                         minmax=False, verbose=VERBOSE)
     assert np.linalg.norm(find_and_sort_coord(img) - find_and_sort_coord(img_out)) < expected
 
 
@@ -102,7 +102,7 @@ def test_get_centerline_linear(img_ctl, expected):
     deg = 3
     img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
     img_out, arr_out, _ = get_centerline(img_sub, algo_fitting='linear', param=ParamCenterline(degree=deg),
-                                         verbose=VERBOSE)
+                                         minmax=False, verbose=VERBOSE)
     assert np.linalg.norm(find_and_sort_coord(img) - find_and_sort_coord(img_out)) < expected
 
 
@@ -113,7 +113,7 @@ def test_get_centerline_nurbs(img_ctl, expected):
     img, img_sub = [img_ctl[0].copy(), img_ctl[1].copy()]
     # Here we need a try/except because nurbs crashes with too few points.
     try:
-        img_out, arr_out, _ = get_centerline(img_sub, algo_fitting='nurbs', verbose=VERBOSE)
+        img_out, arr_out, _ = get_centerline(img_sub, algo_fitting='nurbs', minmax=False, verbose=VERBOSE)
         assert np.linalg.norm(find_and_sort_coord(img) - find_and_sort_coord(img_out)) < expected
     except ArithmeticError as e:
         print(e)
@@ -129,10 +129,11 @@ def test_get_centerline_optic():
     img_t2.data[0, 0, 0] = np.nan
     img_t2.data[1, 0, 0] = np.inf
     img_out, arr_out, _ = get_centerline(img_t2, algo_fitting='optic', param=ParamCenterline(contrast='t2'),
-                                         verbose=VERBOSE)
+                                         minmax=False, verbose=VERBOSE)
     # Open ground truth segmentation and compare
     fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg.nii.gz')
-    img_seg_out, arr_seg_out, _ = get_centerline(Image(fname_t2_seg), algo_fitting='bspline', verbose=VERBOSE)
+    img_seg_out, arr_seg_out, _ = get_centerline(Image(fname_t2_seg), algo_fitting='bspline', minmax=False,
+                                                 verbose=VERBOSE)
     assert np.linalg.norm(find_and_sort_coord(img_seg_out) - find_and_sort_coord(img_out)) < 3.5
 
 


### PR DESCRIPTION
This PR fixes extreme cases where the segmentation is incomplete, causing straightening to crash. There is also speed improvement (less i/o).

Fixes #2153 