### PR TITLE
deepseg_sc/core: do not save tmp file in the working directory

### DIFF
--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -622,9 +622,6 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         # segment data using 2D convolutions
         sct.log.info("Segmenting the spinal cord using deep learning on 2D patches...")
         segmentation_model_fname = os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc.h5'.format(contrast_type))
-        print(segmentation_model_fname)
-        print(contrast_type)
-        print((crop_size, crop_size))
         seg_crop_data = segment_2d(model_fname=segmentation_model_fname,
                                    contrast_type=contrast_type,
                                    input_size=(crop_size, crop_size),
@@ -693,4 +690,4 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         tmp_folder.cleanup()
 
     # reorient to initial orientation
-    return im_image_res_seg_downsamp_postproc.change_orientation(original_orientation), im_nii, seg_uncrop_nii.change_orientation('RPI').save('image_in_RPI_resampled_seg.nii.gz')
+    return im_image_res_seg_downsamp_postproc.change_orientation(original_orientation), im_nii, seg_uncrop_nii.change_orientation('RPI')


### PR DESCRIPTION
This PR aims at fixing the bug reported by #2151.

This PR suggests a minor change: do not save tmp file in working directory at the end of the processing.

To test it:
```
cd example_data/t2
sct_deepseg_sc -i t2.nii.gz -c t2
```