### PR TITLE
Fixed bug and clarified usage of -centerline viewer

### DIFF
--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -122,7 +122,7 @@ def main():
 
     im_image = Image(fname_image)
     im_seg, im_labels_viewer = deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
-                                        brain_bool=brain_bool, remove_temp_files=remove_temp_files)
+                                        brain_bool=brain_bool, remove_temp_files=remove_temp_files, verbose=verbose)
 
     # Save segmentation
     fname_seg = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_lesionseg' +

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -69,9 +69,9 @@ def get_parser():
                       default_value='1')
     parser.add_option(name="-v",
                       type_value="multiple_choice",
-                      description="1: display on, 0: display off (default)",
+                      description="1: display on (default), 0: display off, 2: extended",
                       mandatory=False,
-                      example=["0", "1"],
+                      example=["0", "1", "2"],
                       default_value="1")
     parser.add_option(name='-igt',
                       type_value='image_nifti',
@@ -113,7 +113,7 @@ def main():
 
     remove_temp_files = int(arguments['-r'])
 
-    verbose = arguments['-v']
+    verbose = int(arguments['-v'])
 
     algo_config_stg = '\nMethod:'
     algo_config_stg += '\n\tCenterline algorithm: ' + str(ctr_algo)
@@ -121,7 +121,7 @@ def main():
     sct.printv(algo_config_stg)
 
     im_image = Image(fname_image)
-    im_seg, im_labels_viewer = deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
+    im_seg, im_labels_viewer, im_ctr = deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
                                         brain_bool=brain_bool, remove_temp_files=remove_temp_files, verbose=verbose)
 
     # Save segmentation
@@ -134,6 +134,12 @@ def main():
         fname_labels = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_labels-centerline' +
                                                sct.extract_fname(fname_image)[2]))
         im_labels_viewer.save(fname_labels)
+
+    if verbose == 2:
+        # Save ctr
+        fname_ctr = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_centerline' +
+                                               sct.extract_fname(fname_image)[2]))
+        im_ctr.save(fname_ctr)
 
     sct.display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -40,9 +40,9 @@ def get_parser():
                       example=['t2', 't2_ax', 't2s'])
     parser.add_option(name="-centerline",
                       type_value="multiple_choice",
-                      description="Method used for extracting the centerline.\nsvm: automatic centerline detection, based on Support Vector Machine algorithm.\ncnn: automatic centerline detection, based on Convolutional Neural Network.\nviewer: semi-automatic centerline generation, based on manual selection of a few points using an interactive viewer, then approximation with NURBS.\nmanual: use an existing centerline by specifying its filename with flag -file_centerline (e.g. -file_centerline t2_centerline_manual.nii.gz).\n",
+                      description="Method used for extracting the centerline.\nsvm: automatic centerline detection, based on Support Vector Machine algorithm.\ncnn: automatic centerline detection, based on Convolutional Neural Network.\nviewer: semi-automatic centerline generation, based on manual selection of a few points using an interactive viewer, then approximation with NURBS.\nfile: use an existing centerline by specifying its filename with flag -file_centerline (e.g. -file_centerline t2_centerline_manual.nii.gz).\n",
                       mandatory=False,
-                      example=['svm', 'cnn', 'viewer', 'manual'],
+                      example=['svm', 'cnn', 'viewer', 'file'],
                       default_value="svm")
     parser.add_option(name="-file_centerline",
                       type_value="image_nifti",
@@ -101,13 +101,13 @@ def main():
     else:
         output_folder = arguments["-ofolder"]
 
-    if ctr_algo == 'manual' and "-file_centerline" not in args:
+    if ctr_algo == 'file' and "-file_centerline" not in args:
         sct.log.error('Please use the flag -file_centerline to indicate the centerline filename.')
         sys.exit(1)
     
     if "-file_centerline" in args:
         manual_centerline_fname = arguments["-file_centerline"]
-        ctr_algo = 'manual'
+        ctr_algo = 'file'
     else:
         manual_centerline_fname = None
 

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -121,13 +121,19 @@ def main():
     sct.printv(algo_config_stg)
 
     im_image = Image(fname_image)
-    im_seg = deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
+    im_seg, im_labels_viewer = deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
                                         brain_bool=brain_bool, remove_temp_files=remove_temp_files)
 
     # Save segmentation
     fname_seg = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_lesionseg' +
                                              sct.extract_fname(fname_image)[2]))
     im_seg.save(fname_seg)
