### PR TITLE
Fixed bug in the post processing of detect_c2c3

### DIFF
--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -138,11 +138,13 @@ def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, remove
     nii_im = Image(fname_im)
     nii_seg = Image(fname_seg)
 
+    remove_temp_files = int(remove_temp_files)
+
     # detect C2-C3
-    if remove_temp_file:
-        nii_c2c3 = detect_c2c3(nii_im, nii_seg, contrast, verbose=verbose)
+    if remove_temp_files:
+        nii_c2c3 = detect_c2c3(nii_im.copy(), nii_seg, contrast, verbose=verbose)
     else:
-        nii_c2c3, nii_midSlice, nii_mask, nii_after_postPro, nii_before_postPro = detect_c2c3(nii_im,
+        nii_c2c3, nii_midSlice, nii_mask, nii_after_postPro, nii_before_postPro = detect_c2c3(nii_im.copy(),
                                                                                                 nii_seg,
                                                                                                 contrast,
                                                                                                 remove_temp_files=remove_temp_files,

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -30,12 +30,13 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image, zeros_like
 
 
-def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
+def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, verbose=1):
     """
     Detect the posterior edge of C2-C3 disc.
     :param nii_im:
     :param nii_seg:
     :param contrast:
+    :parem remove_temp_file:
     :param verbose:
     :return:
     """
@@ -116,10 +117,13 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     tmp_folder.cleanup()
 
     nii_c2c3.change_orientation(orientation_init)
-    return nii_c2c3, nii_midSlice, nii_postPro_mask, nii_pred_after_postPro, nii_pred_before_postPro
+    if remove_temp_files:
+        return nii_c2c3
+    else:
+        return nii_c2c3, nii_midSlice, nii_postPro_mask, nii_pred_after_postPro, nii_pred_before_postPro
 
 
-def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, verbose=1):
+def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, remove_temp_files=1, verbose=1):
     """
     Detect the posterior edge of C2-C3 disc.
     :param fname_im:
@@ -135,7 +139,10 @@ def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, verbos
     nii_seg = Image(fname_seg)
 
     # detect C2-C3
-    nii_c2c3 = detect_c2c3(nii_im, nii_seg, contrast, verbose=verbose)
+    if remove_temp_file:
+        nii_c2c3 = detect_c2c3(nii_im, nii_seg, contrast, verbose=verbose)
+    else:
+        nii_c2c3 = detect_c2c3(nii_im, nii_seg, contrast, remove_temp_files=remove_temp_files, verbose=verbose)
 
     # Output C2-C3 disc label
     # by default, output in the same directory as the input images

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -86,7 +86,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
         if np.any(row > 0):
             med_y = int(np.rint(np.median(np.where(row > 0))))
             midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize, z] = 1  # 2D data with PI orientation, mid sag slice of the original data
-    # save the created mask
+    # copy the created mask in an Image object
     nii_postPro_mask = nii_midSlice.copy()
     nii_postPro_mask.data = midSlice_mask  # 2D data with PI orientation, mid sag slice of the original data
 

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -85,10 +85,16 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
         if np.any(row > 0):
             med_y = int(np.rint(np.median(np.where(row > 0))))
             midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize, z] = 1
+    # save the created mask
+    nii_postPro_mask = nii_midSlice.copy()
+    nii_postPro_mask.data = midSlice_mask
 
     # mask prediction
     pred[midSlice_mask == 0] = 0
     pred[:, z_seg_max:] = 0  # Mask above SC segmentation
+    # save the prediction data after post-processing
+    nii_pred_after_postPro = nii_midSlice.copy()
+    nii_pred_after_postPro.data = pred
 
     # assign label to voxel
     nii_c2c3 = zeros_like(nii_seg_flat)
@@ -110,7 +116,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     tmp_folder.cleanup()
 
     nii_c2c3.change_orientation(orientation_init)
-    return nii_c2c3
+    return nii_c2c3, nii_midSlice, nii_postPro_mask, nii_pred_after_postPro, nii_pred_before_postPro
 
 
 def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, verbose=1):

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -79,7 +79,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     mask_halfSize = int(np.rint(25.0 / nii_midSlice.dim[4]))
     for z in range(midSlice_mask.shape[1]):
         row = midSlice_seg[:, z]
-        if np.any(row):
+        if np.any(row > 0):
             med_y = int(np.rint(np.median(np.where(row))))
             midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize] = 1
 

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -74,7 +74,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
     sct.run(cmd_detection, verbose=0, raise_exception=False)
 
     pred = nib.load('data_midSlice_pred_svm.hdr').get_data()
-    # save the prediction data before post-processing
+    # copy the "prediction data before post-processing" in an Image object
     nii_pred_before_postPro = nii_midSlice.copy()
     nii_pred_before_postPro.data = pred
 
@@ -93,7 +93,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
     # mask prediction
     pred[midSlice_mask == 0] = 0
     pred[:, z_seg_max:] = 0  # Mask above SC segmentation
-    # save the prediction data after post-processing
+    # copy the "prediction data after post-processing" in an Image object
     nii_pred_after_postPro = nii_midSlice.copy()
     nii_pred_after_postPro.data = pred
 

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -80,7 +80,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     for z in range(midSlice_mask.shape[1]):
         row = midSlice_seg[:, z]
         if np.any(row > 0):
-            med_y = int(np.rint(np.median(np.where(row))))
+            med_y = int(np.rint(np.median(np.where(row > 0))))
             midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize, z] = 1
 
     # mask prediction

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -73,6 +73,9 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     sct.run(cmd_detection, verbose=0, raise_exception=False)
 
     pred = nib.load('data_midSlice_pred_svm.hdr').get_data()
+    # save the prediction data before post-processing
+    nii_pred_before_postPro = nii_midSlice.copy()
+    nii_pred_before_postPro.data = pred
 
     # Create mask along centerline
     midSlice_mask = np.zeros(midSlice_seg.shape)

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -30,13 +30,12 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image, zeros_like
 
 
-def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, verbose=1):
+def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     """
     Detect the posterior edge of C2-C3 disc.
     :param nii_im:
     :param nii_seg:
     :param contrast:
-    :param remove_temp_file:
     :param verbose:
     :return:
     """
@@ -117,13 +116,13 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
     tmp_folder.cleanup()
 
     nii_c2c3.change_orientation(orientation_init)
-    if remove_temp_files:
+    if verbose < 2:
         return nii_c2c3
-    else:
+    else:  # if verbose == 2, then output temporary files
         return nii_c2c3, nii_midSlice, nii_postPro_mask, nii_pred_after_postPro, nii_pred_before_postPro
 
 
-def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, remove_temp_files=1, verbose=1):
+def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, verbose=1):
     """
     Detect the posterior edge of C2-C3 disc.
     :param fname_im:
@@ -138,16 +137,13 @@ def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, remove
     nii_im = Image(fname_im)
     nii_seg = Image(fname_seg)
 
-    remove_temp_files = int(remove_temp_files)
-
     # detect C2-C3
-    if remove_temp_files:
+    if verbose < 2:
         nii_c2c3 = detect_c2c3(nii_im.copy(), nii_seg, contrast, verbose=verbose)
     else:
         nii_c2c3, nii_midSlice, nii_mask, nii_after_postPro, nii_before_postPro = detect_c2c3(nii_im.copy(),
                                                                                                 nii_seg,
                                                                                                 contrast,
-                                                                                                remove_temp_files=remove_temp_files,
                                                                                                 verbose=verbose)
         nii_midSlice.save(os.path.join(os.path.dirname(nii_im.absolutepath), "tmp_midSlice.nii.gz"))
         nii_mask.save(os.path.join(os.path.dirname(nii_im.absolutepath), "tmp_midSlice_mask.nii.gz"))

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -76,19 +76,19 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
     pred = nib.load('data_midSlice_pred_svm.hdr').get_data()
     # copy the "prediction data before post-processing" in an Image object
     nii_pred_before_postPro = nii_midSlice.copy()
-    nii_pred_before_postPro.data = pred
+    nii_pred_before_postPro.data = pred  # 2D data with orientation, mid sag slice of the original data
 
     # Create mask along centerline
     midSlice_mask = np.zeros(midSlice_seg.shape)
     mask_halfSize = int(np.rint(25.0 / nii_midSlice.dim[4]))
     for z in range(midSlice_mask.shape[1]):
-        row = midSlice_seg[:, z]
+        row = midSlice_seg[:, z]  # 2D data with PI orientation, mid sag slice of the original data
         if np.any(row > 0):
             med_y = int(np.rint(np.median(np.where(row > 0))))
-            midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize, z] = 1
+            midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize, z] = 1  # 2D data with PI orientation, mid sag slice of the original data
     # save the created mask
     nii_postPro_mask = nii_midSlice.copy()
-    nii_postPro_mask.data = midSlice_mask
+    nii_postPro_mask.data = midSlice_mask  # 2D data with PI orientation, mid sag slice of the original data
 
     # mask prediction
     pred[midSlice_mask == 0] = 0
@@ -98,7 +98,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
     nii_pred_after_postPro.data = pred
 
     # assign label to voxel
-    nii_c2c3 = zeros_like(nii_seg_flat)
+    nii_c2c3 = zeros_like(nii_seg_flat)  # 3D data with PIR orientaion
     if np.any(pred > 0):
         sct.printv('C2-C3 detected...', verbose)
 

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -52,7 +52,6 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     # create temporary folder with intermediate results
     sct.log.info("Creating temporary folder...")
     tmp_folder = sct.TempFolder()
