### PR TITLE
Fixed bug that appeared when inputing uncompressed nifti file

### DIFF
--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -111,7 +111,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
         coord_max = np.where(pred == np.max(pred))
         pa_c2c3, is_c2c3 = coord_max[0][0], coord_max[1][0]
         nii_seg.change_orientation('PIR')
-        rl_c2c3 = int(np.rint(center_of_mass(nii_seg.data[:, is_c2c3, :])[1]))
+        rl_c2c3 = int(np.rint(center_of_mass(np.array(nii_seg.data[:, is_c2c3, :]))[1]))
         nii_c2c3.data[pa_c2c3, is_c2c3, rl_c2c3] = 3
     else:
         sct.printv('C2-C3 not detected...', verbose)


### PR DESCRIPTION
This PR aims at fixing the bug reported [here](https://github.com/neuropoly/spinalcordtoolbox/issues/2191#issuecomment-474834806).

`scipy.measurements.center_of_mass` receives `np.array` as input.

The bug occurs when the input segmentation file is not compressed (ie .nii versus .nii.gz). In that case, the type of `seg.data` is `<class 'numpy.core.memmap.memmap'>`.

That's a known issue: #2148.

A solution is to cast `np.array` when calling `seg.data`.

To test:
```
cd example_data/t1
sct_label_vertebrae -i t1.nii.gz -s t1_seg.nii.gz -c t1
```

Fixes #2191.