+
+    if ctr_algo == 'viewer':
+        # Save labels
+        fname_labels = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_labels-centerline' +
+                                               sct.extract_fname(fname_image)[2]))
+        im_labels_viewer.save(fname_labels)
 
     sct.display_viewer_syntax([fname_image, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -74,7 +74,7 @@ def get_parser():
                       default_value='1')
     parser.add_option(name="-v",
                       type_value="multiple_choice",
-                      description="1: display on, 0: display off (default)",
+                      description="1: display on (default), 0: display off, 2: extended",
                       mandatory=False,
                       example=["0", "1", "2"],
                       default_value="1")
@@ -159,7 +159,7 @@ def main():
         im_labels_viewer.save(fname_labels)
 
     if verbose == 2:
-        # Save labels
+        # Save ctr
         fname_ctr = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_centerline' +
                                                sct.extract_fname(fname_image)[2]))
         im_ctr.save(fname_ctr)

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -143,7 +143,7 @@ def main():
 
     im_image = Image(fname_image)
     # note: below we pass im_image.copy() otherwise the field absolutepath becomes None after execution of this function
-    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp = deep_segmentation_spinalcord(
+    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp, im_labels_viewer = deep_segmentation_spinalcord(
         im_image.copy(), contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
         brain_bool=brain_bool, kernel_size=kernel_size, remove_temp_files=remove_temp_files, verbose=verbose)
 
@@ -151,6 +151,12 @@ def main():
     fname_seg = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_seg' +
                                              sct.extract_fname(fname_image)[2]))
     im_seg.save(fname_seg)
+
+    if ctr_algo == 'viewer':
+        # Save labels
+        fname_labels = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_labels-centerline' +
+                                               sct.extract_fname(fname_image)[2]))
+        im_labels_viewer.save(fname_labels)
 
     if path_qc is not None:
         generate_qc(fname_image, fname_seg=fname_seg, args=args, path_qc=os.path.abspath(path_qc),

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -40,7 +40,7 @@ def get_parser():
                       example=['t1', 't2', 't2s', 'dwi'])
     parser.add_option(name="-centerline",
                       type_value="multiple_choice",
-                      description="Method used for extracting the centerline.\nsvm: automatic centerline detection, based on Support Vector Machine algorithm.\ncnn: automatic centerline detection, based on Convolutional Neural Network.\nviewer: semi-automatic centerline generation, based on manual selection of a few points using an interactive viewer, then approximation with NURBS.\nmanual: use an existing centerline by specifying its filename with flag -file_centerline (e.g. -file_centerline t2_centerline_manual.nii.gz).\n",
+                      description="Method used for extracting the centerline.\nsvm: automatic centerline detection, based on Support Vector Machine algorithm.\ncnn: automatic centerline detection, based on Convolutional Neural Network.\nviewer: semi-automatic centerline generation, based on manual selection of a few points using an interactive viewer, then approximation with NURBS.\nfile: use an existing centerline by specifying its filename with flag -file_centerline (e.g. -file_centerline t2_centerline_manual.nii.gz).\n",
                       mandatory=False,
                       example=['svm', 'cnn', 'viewer', 'file'],
                       default_value="svm")

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -76,7 +76,7 @@ def get_parser():
                       type_value="multiple_choice",
                       description="1: display on, 0: display off (default)",
                       mandatory=False,
-                      example=["0", "1"],
+                      example=["0", "1", "2"],
                       default_value="1")
     parser.add_option(name='-qc',
                       type_value='folder_creation',
@@ -131,7 +131,7 @@ def main():
 
     remove_temp_files = int(arguments['-r'])
 
-    verbose = arguments['-v']
+    verbose = int(arguments['-v'])
 
     path_qc = arguments.get("-qc", None)
 
@@ -143,7 +143,7 @@ def main():
 
     im_image = Image(fname_image)
     # note: below we pass im_image.copy() otherwise the field absolutepath becomes None after execution of this function
-    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp, im_labels_viewer = deep_segmentation_spinalcord(
+    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp, im_labels_viewer, im_ctr = deep_segmentation_spinalcord(
         im_image.copy(), contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
         brain_bool=brain_bool, kernel_size=kernel_size, remove_temp_files=remove_temp_files, verbose=verbose)
 
@@ -157,6 +157,12 @@ def main():
         fname_labels = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_labels-centerline' +
                                                sct.extract_fname(fname_image)[2]))
         im_labels_viewer.save(fname_labels)
