### PR TITLE
Faster execution and other minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tmp/**/*
 spinalcordtoolbox_v*
 dev/atlas/create_atlas/results
 dev/atlas/validate_atlas/tmp.*
+sct_testing_data
 
 scripts/.idea/misc.xml
 scripts/.idea/modules.xml

--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -161,7 +161,7 @@ sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t2.nii.gz -iseg $S
 mv warp_PAM50_t22mt1_crop.nii.gz warp_template2mt.nii.gz
 mv warp_mt1_crop2PAM50_t2.nii.gz warp_mt2template.nii.gz
 # Warp template
-sct_warp_template -d mt1_crop.nii.gz -w warp_template2mt.nii.gz
+sct_warp_template -d mt1_crop.nii.gz -w warp_template2mt.nii.gz -qc "$SCT_BP_QC_FOLDER"
 # Compute mtr
 sct_compute_mtr -mt0 mt0_reg.nii.gz -mt1 mt1_crop.nii.gz
 # Register t1w->mt1
@@ -203,7 +203,7 @@ sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz -iseg $S
 mv warp_PAM50_t12dmri_crop_moco_dwi_mean.nii.gz warp_template2dmri.nii.gz
 mv warp_dmri_crop_moco_dwi_mean2PAM50_t1.nii.gz warp_dmri2template.nii.gz
 # Warp template and white matter atlas
-sct_warp_template -d dmri_crop_moco_dwi_mean.nii.gz -w warp_template2dmri.nii.gz
+sct_warp_template -d dmri_crop_moco_dwi_mean.nii.gz -w warp_template2dmri.nii.gz -qc "$SCT_BP_QC_FOLDER"
 # Compute DTI metrics
 # Tips: The flag -method "restore" allows you to estimate the tensor with robust fit (see: sct_dmri_compute_dti -h)
 sct_dmri_compute_dti -i dmri_crop_moco.nii.gz -bval bvals.txt -bvec bvecs.txt

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -105,24 +105,21 @@ class QcImage(object):
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)
 
-    # TODO: activate feature below (for sct_warp_template)
-    # def template(self, mask):
-    #     """Show template statistical atlas"""
-    #     values = mask
-    #     values[values < 0.5] = 0
-    #     color_white = color.colorConverter.to_rgba('white', alpha=0.0)
-    #     color_blue = color.colorConverter.to_rgba('blue', alpha=0.7)
-    #     color_cyan = color.colorConverter.to_rgba('cyan', alpha=0.8)
-    #     cmap = color.LinearSegmentedColormap.from_list('cmap_atlas',
-    #                                                    [color_white, color_blue, color_cyan], N=256)
-    #
-    #     fig = plt.imshow(values,
-    #                      cmap=cmap,
-    #                      interpolation=self.interpolation,
-    #                      aspect=self.aspect_mask)
-    #
-    #     fig.axes.get_xaxis().set_visible(False)
-    #     fig.axes.get_yaxis().set_visible(False)
+    def template(self, mask, ax):
+        """Show template statistical atlas"""
+        values = mask
+        values[values < 0.5] = 0
+        color_white = color.colorConverter.to_rgba('white', alpha=0.0)
+        color_blue = color.colorConverter.to_rgba('blue', alpha=0.7)
+        color_cyan = color.colorConverter.to_rgba('cyan', alpha=0.8)
+        cmap = color.LinearSegmentedColormap.from_list('cmap_atlas',
+                                                       [color_white, color_blue, color_cyan], N=256)
+        ax.imshow(values,
+                  cmap=cmap,
+                  interpolation=self.interpolation,
+                  aspect=self.aspect_mask)
+        ax.get_xaxis().set_visible(False)
+        ax.get_yaxis().set_visible(False)
 
     def no_seg_seg(self, mask, ax):
         """Create figure with image overlay. Notably used by sct_registration_to_template"""
@@ -542,6 +539,12 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, args=None, path_qc=No
         qcslice_type = qcslice.Axial([Image(fname_in1), Image(fname_seg)])
         qcslice_operations = [QcImage.listed_seg]
         qcslice_layout = lambda x: x.mosaic()
+    elif process in ['sct_warp_template']:
+        # axial orientation, switch between the image and the linear segmentation (in blue)
+        plane = 'Axial'
+        qcslice_type = qcslice.Axial([Image(fname_in1), Image(fname_seg)])
+        qcslice_operations = [QcImage.template]
+        qcslice_layout = lambda x: x.mosaic()
     elif process in ['sct_label_vertebrae']:
         # sagittal orientation, display vertebral labels
         plane = 'Sagittal'
@@ -555,6 +558,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, args=None, path_qc=No
         qcslice_type = qcslice.Sagittal([Image(fname_in1), Image(fname_seg)], p_resample=None)
         qcslice_operations = [QcImage.highlight_pmj]
         qcslice_layout = lambda x: x.single()
+    else:
+        sct.log.error('Unrecognised process.')
 
     add_entry(
         src=fname_in1,


### PR DESCRIPTION
The main purpose of this PR was to use `isct_antsApplyTransfo` instead of SCT system call for warping each volume, resulting in faster execution. In a typical dataset, execution time goes from 4.5min to 2min. Fixes #2173. This change makes #602 less relevant, there we can consider that this PR Fixes #602.

Other improvements include:
- QC now supporting `sct_warp_template`
- Change display message at the end, in case user does not ask for atlas. Fixes #172 
- Cleanup usage. Fixes #1528

TODO:
- Add QC in batch_processing