-    # print tmp_folder.path_tmp
     tmp_folder.chdir()
 
     # Extract mid-slice
@@ -86,8 +85,6 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
 
     # mask prediction
     pred[midSlice_mask == 0] = 0
-    # dist_medulla = 30.0 if contrast == 't1' else 40.0  # Observation: segmentation ends higher on t2 images than t1
-    # z_seg_max -= int(np.rint(dist_medulla / nii_midSlice.dim[5])) # TODO: take into account the curvature
     pred[:, z_seg_max:] = 0  # Mask above SC segmentation
 
     # assign label to voxel
@@ -96,17 +93,6 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
         sct.printv('C2-C3 detected...', verbose)
 
         pred_bin = (pred > 0).astype(np.int_)
-        # labeled_pred, nb_regions = label_regions(pred_bin, return_num=True)
-        # if nb_regions > 1:  # if there are several clusters of voxels detected
-        #     region_idx_top, region_z_top = 0, 0
-        #     for region_idx in range(1, nb_regions+1):
-        #         pred_idx = (labeled_pred == region_idx).astype(np.int_)
-        #         pa_com, is_com = center_of_mass(pred_idx)
-        #         if is_com >= region_z_top:
-        #             region_idx_top = region_idx
-        #             region_z_top = is_com
-        #     pred[labeled_pred != region_idx_top] = 0  # then keep the one located at the top (IS direction)
-
         coord_max = np.where(pred == np.max(pred))
         pa_c2c3, is_c2c3 = coord_max[0][0], coord_max[1][0]
         nii_seg.change_orientation('PIR')

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -81,7 +81,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
         row = midSlice_seg[:, z]
         if np.any(row > 0):
             med_y = int(np.rint(np.median(np.where(row))))
-            midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize] = 1
+            midSlice_mask[med_y-mask_halfSize:med_y+mask_halfSize, z] = 1
 
     # mask prediction
     pred[midSlice_mask == 0] = 0

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -36,7 +36,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, remove_temp_files=1, 
     :param nii_im:
     :param nii_seg:
     :param contrast:
-    :parem remove_temp_file:
+    :param remove_temp_file:
     :param verbose:
     :return:
     """

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -142,7 +142,15 @@ def detect_c2c3_from_file(fname_im, fname_seg, contrast, fname_c2c3=None, remove
     if remove_temp_file:
         nii_c2c3 = detect_c2c3(nii_im, nii_seg, contrast, verbose=verbose)
     else:
-        nii_c2c3 = detect_c2c3(nii_im, nii_seg, contrast, remove_temp_files=remove_temp_files, verbose=verbose)
+        nii_c2c3, nii_midSlice, nii_mask, nii_after_postPro, nii_before_postPro = detect_c2c3(nii_im,
+                                                                                                nii_seg,
+                                                                                                contrast,
+                                                                                                remove_temp_files=remove_temp_files,
+                                                                                                verbose=verbose)
+        nii_midSlice.save(os.path.join(os.path.dirname(nii_im.absolutepath), "tmp_midSlice.nii.gz"))
+        nii_mask.save(os.path.join(os.path.dirname(nii_im.absolutepath), "tmp_midSlice_mask.nii.gz"))
+        nii_before_postPro.save(os.path.join(os.path.dirname(nii_im.absolutepath), "tmp_midSlice_before_postPro.nii.gz"))
+        nii_after_postPro.save(os.path.join(os.path.dirname(nii_im.absolutepath), "tmp_midSlice_after_postPro.nii.gz"))
 
     # Output C2-C3 disc label
     # by default, output in the same directory as the input images


### PR DESCRIPTION
This PR aims at:
- Fixing a bug in the post processing of `detect_c2c3` module. Fixes #2191 
- Allowing a way not to remove temporary files, in order to facilitate the debugging.

### Post processing bug:
We create a mask around the centerline, which is used in the post-processing of `detect_c2c3` module. In the new implementation, we only consider z-slices where the spinal cord is present (ie not in the brain area to speed up the process) and do not forget to iterate along the z-axis (which was not the case in the former implementation.. shame.).

### Temporary files:
Keep temporary files of `detect_c2c3` module is now possible.
To test it:
```
cd spinalcordtoolbox/spinalcordtoolbox/vertebrae/
python
```
Then,
```
>>> from detect_c2c3 import detect_c2c3_from_file
>>> detect_c2c3_from_file('/home/charley/data/thiago/cont_03.nii.gz', '/home/charley/data/thiago/cont_03_seg.nii.gz', 't1', fname_c2c3='/home/charley/data/thiago/cont_03_c2c3.nii.gz', verbose=2)
```

And:
```
cd /home/charley/data/thiago/
fsleyes tmp_midSlice.nii.gz tmp_midSlice_mask.nii.gz -cm red tmp_midSlice_before_postPro.nii.gz -cm blue tmp_midSlice_after_postPro.nii.gz -cm green
```