+
+    if verbose == 2:
+        # Save labels
+        fname_ctr = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_centerline' +
+                                               sct.extract_fname(fname_image)[2]))
+        im_ctr.save(fname_ctr)
 
     if path_qc is not None:
         generate_qc(fname_image, fname_seg=fname_seg, args=args, path_qc=os.path.abspath(path_qc),

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -129,7 +129,6 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     """
 
     # create temporary folder with intermediate results
-    sct.log.info("\nCreating temporary folder...")
     tmp_folder = sct.TempFolder(verbose=verbose)
     tmp_folder_path = tmp_folder.get_path()
     if ctr_algo == 'file':  # if the ctr_file is provided
@@ -223,6 +222,14 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     else:
         im_image_res_labels_downsamp = None
 
+    if verbose == 2:
+        fname_res_ctr = sct.add_suffix(fname_orient, '_ctr')
+        resampling.resample_file(fname_res_ctr, fname_res_ctr, initial_resolution,
+                                                           'mm', 'linear', verbose=0)
+        im_image_res_ctr_downsamp = Image(fname_res_ctr).change_orientation(original_orientation)
+    else:
+        im_image_res_ctr_downsamp = None
+
     # binarize the resampled image to remove interpolation effects
     sct.log.info("\nBinarizing the segmentation to avoid interpolation effects...")
     thr = 0.1
@@ -239,4 +246,4 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
         tmp_folder.cleanup()
 
     # reorient to initial orientation
-    return seg_initres_nii.change_orientation(original_orientation), im_image_res_labels_downsamp
+    return seg_initres_nii.change_orientation(original_orientation), im_image_res_labels_downsamp, im_image_res_ctr_downsamp

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -215,6 +215,14 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
                                                            'mm', 'linear', verbose=0)
     seg_initres_nii = Image(fname_seg_RPI)
 
+    if ctr_algo == 'viewer':  # resample and reorient the viewer labels
+        fname_res_labels = sct.add_suffix(fname_orient, '_labels-centerline')
+        resampling.resample_file(fname_res_labels, fname_res_labels, initial_resolution,
+                                                           'mm', 'linear', verbose=0)
+        im_image_res_labels_downsamp = Image(fname_res_labels).change_orientation(original_orientation)
+    else:
+        im_image_res_labels_downsamp = None
+
     # binarize the resampled image to remove interpolation effects
     sct.log.info("\nBinarizing the segmentation to avoid interpolation effects...")
     thr = 0.1
@@ -231,4 +239,4 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
         tmp_folder.cleanup()
 
     # reorient to initial orientation
-    return seg_initres_nii.change_orientation(original_orientation)
+    return seg_initres_nii.change_orientation(original_orientation), im_image_res_labels_downsamp

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -163,9 +163,9 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     # crop image around the spinal cord centerline
     sct.log.info("\nCropping the image around the spinal cord...")
     crop_size = 48
-    X_CROP_LST, Y_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
-                                                                      ctr_in=ctr_nii,
-                                                                      crop_size=crop_size)
+    X_CROP_LST, Y_CROP_LST, Z_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
+                                                                                  ctr_in=ctr_nii,
+                                                                                  crop_size=crop_size)
     del ctr_nii
 
     # normalize the intensity of the images
@@ -202,7 +202,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     # reconstruct the segmentation from the crop data
     sct.log.info("\nReassembling the image...")
     seg_uncrop_nii = uncrop_image(ref_in=im_nii, data_crop=seg_crop.copy().data, x_crop_lst=X_CROP_LST,
-                                  y_crop_lst=Y_CROP_LST)
+                                  y_crop_lst=Y_CROP_LST, z_crop_lst=Z_CROP_LST)
     fname_seg_res_RPI = sct.add_suffix(fname_in, '_res_RPI_seg')
     seg_uncrop_nii.save(fname_seg_res_RPI)
     del seg_crop

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -132,7 +132,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     sct.log.info("\nCreating temporary folder...")
     tmp_folder = sct.TempFolder()
     tmp_folder_path = tmp_folder.get_path()
-    if ctr_algo == 'manual':  # if the ctr_file is provided
+    if ctr_algo == 'file':  # if the ctr_file is provided
         tmp_folder.copy_from(ctr_file)
         file_ctr = os.path.basename(ctr_file)
     else:

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -116,7 +116,7 @@ def segment_3d(model_fname, contrast_type, im):
 
 
 def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file=None, brain_bool=True,
-                               remove_temp_files=1):
+                               remove_temp_files=1, verbose=1):
     """
     Segment lesions from MRI data.
     :param im_image: Image() object containing the lesions to segment
@@ -130,7 +130,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
 
     # create temporary folder with intermediate results
     sct.log.info("\nCreating temporary folder...")
-    tmp_folder = sct.TempFolder()
+    tmp_folder = sct.TempFolder(verbose=verbose)
     tmp_folder_path = tmp_folder.get_path()
     if ctr_algo == 'file':  # if the ctr_file is provided
         tmp_folder.copy_from(ctr_file)

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -576,7 +576,6 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
                                  kernel_size='2d', remove_temp_files=1, verbose=1):
     """Pipeline"""
     # create temporary folder with intermediate results
