### PR TITLE
Fix I-S shift when -centerline viewer

### DIFF
--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -163,9 +163,9 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     # crop image around the spinal cord centerline
     sct.log.info("\nCropping the image around the spinal cord...")
     crop_size = 48
-    X_CROP_LST, Y_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
-                                                                      ctr_in=ctr_nii,
-                                                                      crop_size=crop_size)
+    X_CROP_LST, Y_CROP_LST, Z_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
+                                                                                  ctr_in=ctr_nii,
+                                                                                  crop_size=crop_size)
     del ctr_nii
 
     # normalize the intensity of the images

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -202,7 +202,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     # reconstruct the segmentation from the crop data
     sct.log.info("\nReassembling the image...")
     seg_uncrop_nii = uncrop_image(ref_in=im_nii, data_crop=seg_crop.copy().data, x_crop_lst=X_CROP_LST,
-                                  y_crop_lst=Y_CROP_LST)
+                                  y_crop_lst=Y_CROP_LST, z_crop_lst=Z_CROP_LST)
     fname_seg_res_RPI = sct.add_suffix(fname_in, '_res_RPI_seg')
     seg_uncrop_nii.save(fname_seg_res_RPI)
     del seg_crop

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -192,7 +192,7 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
 
             x_lst.append(str(x_start))
             y_lst.append(str(y_start))
-            z_lst.append(str(zz))
+            z_lst.append(zz)
 
     im_new.data = data_im_new
     return x_lst, y_lst, z_lst, im_new
@@ -492,15 +492,15 @@ def segment_2d(model_fname, contrast_type, input_size, im_in):
     return seg_crop.data
 
 
-def uncrop_image(ref_in, data_crop, x_crop_lst, y_crop_lst):
+def uncrop_image(ref_in, data_crop, x_crop_lst, y_crop_lst, z_crop_lst):
     """Reconstruc the data from the crop segmentation."""
     seg_unCrop = zeros_like(ref_in, dtype=np.uint8)
 
     crop_size_x, crop_size_y = data_crop.shape[:2]
 
-    for zz in range(len(x_crop_lst)):
+    for i_z, zz in enumerate(z_crop_lst):
         pred_seg = data_crop[:, :, zz]
-        x_start, y_start = int(x_crop_lst[zz]), int(y_crop_lst[zz])
+        x_start, y_start = int(x_crop_lst[i_z]), int(y_crop_lst[i_z])
         x_end = x_start + crop_size_x if x_start + crop_size_x < seg_unCrop.dim[0] else seg_unCrop.dim[0]
         y_end = y_start + crop_size_y if y_start + crop_size_y < seg_unCrop.dim[1] else seg_unCrop.dim[1]
         seg_unCrop.data[x_start:x_end, y_start:y_end, zz] = pred_seg[0:x_end - x_start, 0:y_end - y_start]
@@ -658,7 +658,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     seg_uncrop_nii = uncrop_image(ref_in=im_nii,
                                   data_crop=seg_crop_data,
                                   x_crop_lst=X_CROP_LST,
-                                  y_crop_lst=Y_CROP_LST)
+                                  y_crop_lst=Y_CROP_LST,
+                                  z_crop_lst=Z_CROP_LST)
     fname_res_seg = sct.add_suffix(fname_res, '_seg')
     seg_uncrop_nii.save(fname_res_seg)
     del seg_crop_data

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -175,7 +175,7 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
     data_in = im_in.data.astype(np.float32)
     im_new = empty_like(im_in)  # but in fact we're going to crop it
 
-    x_lst, y_lst = [], []
+    x_lst, y_lst, z_lst = [], [], []
     data_im_new = np.zeros((crop_size, crop_size, im_in.dim[2]))
     for zz in range(im_in.dim[2]):
         if np.any(np.array(data_ctr[:, :, zz])):
@@ -192,9 +192,10 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
 
             x_lst.append(str(x_start))
             y_lst.append(str(y_start))
+            z_lst.append(str(zz))
 
     im_new.data = data_im_new
