### PR TITLE
Remove Optic temp files by default

### DIFF
--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -539,7 +539,7 @@ def propseg(img_input, options_dict):
 
     # If using OptiC
     elif use_optic:
-        image_centerline = optic.detect_centerline(image_input, contrast_type)
+        image_centerline = optic.detect_centerline(image_input, contrast_type, verbose)
         fname_centerline_optic = os.path.join(path_tmp, 'centerline_optic.nii.gz')
         image_centerline.save(fname_centerline_optic)
         cmd += ["-init-centerline", fname_centerline_optic]

--- a/spinalcordtoolbox/centerline/core.py
+++ b/spinalcordtoolbox/centerline/core.py
@@ -103,7 +103,7 @@ def get_centerline(im_seg, algo_fitting='polyfit', minmax=True, param=ParamCente
         # image itself (not the segmentation). Hence, we can bypass the fitting procedure and centerline creation
         # and directly output results.
         from spinalcordtoolbox.centerline import optic
-        im_centerline = optic.detect_centerline(im_seg, param.contrast)
+        im_centerline = optic.detect_centerline(im_seg, param.contrast, verbose)
         x_centerline_fit, y_centerline_fit, z_centerline = find_and_sort_coord(im_centerline)
         # Compute derivatives using polynomial fit
         # TODO: Fix below with reorientation of axes

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -62,7 +62,7 @@ def centerline2roi(fname_image, folder_output='./', verbose=0):
     return fname_output
 
 
-def detect_centerline(img, contrast):
+def detect_centerline(img, contrast, verbose=1):
     """Detect spinal cord centerline using OptiC.
     :param img: input Image() object.
     :param contrast: str: The type of contrast. Will define the path to Optic model.
@@ -116,5 +116,8 @@ def detect_centerline(img, contrast):
 
     # return to initial folder
     temp_folder.chdir_undo()
+    if verbose < 2:
+        sct.log.info("Remove temporary files...")
+        temp_folder.cleanup()
 
     return img_ctl


### PR DESCRIPTION
This PR aims at removing Optic temp files by default.

The files are not removed if verbose >= 2.

Fixes #2209.