-    sct.log.info("Creating temporary folder...")
     # file_fname = os.path.basename(fname_image)
     tmp_folder = sct.TempFolder(verbose=verbose)
     tmp_folder_path = tmp_folder.get_path()
@@ -685,6 +684,14 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     else:
         im_image_res_labels_downsamp = None
 
+    if verbose == 2:
+        fname_res_ctr = sct.add_suffix(fname_orient, '_ctr')
+        resampling.resample_file(fname_res_ctr, fname_res_ctr, initial_resolution,
+                                                           'mm', 'linear', verbose=0)
+        im_image_res_ctr_downsamp = Image(fname_res_ctr).change_orientation(original_orientation)
+    else:
+        im_image_res_ctr_downsamp = None
+
     # binarize the resampled image to remove interpolation effects
     sct.log.info("Binarizing the segmentation to avoid interpolation effects...")
     thr = 0.0001 if contrast_type in ['t1', 'dwi'] else 0.5
@@ -703,4 +710,4 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         tmp_folder.cleanup()
 
     # reorient to initial orientation
-    return im_image_res_seg_downsamp_postproc.change_orientation(original_orientation), im_nii, seg_uncrop_nii.change_orientation('RPI'), im_image_res_labels_downsamp
+    return im_image_res_seg_downsamp_postproc.change_orientation(original_orientation), im_nii, seg_uncrop_nii.change_orientation('RPI'), im_image_res_labels_downsamp, im_image_res_ctr_downsamp

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -111,11 +111,15 @@ def find_centerline(algo, image_fname, contrast_type, brain_bool, folder_output,
         im_labels = _call_viewer_centerline(Image(image_fname))
         im_centerline, arr_centerline, _ = get_centerline(im_labels)
         centerline_filename = sct.add_suffix(image_fname, "_ctr")
+        labels_filename = sct.add_suffix(image_fname, "_labels-centerline")
         im_centerline.save(centerline_filename)
+        im_labels.save(labels_filename)
+
     elif algo == 'file':
         centerline_filename = sct.add_suffix(image_fname, "_ctr")
         # Re-orient the manual centerline
         Image(centerline_fname).change_orientation('RPI').save(centerline_filename)
+
     else:
         sct.log.error('The parameter "-centerline" is incorrect. Please try again.')
         sys.exit(1)
@@ -673,6 +677,14 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
                                                            'mm', 'linear', verbose=0)
     im_image_res_seg_downsamp = Image(fname_res_seg_downsamp)
 
+    if ctr_algo == 'viewer':
+        fname_res_labels = sct.add_suffix(fname_orient, '_labels-centerline')
+        resampling.resample_file(fname_res_labels, fname_res_labels, initial_resolution,
+                                                           'mm', 'linear', verbose=0)
+        im_image_res_labels_downsamp = Image(fname_res_labels).change_orientation(original_orientation)
+    else:
+        im_image_res_labels_downsamp = None
+
     # binarize the resampled image to remove interpolation effects
     sct.log.info("Binarizing the segmentation to avoid interpolation effects...")
     thr = 0.0001 if contrast_type in ['t1', 'dwi'] else 0.5
@@ -691,4 +703,4 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         tmp_folder.cleanup()
 
     # reorient to initial orientation
-    return im_image_res_seg_downsamp_postproc.change_orientation(original_orientation), im_nii, seg_uncrop_nii.change_orientation('RPI')
+    return im_image_res_seg_downsamp_postproc.change_orientation(original_orientation), im_nii, seg_uncrop_nii.change_orientation('RPI'), im_image_res_labels_downsamp

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -578,7 +578,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # create temporary folder with intermediate results
     sct.log.info("Creating temporary folder...")
     # file_fname = os.path.basename(fname_image)
