### PR TITLE
Fixed ignored -init flag and minor improvements

### DIFF
--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -547,6 +547,11 @@ def propseg(img_input, options_dict):
         image_centerline.save('centerline.nii.gz')
         cmd += ["-init-centerline", 'centerline.nii.gz']
 
+    if init_option is not None:
+        if init_option > 1:
+            init_option /= (nz - 1)
+        cmd += ['-init', str(init_option)]
+
     # enabling centerline extraction by default (needed by check_and_correct_segmentation() )
     cmd += ['-centerline-binary']
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -486,7 +486,8 @@ def propseg(img_input, options_dict):
 
     # check if input image is in 3D. Otherwise itk image reader will cut the 4D image in 3D volumes and only take the first one.
     image_input = Image(fname_data)
-    nx, ny, nz, nt, px, py, pz, pt = image_input.dim
+    image_input_rpi = image_input.copy().change_orientation('RPI')
+    nx, ny, nz, nt, px, py, pz, pt = image_input_rpi.dim
     if nt > 1:
         sct.log.error('ERROR: your input image needs to be 3D in order to be segmented.')
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -539,12 +539,6 @@ def propseg(img_input, options_dict):
 
     # If using OptiC
     elif use_optic:
-        path_script = os.path.dirname(__file__)
-        path_sct = os.path.dirname(path_script)
-        path_classifier = os.path.join(path_sct,
-                                       'data/optic_models',
-                                       '{}_model'.format(contrast_type))
-
         image_centerline = optic.detect_centerline(image_input, contrast_type)
         fname_centerline_optic = os.path.join(path_tmp, 'centerline_optic.nii.gz')
         image_centerline.save(fname_centerline_optic)

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -609,7 +609,7 @@ def main(arguments):
     if path_qc is not None:
         generate_qc(fname_in1=fname_input_data, fname_seg=fname_seg, args=args, path_qc=os.path.abspath(path_qc),
                     process='sct_propseg')
-    sct.display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    sct.display_viewer_syntax([fname_input_data, fname_seg], colormaps=['gray', 'red'], opacities=['', '1'])
 
 
 if __name__ == "__main__":

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -492,6 +492,7 @@ def propseg(img_input, options_dict):
         sct.log.error('ERROR: your input image needs to be 3D in order to be segmented.')
 
     path_data, file_data, ext_data = sct.extract_fname(fname_data)
+    path_tmp = sct.tmp_create(basename="label_vertebrae", verbose=verbose)
 
     # rescale header (see issue #1406)
     if rescale_header is not 1:
@@ -545,8 +546,9 @@ def propseg(img_input, options_dict):
                                        '{}_model'.format(contrast_type))
 
         image_centerline = optic.detect_centerline(image_input, contrast_type)
-        image_centerline.save('centerline.nii.gz')
-        cmd += ["-init-centerline", 'centerline.nii.gz']
+        fname_centerline_optic = os.path.join(path_tmp, 'centerline_optic.nii.gz')
+        image_centerline.save(fname_centerline_optic)
+        cmd += ["-init-centerline", fname_centerline_optic]
 
     if init_option is not None:
         if init_option > 1:


### PR DESCRIPTION
Due to a regression bug, `v4.0.0-beta.1` was not accounting for the flag `-init` anymore. This PR addresses that issue, as well as other minor improvements:

- Fixed `-init` flag ignored in v4.0.0-beta.1. Fixes #2190
- Output segmentation now overlaid with opacity=100 in display_syntax_viewer(). Fixes #1833
- No more save Optic centerline output because there is already another centerline output, called `xxx_centerline.nii.gz` and directly derived from the segmentation directly (hence more precise).
