### PR TITLE
Fixed wrong estimate of derivatives on ref image

### DIFF
--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -288,10 +288,10 @@ class SpinalCordStraightener(object):
                 _, arr_ctl, arr_ctl_der = get_centerline(image_centerline_straight, algo_fitting=algo_fitting,
                                                          minmax=True, verbose=verbose)
                 x_centerline, y_centerline, z_centerline = arr_ctl
-                x_centerline_deriv, y_centerline_deriv = arr_ctl_der
+                x_centerline_deriv, y_centerline_deriv, z_centerline_deriv = arr_ctl_der
                 centerline_straight = Centerline(x_centerline.tolist(), y_centerline.tolist(), z_centerline.tolist(),
                                                  x_centerline_deriv.tolist(), y_centerline_deriv.tolist(),
-                                                 np.ones_like(x_centerline_deriv).tolist())
+                                                 z_centerline_deriv.tolist())
 
                 # Prepare warping fields headers
                 hdr_warp = image_centerline_pad.hdr.copy()

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -779,6 +779,10 @@ def find_zmin_zmax(im, threshold=0.1):
     """
     slicer = SlicerOneAxis(im, axis="IS")
 
+    # Make sure image is not empty
+    if not np.any(slicer):
+        sct.log.error('Input image is empty')
+
     # Iterate from bottom to top until we find data
     for zmin in range(0, len(slicer)):
         if np.any(slicer[zmin] > threshold):


### PR DESCRIPTION
This regression bug was introduced by https://github.com/neuropoly/spinalcordtoolbox/pull/2147.

Fixes #2164 