-    tmp_folder = sct.TempFolder()
+    tmp_folder = sct.TempFolder(verbose=verbose)
     tmp_folder_path = tmp_folder.get_path()
     # fname_image_tmp = tmp_folder.copy_from(fname_image)
     if ctr_algo == 'file':  # if the ctr_file is provided

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -192,11 +192,7 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
 
             x_lst.append(str(x_start))
             y_lst.append(str(y_start))
-<<<<<<< bd4d0bab9ced1ea362be54c8575636822048942f
             z_lst.append(zz)
-=======
-            z_lst.append(str(zz))
->>>>>>> deepseg_sc.crop: output the z coordinates
 
     im_new.data = data_im_new
     return x_lst, y_lst, z_lst, im_new

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -192,7 +192,11 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
 
             x_lst.append(str(x_start))
             y_lst.append(str(y_start))
+<<<<<<< bd4d0bab9ced1ea362be54c8575636822048942f
             z_lst.append(zz)
+=======
+            z_lst.append(str(zz))
+>>>>>>> deepseg_sc.crop: output the z coordinates
 
     im_new.data = data_im_new
     return x_lst, y_lst, z_lst, im_new

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -175,7 +175,7 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
     data_in = im_in.data.astype(np.float32)
     im_new = empty_like(im_in)  # but in fact we're going to crop it
 
-    x_lst, y_lst = [], []
+    x_lst, y_lst, z_lst = [], [], []
     data_im_new = np.zeros((crop_size, crop_size, im_in.dim[2]))
     for zz in range(im_in.dim[2]):
         if np.any(np.array(data_ctr[:, :, zz])):
@@ -192,9 +192,10 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
 
             x_lst.append(str(x_start))
             y_lst.append(str(y_start))
+            z_lst.append(zz)
 
     im_new.data = data_im_new
-    return x_lst, y_lst, im_new
+    return x_lst, y_lst, z_lst, im_new
 
 
 def _remove_extrem_holes(z_lst, end_z, start_z=0):
@@ -491,15 +492,15 @@ def segment_2d(model_fname, contrast_type, input_size, im_in):
     return seg_crop.data
 
 
-def uncrop_image(ref_in, data_crop, x_crop_lst, y_crop_lst):
+def uncrop_image(ref_in, data_crop, x_crop_lst, y_crop_lst, z_crop_lst):
     """Reconstruc the data from the crop segmentation."""
     seg_unCrop = zeros_like(ref_in, dtype=np.uint8)
 
     crop_size_x, crop_size_y = data_crop.shape[:2]
 
-    for zz in range(len(x_crop_lst)):
+    for i_z, zz in enumerate(z_crop_lst):
         pred_seg = data_crop[:, :, zz]
-        x_start, y_start = int(x_crop_lst[zz]), int(y_crop_lst[zz])
+        x_start, y_start = int(x_crop_lst[i_z]), int(y_crop_lst[i_z])
         x_end = x_start + crop_size_x if x_start + crop_size_x < seg_unCrop.dim[0] else seg_unCrop.dim[0]
         y_end = y_start + crop_size_y if y_start + crop_size_y < seg_unCrop.dim[1] else seg_unCrop.dim[1]
         seg_unCrop.data[x_start:x_end, y_start:y_end, zz] = pred_seg[0:x_end - x_start, 0:y_end - y_start]
@@ -607,9 +608,9 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # crop image around the spinal cord centerline
     sct.log.info("Cropping the image around the spinal cord...")
     crop_size = 96 if (kernel_size == '3d' and contrast_type == 't2s') else 64
-    X_CROP_LST, Y_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
-                                                                       ctr_in=ctr_nii,
-                                                                       crop_size=crop_size)
+    X_CROP_LST, Y_CROP_LST, Z_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
+                                                                                   ctr_in=ctr_nii,
+                                                                                   crop_size=crop_size)
     del ctr_nii
 
     # normalize the intensity of the images
@@ -657,7 +658,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     seg_uncrop_nii = uncrop_image(ref_in=im_nii,
                                   data_crop=seg_crop_data,
                                   x_crop_lst=X_CROP_LST,
-                                  y_crop_lst=Y_CROP_LST)
+                                  y_crop_lst=Y_CROP_LST,
+                                  z_crop_lst=Z_CROP_LST)
     fname_res_seg = sct.add_suffix(fname_res, '_seg')
     seg_uncrop_nii.save(fname_res_seg)
     del seg_crop_data

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -677,7 +677,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
                                                            'mm', 'linear', verbose=0)
     im_image_res_seg_downsamp = Image(fname_res_seg_downsamp)
 