-    return x_lst, y_lst, im_new
+    return x_lst, y_lst, z_lst, im_new
 
 
 def _remove_extrem_holes(z_lst, end_z, start_z=0):
@@ -607,9 +608,9 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # crop image around the spinal cord centerline
     sct.log.info("Cropping the image around the spinal cord...")
     crop_size = 96 if (kernel_size == '3d' and contrast_type == 't2s') else 64
-    X_CROP_LST, Y_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
-                                                                       ctr_in=ctr_nii,
-                                                                       crop_size=crop_size)
+    X_CROP_LST, Y_CROP_LST, Z_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_nii,
+                                                                                   ctr_in=ctr_nii,
+                                                                                   crop_size=crop_size)
     del ctr_nii
 
     # normalize the intensity of the images

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -38,10 +38,10 @@ def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
     resample_file(fname_t2_seg_RPI, fname_t2_seg_RPI_res, new_resolution, 'mm', 'linear', verbose=0)
 
     img, ctr, gt = Image(fname_res), Image(fname_ctr), Image(fname_t2_seg_RPI_res)
-    _, _, img = deepseg_sc.crop_image_around_centerline(im_in=img,
+    _, _, _, img = deepseg_sc.crop_image_around_centerline(im_in=img,
                                                         ctr_in=ctr,
                                                         crop_size=64)
-    _, _, gt = deepseg_sc.crop_image_around_centerline(im_in=gt,
+    _, _, _, gt = deepseg_sc.crop_image_around_centerline(im_in=gt,
                                                         ctr_in=ctr,
                                                         crop_size=64)
     del ctr
@@ -125,7 +125,7 @@ def test_crop_image_around_centerline():
 
     ctr, _ = dummy_centerline_small(size_arr=input_shape)
 
-    _, _, img_out = deepseg_sc.crop_image_around_centerline(im_in=img.copy(),
+    _, _, _, img_out = deepseg_sc.crop_image_around_centerline(im_in=img.copy(),
                                                         ctr_in=ctr.copy(),
                                                         crop_size=crop_size)
 

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -147,6 +147,7 @@ def test_uncrop_image():
 
     x_crop_lst = list(np.random.randint(0, input_shape[0]-crop_size, input_shape[2]))
     y_crop_lst = list(np.random.randint(0,input_shape[1]-crop_size, input_shape[2]))
+    z_crop_lst = range(input_shape[2])
 
     affine = np.eye(4)
     nii = nib.nifti1.Nifti1Image(data_in, affine)
@@ -155,7 +156,8 @@ def test_uncrop_image():
     img_uncrop = deepseg_sc.uncrop_image(ref_in=img_in,
                                         data_crop=data_crop,
                                         x_crop_lst=x_crop_lst,
-                                        y_crop_lst=y_crop_lst)
+                                        y_crop_lst=y_crop_lst,
+                                        z_crop_lst=z_crop_lst)
 
 
 

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -159,8 +159,6 @@ def test_uncrop_image():
                                         y_crop_lst=y_crop_lst,
                                         z_crop_lst=z_crop_lst)
 
-
-
     assert img_uncrop.data.shape == input_shape
     z_rand = np.random.randint(0, input_shape[2])
     assert np.allclose(img_uncrop.data[x_crop_lst[z_rand]:x_crop_lst[z_rand]+crop_size,


### PR DESCRIPTION
/!\ DO NOT MERGE --> waiting for https://github.com/neuropoly/spinalcordtoolbox/pull/2183

This PR aims at fixing the issue #2186:
when the centerline does not start from `z=0`, then the segmentation is shifted in the I-S direction.
It can happen when:
- `-centerline viewer` --> the user do not add a label on the first slice
- `-centerline file` --> when the centerline does not start from `z=0`

The suggested solution is: To use the z coordinates of the centerline when the segmentation is reconstructed (ie `deepseg_sc.uncrop_image`), instead of assuming that it starts at `z=0`.

To test:
Data (internal server): 20190309_issue2186
```
sct_deepseg_sc -i sanlm_structural.nii.gz -c t1 -ofolder deepseg.viewer -centerline viewer
```

Fixes #2186 