-    if ctr_algo == 'viewer':
+    if ctr_algo == 'viewer':  # resample and reorient the viewer labels
         fname_res_labels = sct.add_suffix(fname_orient, '_labels-centerline')
         resampling.resample_file(fname_res_labels, fname_res_labels, initial_resolution,
                                                            'mm', 'linear', verbose=0)

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -112,7 +112,7 @@ def find_centerline(algo, image_fname, contrast_type, brain_bool, folder_output,
         im_centerline, arr_centerline, _ = get_centerline(im_labels)
         centerline_filename = sct.add_suffix(image_fname, "_ctr")
         im_centerline.save(centerline_filename)
-    elif algo == 'manual':
+    elif algo == 'file':
         centerline_filename = sct.add_suffix(image_fname, "_ctr")
         # Re-orient the manual centerline
         Image(centerline_fname).change_orientation('RPI').save(centerline_filename)
@@ -577,7 +577,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     tmp_folder = sct.TempFolder()
     tmp_folder_path = tmp_folder.get_path()
     # fname_image_tmp = tmp_folder.copy_from(fname_image)
-    if ctr_algo == 'manual':  # if the ctr_file is provided
+    if ctr_algo == 'file':  # if the ctr_file is provided
         tmp_folder.copy_from(ctr_file)
         file_ctr = os.path.basename(ctr_file)
     else:

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -38,10 +38,10 @@ def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
     resample_file(fname_t2_seg_RPI, fname_t2_seg_RPI_res, new_resolution, 'mm', 'linear', verbose=0)
 
     img, ctr, gt = Image(fname_res), Image(fname_ctr), Image(fname_t2_seg_RPI_res)
-    _, _, img = deepseg_sc.crop_image_around_centerline(im_in=img,
+    _, _, _, img = deepseg_sc.crop_image_around_centerline(im_in=img,
                                                         ctr_in=ctr,
                                                         crop_size=64)
-    _, _, gt = deepseg_sc.crop_image_around_centerline(im_in=gt,
+    _, _, _, gt = deepseg_sc.crop_image_around_centerline(im_in=gt,
                                                         ctr_in=ctr,
                                                         crop_size=64)
     del ctr
@@ -125,7 +125,7 @@ def test_crop_image_around_centerline():
 
     ctr, _ = dummy_centerline_small(size_arr=input_shape)
 
-    _, _, img_out = deepseg_sc.crop_image_around_centerline(im_in=img.copy(),
+    _, _, _, img_out = deepseg_sc.crop_image_around_centerline(im_in=img.copy(),
                                                         ctr_in=ctr.copy(),
                                                         crop_size=crop_size)
 
@@ -147,6 +147,7 @@ def test_uncrop_image():
 
     x_crop_lst = list(np.random.randint(0, input_shape[0]-crop_size, input_shape[2]))
     y_crop_lst = list(np.random.randint(0,input_shape[1]-crop_size, input_shape[2]))
+    z_crop_lst = range(input_shape[2])
 
     affine = np.eye(4)
     nii = nib.nifti1.Nifti1Image(data_in, affine)
@@ -155,9 +156,8 @@ def test_uncrop_image():
     img_uncrop = deepseg_sc.uncrop_image(ref_in=img_in,
                                         data_crop=data_crop,
                                         x_crop_lst=x_crop_lst,
-                                        y_crop_lst=y_crop_lst)
-
-
+                                        y_crop_lst=y_crop_lst,
+                                        z_crop_lst=z_crop_lst)
 
     assert img_uncrop.data.shape == input_shape
     z_rand = np.random.randint(0, input_shape[2])


### PR DESCRIPTION
This PR aims at:
- fixing the bug #2168 
- implement the suggested enhancement: #2167 

### Syntax bug:
There was a confusion between an old and new naming convention for `-centerline manual` versus `-centerline file`. We have now `file` everywhere, in both `sct_deepseg_lesion` and `sct_deepseg_sc`.
For instance:
```
sct_deepseg_sc -i t2.nii.gz -c t2 -centerline file -file_centerline t2_ctr.nii.gz
```

### New output:
Output the viewer labels when using `-centerline viewer`. Implemented in both `sct_deepseg_lesion` and `sct_deepseg_sc`. The output file has the following suffix: `_labels-centerline.nii.gz`.
To test:
```
sct_deepseg_sc -i t2.nii.gz -c t2 -centerline viewer
```

Fixes #2167, Fixes #2168