### PR TITLE
Clarify handling of logger, error and exceptions

### DIFF
--- a/scripts/isct_check_detection.py
+++ b/scripts/isct_check_detection.py
@@ -48,7 +48,7 @@ def main():
         try:
             opts, args = getopt.getopt(sys.argv[1:], 'hi:t:')
         except getopt.GetoptError as err:
-            sct.log.error(str(err))
+            logger.error(str(err))
             usage()
         for opt, arg in opts:
             if opt == '-h':

--- a/scripts/isct_test_ants.py
+++ b/scripts/isct_test_ants.py
@@ -145,7 +145,7 @@ def main():
 #=======================================================================================================================
 def printv(string, verbose):
     if verbose:
-        sct.log.info(string)
+        logger.info(string)
 
 
 # sct.printv(usage)

--- a/scripts/msct_parser.py
+++ b/scripts/msct_parser.py
@@ -81,8 +81,12 @@
 from __future__ import absolute_import
 
 import os
+import logging
+
 import sct_utils as sct
 from msct_types import Coordinate  # DO NOT REMOVE THIS LINE!!!!!!! IT IS MANDATORY!
+
+logger = logging.getLogger(__name__)
 
 ########################################################################################################################
 # OPTION
@@ -248,7 +252,7 @@ class Option:
         elif no_image:
             return param
         else:
-            sct.log.debug('executed in {}'.format(os.getcwd()))
+            logger.debug('executed in {}'.format(os.getcwd()))
             self.parser.usage.error("Option " + self.name + " file " + param + " does not exist.")
 
     def checkFolder(self, param):
@@ -267,7 +271,7 @@ class Option:
         if result_creation == 2:
             raise OSError("Permission denied for folder creation {}".format(param))
         elif result_creation == 1:
-            sct.log.info("Folder " + param + " has been created.")
+            logger.info("Folder " + param + " has been created.")
         return param
 
 
@@ -386,10 +390,10 @@ class Parser:
                 # for each argument, check if is in the option list.
                 # if so, check the integrity of the argument
                 if self.options[arg].deprecated:
-                    sct.log.warning(" {} is a deprecated argument and will no longer be updated in future versions.".format(arg))
+                    logger.warning(" {} is a deprecated argument and will no longer be updated in future versions.".format(arg))
                 if self.options[arg].deprecated_by is not None:
                     try:
-                        sct.log.warning(arg + " is a deprecated argument and will no longer be updated in future versions. Changing argument to " + self.options[arg].deprecated_by + ".")
+                        logger.warning(arg + " is a deprecated argument and will no longer be updated in future versions. Changing argument to " + self.options[arg].deprecated_by + ".")
                         arg = self.options[arg].deprecated_by
                     except KeyError as e:
                         raise SyntaxError("Argument {} non existent".format(arg))
@@ -596,10 +600,10 @@ class Usage:
         usage = self.header + self.description + self.usage + self.arguments_string
 
         if error:
-            sct.log.info(usage)
-            sct.log.error("Command-line usage error: {}\nAborted...".format(error))
+            logger.info(usage)
+            logger.error("Command-line usage error: {}\nAborted...".format(error))
         else:
-            sct.log.info(usage)
+            logger.info(usage)
 
     def error(self, error=None):
         self.generate(error)

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -199,7 +199,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
 
     # construct 3D warping matrix
     for iz in z_nonzero:
-        # TODO: replace the thing below with tqdm
+        # TODO: replace the thing below with "tqdm-like" logger-based function
         # sct.no_new_line_log('{}/{}..'.format(iz + 1, nz))
         # get indices of x and y coordinates
         row, col = np.indices((nx, ny))

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -18,7 +18,7 @@
 
 from __future__ import division, absolute_import
 
-import sys, os, shutil
+import sys, os, shutil, logging
 from math import asin, cos, sin, acos
 import numpy as np
 
@@ -30,6 +30,8 @@ from spinalcordtoolbox.image import Image
 import sct_utils as sct
 from sct_convert import convert
 from sct_register_multimodal import Paramreg
+
+logger = logging.getLogger(__name__)
 
 
 def register_slicewise(fname_src,

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -199,7 +199,8 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
 
     # construct 3D warping matrix
     for iz in z_nonzero:
-        sct.no_new_line_log('{}/{}..'.format(iz + 1, nz))
+        # TODO: replace the thing below with tqdm
+        # sct.no_new_line_log('{}/{}..'.format(iz + 1, nz))
         # get indices of x and y coordinates
         row, col = np.indices((nx, ny))
         # build 2xn array of coordinates in pixel space

--- a/scripts/msct_register.py
+++ b/scripts/msct_register.py
@@ -278,7 +278,7 @@ def register2d_centermassrot(fname_src, fname_dest, fname_warp='warp_forward.nii
         warp_inv_x[:, :, iz] = np.array([coord_inverse_phy[i, 0] - coord_init_phy[i, 0] for i in range(nx * ny)]).reshape((nx, ny))
         warp_inv_y[:, :, iz] = np.array([coord_inverse_phy[i, 1] - coord_init_phy[i, 1] for i in range(nx * ny)]).reshape((nx, ny))
 
-    sct.log.info('\n Done')
+    logger.info('\n Done')
 
     # Generate forward warping field (defined in destination space)
     generate_warping_field(fname_dest, warp_x, warp_y, fname_warp, verbose)
@@ -732,7 +732,7 @@ def numerotation(nb):
         nb_output: the number of the slice for fslsplit (type: string)
     """
     if nb < 0:
-        sct.log.error('ERROR: the number is negative.')
+        logger.error('ERROR: the number is negative.')
         sys.exit(status=2)
     elif -1 < nb < 10:
         nb_output = '000' + str(nb)
@@ -743,7 +743,7 @@ def numerotation(nb):
     elif 999 < nb < 10000:
         nb_output = str(nb)
     elif nb > 9999:
-        sct.log.error('ERROR: the number is superior to 9999.')
+        logger.error('ERROR: the number is superior to 9999.')
         sys.exit(status = 2)
     return nb_output
 

--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -540,10 +540,8 @@ def main(args=None):
         rm_tmp = True
 
     # Verbosity
-    if '-v' in arguments:
-        verbose = int(arguments['-v'])
-    else:
-        verbose = '1'
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # create the Lesion constructor
     lesion_obj = AnalyzeLeion(fname_mask=fname_mask,

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -320,8 +320,8 @@ def main(args=None):
         param.dim = arguments['-dim']
     if '-r' in arguments:
         param.rm_tmp = bool(int(arguments['-r']))
-    if '-v' in arguments:
-        param.verbose = bool(int(arguments['-v']))
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # create the GLCM constructor
     glcm = ExtractGLCM(param=param, param_glcm=param_glcm)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -290,8 +290,8 @@ def main(args=None):
         transform.interp = arguments["-x"]
     if "-r" in arguments:
         transform.remove_temp_files = int(arguments["-r"])
-    if "-v" in arguments:
-        transform.verbose = int(arguments["-v"])
+    transform.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
 
     transform.apply()
 

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -127,15 +127,9 @@ def main():
     arguments = parser.parse_args()
     if arguments.complete:
         complete_test = 1
-    if arguments.generate_log:
-        create_log_file = 1
 
     # use variable "verbose" when calling sct.run for more clarity
     verbose = complete_test
-
-    # redirect to log file
-    if create_log_file:
-        handle_log = sct.ForkStdoutToFile(file_log)
 
     # complete test
     if complete_test:
@@ -357,11 +351,6 @@ def get_parser():
 
     parser.add_argument("--complete", "-c",
                         help="Complete test.",
-                        action="store_true",
-                        )
-
-    parser.add_argument("--generate-log", "-log", "-l",
-                        help="Generate log file.",
                         action="store_true",
                         )
 

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -327,7 +327,7 @@ def get_dependencies(requirements_txt=None):
             line = line.rstrip()
             m = re.match("^(?P<pkg>\S+?)(==?(?P<ver>\S+))?\s*(#.*)?$", line)
             if m is None:
-                sct.log.warn("Invalid requirements.txt line: %s", line)
+                logger.warn("Invalid requirements.txt line: %s", line)
                 continue
             pkg = m.group("pkg")
             try:

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -141,8 +141,8 @@ def main(args=None):
         input_tr_max = arguments["-b"][1]
     if "-tr" in arguments :
         input_tr = arguments["-tr"]
-    if "-v" in arguments :
-        verbose = int(arguments["-v"])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     graph = ErnstAngle(input_t1, tr=input_tr, fname_output=input_fname_output)
     if input_tr is not None:

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -474,11 +474,11 @@ def get_parser():
                       default_value='hausdorff_distance.txt',
                       example='my_hausdorff_dist.txt')
     parser.add_option(name="-v",
-                      type_value="int",
-                      description="verbose: 0 = nothing, 1 = classic, 2 = expended",
+                      type_value="multiple_choice",
+                      description="Verbose. 0: nothing, 1: basic, 2: extended.",
                       mandatory=False,
-                      default_value=0,
-                      example='1')
+                      example=['0', '1', '2'],
+                      default_value='1')
     return parser
 
 ########################################################################################################################
@@ -509,8 +509,8 @@ if __name__ == "__main__":
             resample_to = arguments["-resampling"]
         if "-o" in arguments:
             output_fname = arguments["-o"]
-        if "-v" in arguments:
-            param.verbose = int(arguments["-v"])
+        param.verbose = int(arguments.get('-v'))
+        sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
         tmp_dir = sct.tmp_create()
         im1_name = "im1.nii.gz"

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -57,7 +57,8 @@ def main(args=None):
     fname_mt0 = arguments['-mt0']
     fname_mt1 = arguments['-mt1']
     remove_temp_files = int(arguments['-r'])
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # Extract path/file/extension
     path_mt0, file_mt0, ext_mt0 = sct.extract_fname(fname_mt0)

--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -80,8 +80,6 @@ def main(args):
     import sct_utils as sct
     from spinalcordtoolbox.mtsat import mtsat
 
-    sct.start_stream_logger()
-
     fname_mtsat, fname_t1map = mtsat.compute_mtsat_from_file(
         args.mt, args.pd, args.t1, args.trmt, args.trpd, args.trt1, args.famt, args.fapd, args.fat1,
         fname_b1map=args.b1map, fname_mtsat=args.omtsat, fname_t1map=args.ot1map, verbose=1)

--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -80,15 +80,18 @@ def main(args):
     import sct_utils as sct
     from spinalcordtoolbox.mtsat import mtsat
 
+    verbose = args.v
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
+
     fname_mtsat, fname_t1map = mtsat.compute_mtsat_from_file(
         args.mt, args.pd, args.t1, args.trmt, args.trpd, args.trt1, args.famt, args.fapd, args.fat1,
-        fname_b1map=args.b1map, fname_mtsat=args.omtsat, fname_t1map=args.ot1map, verbose=1)
+        fname_b1map=args.b1map, fname_mtsat=args.omtsat, fname_t1map=args.ot1map, verbose=verbose)
 
     sct.display_viewer_syntax([fname_mtsat, fname_t1map],
                               colormaps=['gray', 'gray'],
                               minmax=['-10,10', '0, 3'],
                               opacities=['1', '1'],
-                              verbose=args.v)
+                              verbose=verbose)
 
 
 if __name__ == '__main__':

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -70,10 +70,10 @@ def get_parser():
                       example=['0', '1'])
     parser.add_option(name="-v",
                       type_value="multiple_choice",
-                      description="""Verbose. 0: nothing. 1: basic.""",
+                      description="Verbose. 0: nothing, 1: basic, 2: extended.",
                       mandatory=False,
-                      default_value='0',
-                      example=['0', '1'])
+                      example=['0', '1', '2'],
+                      default_value='1')
     return parser
 
 
@@ -107,6 +107,8 @@ def main():
         index_vol_user = arguments['-vol']
     else:
         index_vol_user = ''
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # Check parameters
     if method == 'diff':

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -15,19 +15,16 @@
 
 from __future__ import absolute_import, division
 
-import sys, io, os, getopt, functools
+import sys, os, functools
 
 import sct_utils as sct
 from msct_parser import Parser
 from spinalcordtoolbox.image import Image
 
-# DEFAULT PARAMETERS
-
 
 class Param:
     # The constructor
     def __init__(self):
-        self.debug = 0
         self.fname_warp_final = 'warp_final.nii.gz'
 
 
@@ -36,29 +33,19 @@ class Param:
 def main():
 
     # Initialization
-    fname_warp_list = ''  # list of warping fields
-    fname_dest = ''  # destination image (fix)
     fname_warp_final = ''  # concatenated transformations
-    verbose = 1
 
-    # Parameters for debug mode
-    if param.debug:
-        sct.printv('\n*** WARNING: DEBUG MODE ON ***\n')
-        path_sct_data = os.path.join(sct.__data_dir__, "sct_testing_data")
-        fname_warp_list = os.path.join(path_sct_data, 't2', 'warp_template2anat.nii.gz') + '-' + os.path.join(path_sct_data, 'mt', 'warp_template2mt.nii.gz')
-        fname_dest = os.path.join(path_sct_data, 'mt', 'mtr.nii.gz')
-        verbose = 1
-    else:
-        # Check input parameters
-        parser = get_parser()
-        arguments = parser.parse(sys.argv[1:])
+    # Check input parameters
+    parser = get_parser()
+    arguments = parser.parse(sys.argv[1:])
 
-        fname_dest = arguments['-d']
-        fname_warp_list = arguments['-w']
+    fname_dest = arguments['-d']
+    fname_warp_list = arguments['-w']
 
-        if '-o' in arguments:
-            fname_warp_final = arguments['-o']
-        verbose = int(arguments['-v'])
+    if '-o' in arguments:
+        fname_warp_final = arguments['-o']
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # Parse list of warping fields
     sct.printv('\nParse list of transformations...', verbose)

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -73,8 +73,9 @@ def main(args=None):
         param.fname_out = os.path.abspath(arguments['-o'])
     if '-r' in arguments:
         param.remove_temp_files = int(arguments['-r'])
-    if '-v' in arguments:
-        param.verbose = int(arguments['-v'])
+
+    param.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # run main program
     create_mask(param)

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -403,11 +403,11 @@ if __name__ == "__main__":
     if "-g" in arguments:
         exec_choice = bool(int(arguments["-g"]))
 
+    # cropping with GUI
+    cropper = ImageCropper(input_filename)
     cropper.verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=cropper.verbose, update=True)  # Update log level
 
-    # cropping with GUI
-    cropper = ImageCropper(input_filename)
     if exec_choice:
         fname_data = arguments["-i"]
         if "-r" in arguments:

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -403,15 +403,15 @@ if __name__ == "__main__":
     if "-g" in arguments:
         exec_choice = bool(int(arguments["-g"]))
 
+    cropper.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=cropper.verbose, update=True)  # Update log level
+
     # cropping with GUI
     cropper = ImageCropper(input_filename)
     if exec_choice:
         fname_data = arguments["-i"]
         if "-r" in arguments:
             cropper.rm_tmp_files = int(arguments["-r"])
-        if "-v" in arguments:
-            cropper.verbose = int(arguments["-v"])
-
         cropper.crop_with_gui()
 
     # cropping with specified command-line arguments

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -105,9 +105,10 @@ def run_main():
         output_filename = sct.add_suffix(input_filename, '_gmseg')
 
     use_tta = "-t" in arguments
-    verbose = arguments["-v"]
     model_name = arguments["-m"]
     threshold = arguments['-thr']
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     if threshold > 1.0 or threshold < 0.0:
         raise RuntimeError("Threshold should be between 0.0 and 1.0.")

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -114,7 +114,8 @@ def main():
 
     remove_temp_files = int(arguments['-r'])
 
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     algo_config_stg = '\nMethod:'
     algo_config_stg += '\n\tCenterline algorithm: ' + str(ctr_algo)

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -103,7 +103,7 @@ def main():
         output_folder = arguments["-ofolder"]
 
     if ctr_algo == 'file' and "-file_centerline" not in args:
-        logger.error('Please use the flag -file_centerline to indicate the centerline filename.')
+        sct.printv('Please use the flag -file_centerline to indicate the centerline filename.', 1, 'error')
         sys.exit(1)
     
     if "-file_centerline" in args:

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -103,7 +103,7 @@ def main():
         output_folder = arguments["-ofolder"]
 
     if ctr_algo == 'file' and "-file_centerline" not in args:
-        sct.log.error('Please use the flag -file_centerline to indicate the centerline filename.')
+        logger.error('Please use the flag -file_centerline to indicate the centerline filename.')
         sys.exit(1)
     
     if "-file_centerline" in args:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -128,7 +128,7 @@ def main():
         output_folder = arguments["-ofolder"]
 
     if ctr_algo == 'file' and "-file_centerline" not in args:
-        sct.log.warning('Please use the flag -file_centerline to indicate the centerline filename.')
+        logger.warning('Please use the flag -file_centerline to indicate the centerline filename.')
         sys.exit(1)
     
     if "-file_centerline" in args:

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -139,7 +139,8 @@ def main():
 
     remove_temp_files = int(arguments['-r'])
 
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     path_qc = arguments.get("-qc", None)
     qc_dataset = arguments.get("-qc-dataset", None)

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -155,8 +155,9 @@ if __name__ == "__main__":
 
     parameter = arguments["-p"]
     remove_temp_files = int(arguments["-r"])
-    verbose = int(arguments["-v"])
     noise_threshold = int(arguments['-d'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     if "-i" in arguments:
         file_to_denoise = arguments["-i"]

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -270,8 +270,8 @@ def main(args=None):
     # Remove temp folder
     rm_tmp = bool(int(arguments.get("-r", 1)))
 
-    # Verbosity
-    verbose = int(arguments.get("-v", 1))
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # Initialize DetectPMJ
     detector = DetectPMJ(fname_im=fname_in,

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -86,7 +86,8 @@ if __name__ == "__main__":
     fname_input1 = arguments['-i']
     fname_input2 = arguments['-d']
 
-    verbose = arguments['-v']
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     tmp_dir = sct.tmp_create(verbose=verbose)  # create tmp directory
     tmp_dir = os.path.abspath(tmp_dir)

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -101,7 +101,8 @@ def main(args = None):
     evecs = bool(arguments['-evecs'])
     if "-m" in arguments:
         file_mask = arguments['-m']
-    param.verbose = int(arguments['-v'])
+    param.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # compute DTI
     if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):

--- a/scripts/sct_dmri_create_noisemask.py
+++ b/scripts/sct_dmri_create_noisemask.py
@@ -74,7 +74,6 @@ def main(fname_in, freedom_degree, file_output):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == '__main__':
-    sct.start_stream_logger()
     parser = get_parser()
     arguments = parser.parse(sys.argv[1:])
 

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -236,8 +236,8 @@ def main(args=None):
         path_out = arguments['-ofolder']
     if '-r' in arguments:
         param.remove_temp_files = int(arguments['-r'])
-    if '-v' in arguments:
-        param.verbose = int(arguments['-v'])
+    param.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # Get full path
     param.fname_data = os.path.abspath(param.fname_data)

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -107,7 +107,8 @@ def main(args=None):
     fname_data = arguments['-i']
     fname_bvecs = arguments['-bvec']
     average = arguments['-a']
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     remove_temp_files = int(arguments['-r'])
     path_out = arguments['-ofolder']
 

--- a/scripts/sct_dmri_transpose_bvecs.py
+++ b/scripts/sct_dmri_transpose_bvecs.py
@@ -83,7 +83,8 @@ def main(args=None):
         fname_out = arguments['-o']
     else:
         fname_out = ''
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # get bvecs in proper orientation
     from dipy.io import read_bvals_bvecs

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -122,7 +122,8 @@ def main(args=None):
     parser = get_parser()
     arguments = parser.parse(args)
     data_name = arguments['-d']
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     dest_folder = arguments.get('-o', os.path.abspath(os.curdir))
 
     # Download data

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -219,7 +219,8 @@ To compute average MTR in a region defined by a single label file (could be bina
 
 def main(fname_data, path_label, method, slices, levels, fname_output, labels_user, append,
          fname_normalizing_label, normalization_method, label_to_fix, adv_param_user, fname_output_metric_map,
-         fname_mask_weight, fname_vertebral_labeling="", perslice=1, perlevel=1, discard_negative_values=False):
+         fname_mask_weight, fname_vertebral_labeling="", perslice=1, perlevel=1, discard_negative_values=False,
+         verbose=1):
     """
     Extract metrics from MRI data based on mask (could be single file of folder to atlas)
     :param fname_data: data to extract metric from
@@ -245,11 +246,9 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
     :param perlevel: if user selected several levels, then the function outputs a metric within each vertebral level
            instead of a single average output.
     :param discard_negative_values: Bool: Discard negative voxels when computing metrics statistics
+    :param verbose
     :return:
     """
-
-    # Initialization
-    verbose = param_default.verbose
 
     # check if path_label is a file (e.g., single binary mask) instead of a folder (e.g., SCT atlas structure which
     # contains info_label.txt file)
@@ -409,9 +408,11 @@ if __name__ == "__main__":
         fname_mask_weight = ''
     # if 'discard_negative_values' in arguments:
     discard_negative_values = int(arguments['-discard-neg-val'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
     main(fname_data, path_label, method, parse_num_list(slices_of_interest), parse_num_list(vertebral_levels),
          fname_output, labels_user, append, fname_normalizing_label, normalization_method, label_to_fix,
          adv_param_user, fname_output_metric_map, fname_mask_weight, fname_vertebral_labeling=fname_vertebral_labeling,
-         perslice=perslice, perlevel=perlevel, discard_negative_values=discard_negative_values)
+         perslice=perslice, perlevel=perlevel, discard_negative_values=discard_negative_values, verbose=verbose)

--- a/scripts/sct_flatten_sagittal.py
+++ b/scripts/sct_flatten_sagittal.py
@@ -144,7 +144,8 @@ if __name__ == "__main__":
     arguments = parser.parse(sys.argv[1:])
     fname_anat = arguments['-i']
     fname_centerline = arguments['-s']
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
     main(fname_anat, fname_centerline, verbose)

--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -98,7 +98,8 @@ def main(args=None):
     arguments = parser.parse(sys.argv[1:])
     fname_src = arguments['-i']
     fname_dst = arguments.get("-o", sct.add_suffix(fname_src, "_tsnr"))
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -177,8 +177,8 @@ def main(args=None):
         path_out = arguments['-ofolder']
     if '-r' in arguments:
         param.remove_temp_files = int(arguments['-r'])
-    if '-v' in arguments:
-        param.verbose = int(arguments['-v'])
+    param.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     sct.printv('\nInput parameters:', param.verbose)
     sct.printv('  input file ............' + param.fname_data, param.verbose)

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -101,10 +101,8 @@ def run_main():
         path_data, file_data, ext_data = sct.extract_fname(fname_data)
         file_output = os.path.join(path_data, file_data + '_centerline')
 
-    # Verbosity
-    verbose = 0
-    if "-v" in arguments:
-        verbose = int(arguments["-v"])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     if method == 'viewer':
         im_labels = _call_viewer_centerline(Image(fname_data), interslice_gap=interslice_gap)

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -142,7 +142,8 @@ def main(args=None):
     arguments = parser.parse(args)
     fname_in = arguments["-i"]
     n_in = len(fname_in)
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     if "-o" in arguments:
         fname_out = arguments["-o"]

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -756,11 +756,12 @@ def main(args=None):
         msg = ""
     if '-o' in arguments:
         input_fname_output = arguments['-o']
-    input_verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     processor = ProcessLabels(input_filename, fname_output=input_fname_output, fname_ref=input_fname_ref,
                               cross_radius=input_cross_radius, dilate=input_dilate, coordinates=input_coordinates,
-                              verbose=input_verbose, vertebral_levels=vertebral_levels, value=value, msg=msg)
+                              verbose=verbose, vertebral_levels=vertebral_levels, value=value, msg=msg)
     processor.process(process_type)
 
     # return based on process type

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -218,7 +218,8 @@ def main(args=None):
         fname_initlabel = os.path.abspath(arguments['-initlabel'])
     if '-param' in arguments:
         param.update(arguments['-param'][0])
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     remove_temp_files = int(arguments['-r'])
     denoise = int(arguments['-denoise'])
     laplacian = int(arguments['-laplacian'])

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -195,7 +195,8 @@ def main(args = None):
     arguments = parser.parse(args)
     fname_in = arguments["-i"]
     fname_out = arguments["-o"]
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     if '-type' in arguments:
         output_type = arguments['-type']
     else:

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -194,8 +194,8 @@ def main(args=None):
         param.interp = arguments['-x']
     if '-r' in arguments:
         param.rm_tmp = bool(int(arguments['-r']))
-    if '-v' in arguments:
-        param.verbose = arguments['-v']
+    param.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # check if list of input files and warping fields have same length
     assert len(list_fname_src) == len(list_fname_warp), "ERROR: list of files are not of the same length"

--- a/scripts/sct_pipeline_makefig.py
+++ b/scripts/sct_pipeline_makefig.py
@@ -41,8 +41,6 @@ def main(args):
     import numpy as np
     import matplotlib.pyplot as plt
 
-    sct.start_stream_logger()
-
     # make sure number of inputs and labels are the same
     if len(arguments.input) != len(arguments.label):
         raise RuntimeError("Mismatch between # of files and labels")

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -160,8 +160,6 @@ def main(args):
         perlevel = arguments['-perlevel']
     else:
         perlevel = Param().perlevel
-    if '-v' in arguments:
-        verbose = int(arguments['-v'])
     if '-z' in arguments:
         slices = arguments['-z']
     if '-perslice' in arguments:
@@ -174,8 +172,10 @@ def main(args):
         elif arguments['-angle-corr'] == '0':
             angle_correction = False
 
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
+
     # update fields
-    param.verbose = verbose
     metrics_agg = {}
     if not file_out:
         file_out = 'csa.csv'

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -396,7 +396,7 @@ def propseg(img_input, options_dict):
         folder_output = './'
     cmd += ['-o', folder_output]
     if not os.path.isdir(folder_output) and os.path.exists(folder_output):
-        sct.log.error("output directory %s is not a valid directory" % folder_output)
+        logger.error("output directory %s is not a valid directory" % folder_output)
     if not os.path.exists(folder_output):
         os.makedirs(folder_output)
 
@@ -443,7 +443,7 @@ def propseg(img_input, options_dict):
     if "-init" in arguments:
         init_option = float(arguments["-init"])
         if init_option < 0:
-            sct.log.error('Command-line usage error: ' + str(init_option) + " is not a valid value for '-init'")
+            logger.error('Command-line usage error: ' + str(init_option) + " is not a valid value for '-init'")
             sys.exit(1)
     if "-init-centerline" in arguments:
         if str(arguments["-init-centerline"]) == "viewer":
@@ -497,7 +497,7 @@ def propseg(img_input, options_dict):
     image_input_rpi = image_input.copy().change_orientation('RPI')
     nx, ny, nz, nt, px, py, pz, pt = image_input_rpi.dim
     if nt > 1:
-        sct.log.error('ERROR: your input image needs to be 3D in order to be segmented.')
+        logger.error('ERROR: your input image needs to be 3D in order to be segmented.')
 
     path_data, file_data, ext_data = sct.extract_fname(fname_data)
     path_tmp = sct.tmp_create(basename="label_vertebrae", verbose=verbose)
@@ -534,7 +534,7 @@ def propseg(img_input, options_dict):
         fname_labels_viewer = sct.add_suffix(fname_data_propseg, '_labels_viewer')
 
         if not controller.saved:
-            sct.log.error('The viewer has been closed before entering all manual points. Please try again.')
+            logger.error('The viewer has been closed before entering all manual points. Please try again.')
             sys.exit(1)
         # save labels
         controller.as_niftii(fname_labels_viewer)
@@ -565,7 +565,7 @@ def propseg(img_input, options_dict):
 
     # check status is not 0
     if not status == 0:
-        sct.log.error('Automatic cord detection failed. Please initialize using -init-centerline or '
+        logger.error('Automatic cord detection failed. Please initialize using -init-centerline or '
                       '-init-mask (see help).')
         sys.exit(1)
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -409,11 +409,11 @@ def propseg(img_input, options_dict):
     if "-r" in arguments:
         remove_temp_files = int(arguments["-r"])
 
-    verbose = 0
-    if "-v" in arguments:
-        if arguments["-v"] is "1":
-            verbose = 2
-            cmd += ["-verbose"]
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    # Update for propseg binary
+    if verbose > 0:
+        cmd += ["-verbose"]
 
     # Output options
     if "-mesh" in arguments:

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -443,7 +443,7 @@ def propseg(img_input, options_dict):
     if "-init" in arguments:
         init_option = float(arguments["-init"])
         if init_option < 0:
-            logger.error('Command-line usage error: ' + str(init_option) + " is not a valid value for '-init'")
+            sct.printv('Command-line usage error: ' + str(init_option) + " is not a valid value for '-init'", 1, 'error')
             sys.exit(1)
     if "-init-centerline" in arguments:
         if str(arguments["-init-centerline"]) == "viewer":
@@ -497,7 +497,7 @@ def propseg(img_input, options_dict):
     image_input_rpi = image_input.copy().change_orientation('RPI')
     nx, ny, nz, nt, px, py, pz, pt = image_input_rpi.dim
     if nt > 1:
-        logger.error('ERROR: your input image needs to be 3D in order to be segmented.')
+        sct.printv('ERROR: your input image needs to be 3D in order to be segmented.', 1, 'error')
 
     path_data, file_data, ext_data = sct.extract_fname(fname_data)
     path_tmp = sct.tmp_create(basename="label_vertebrae", verbose=verbose)
@@ -534,7 +534,7 @@ def propseg(img_input, options_dict):
         fname_labels_viewer = sct.add_suffix(fname_data_propseg, '_labels_viewer')
 
         if not controller.saved:
-            logger.error('The viewer has been closed before entering all manual points. Please try again.')
+            sct.printv('The viewer has been closed before entering all manual points. Please try again.', 1, 'error')
             sys.exit(1)
         # save labels
         controller.as_niftii(fname_labels_viewer)
@@ -565,8 +565,8 @@ def propseg(img_input, options_dict):
 
     # check status is not 0
     if not status == 0:
-        logger.error('Automatic cord detection failed. Please initialize using -init-centerline or '
-                      '-init-mask (see help).')
+        sct.printv('Automatic cord detection failed. Please initialize using -init-centerline or -init-mask (see help)',
+                   1, 'error')
         sys.exit(1)
 
     # build output filename

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import, division
 
 import argparse
+import sct_utils as sct
 
 
 def get_parser():
@@ -45,11 +46,6 @@ def get_parser():
                         help='Path to save QC report. Default: ./qc',
                         required=False,
                         default='./qc')
-    parser.add_argument('-v',
-                        help='Verbosity: 0: no verbosity, 1: verbosity (default).',
-                        choices=('0', '1'),
-                        type=int,
-                        default=1)
     return parser
 
 
@@ -65,6 +61,7 @@ def main(args):
 
 
 if __name__ == '__main__':
+    sct.init()
     parser = get_parser()
     arguments = parser.parse_args()
     main(arguments)

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -63,7 +63,6 @@ def get_parser():
 def main(args):
     from spinalcordtoolbox.reports.qc import generate_qc
 
-    print args
     generate_qc(fname_in1=args.i,
                 fname_in2=args.d,
                 fname_seg=args.s,

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -61,7 +61,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    sct.init()
+    sct.init_sct()
     parser = get_parser()
     arguments = parser.parse_args()
     main(arguments)

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -20,7 +20,8 @@ def get_parser():
         formatter_class=argparse.RawTextHelpFormatter,
         epilog='Examples:\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc\n'
-               'sct_qc -i t2.nii.gz -s t2_seg_labeled.nii.gz -p sct_label_vertebrae'
+               'sct_qc -i t2.nii.gz -s t2_seg_labeled.nii.gz -p sct_label_vertebrae\n'
+               'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc -qc-dataset mydata -qc-subject sub-45'
     )
     parser.add_argument('-i',
                         metavar='IMAGE',
@@ -46,17 +47,30 @@ def get_parser():
                         help='Path to save QC report. Default: ./qc',
                         required=False,
                         default='./qc')
+    parser.add_argument('-qc-dataset',
+                        metavar='DATASET',
+                        help='If provided, this string will be mentioned in the QC report as the dataset the process '
+                             'was run on',
+                        required=False)
+    parser.add_argument('-qc-subject',
+                        metavar='SUBJECT',
+                        help='If provided, this string will be mentioned in the QC report as the subject the process '
+                             'was run on',
+                        required=False)
     return parser
 
 
 def main(args):
     from spinalcordtoolbox.reports.qc import generate_qc
 
+    print args
     generate_qc(fname_in1=args.i,
                 fname_in2=args.d,
                 fname_seg=args.s,
                 args=None,
                 path_qc=args.qc,
+                dataset=args.qc_dataset,
+                subject=args.qc_subject,
                 process=args.p)
 
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -363,7 +363,8 @@ def main(args=None):
     identity = int(arguments['-identity'])
     interp = arguments['-x']
     remove_temp_files = int(arguments['-r'])
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # sct.printv(arguments)
     sct.printv('\nInput parameters:')

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -210,7 +210,8 @@ def main(args=None):
     contrast_template = arguments['-c']
     ref = arguments['-ref']
     remove_temp_files = int(arguments['-r'])
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both
     # if '-straighten-fitting' in arguments:
     param.straighten_fitting = arguments['-straighten-fitting']

--- a/scripts/sct_segment_graymatter.py
+++ b/scripts/sct_segment_graymatter.py
@@ -649,8 +649,8 @@ def main(args=None):
 
     if '-r' in arguments:
         param.rm_tmp = bool(int(arguments['-r']))
-    if '-v' in arguments:
-        param.verbose = arguments['-v']
+    param.verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     start_time = time.time()
     seg_gm = SegmentGM(param_seg=param_seg, param_data=param_data, param_model=param_model, param=param)

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -119,8 +119,8 @@ def main(args=None):
         param.update(arguments['-param'])
     if '-r' in arguments:
         remove_temp_files = int(arguments['-r'])
-    if '-v' in arguments:
-        verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # Display arguments
     sct.printv('\nCheck input arguments...')

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -196,6 +196,7 @@ def main(args=None):
         sc_straight.path_output = './'
 
     verbose = int(arguments.get("-v", 0))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     sc_straight.verbose = verbose
 
     # if "-cpu-nb" in arguments:
@@ -240,6 +241,6 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct(log_level='DEBUG')
+    sct.init_sct(log_level=1)
     # call main function
     main()

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -195,7 +195,7 @@ def main(args=None):
     else:
         sc_straight.path_output = './'
 
-    verbose = int(arguments.get("-v", 0))
+    verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
     sc_straight.verbose = verbose
 
@@ -241,6 +241,6 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct(log_level=1)
+    sct.init_sct()
     # call main function
     main()

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -240,6 +240,6 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    sct.init_sct(log_level='DEBUG')
     # call main function
     main()

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -222,6 +222,7 @@ def main(args=None):
     jobs = arguments.jobs
 
     param.verbose = arguments.verbose
+    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     start_time = time.time()
 

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -16,8 +16,6 @@ import sys, io, os, time, random, copy, shlex, importlib, multiprocessing, tempf
 import traceback, inspect
 import signal, stat
 
-
-
 import numpy as np
 from pandas import DataFrame
 
@@ -58,7 +56,7 @@ def fs_ok(sig_a, sig_b, exclude=()):
     errors = [ (x,y) for (x,y) in errors if not x.startswith(exclude) ]
     if errors:
         for error in errors:
-            sct.log.error("Error: %s", error)
+            sct.printv("Error: %s", 1, type='error')
         raise RuntimeError()
 
 # Parameters
@@ -468,15 +466,15 @@ def make_dot_lines(string):
 # print in color
 # ==========================================================================================
 def print_ok():
-    sct.log.info("[" + bcolors.OKGREEN + "OK" + bcolors.ENDC + "]")
+    sct.printv("[" + bcolors.OKGREEN + "OK" + bcolors.ENDC + "]")
 
 
 def print_warning():
-    sct.log.warning("[" + bcolors.WARNING + "WARNING" + bcolors.ENDC + "]")
+    sct.printv("[" + bcolors.WARNING + "WARNING" + bcolors.ENDC + "]")
 
 
 def print_fail():
-    sct.log.error("[" + bcolors.FAIL + "FAIL" + bcolors.ENDC + "]")
+    sct.printv("[" + bcolors.FAIL + "FAIL" + bcolors.ENDC + "]")
 
 
 # write to log file
@@ -522,7 +520,7 @@ def test_function(param_test):
     -------
     path_output str: path where to output testing data
     """
-    sct.log.debug("Starting test function")
+    # sct.printv("Starting test function")
 
     # load modules of function to test
     module_function_to_test = importlib.import_module(param_test.function_to_test)
@@ -561,12 +559,12 @@ def test_function(param_test):
         param_test.fname_log = os.path.join(param_test.path_output, param_test.function_to_test + '.log')
 
     # redirect to log file
-    if param_test.redirect_stdout:
-        file_handler = sct.add_file_handler_to_logger(param_test.fname_log)
-    sct.log.debug("logging to file")
+    # if param_test.redirect_stdout:
+    #     file_handler = sct.add_file_handler_to_logger(param_test.fname_log)
+    # sct.log.debug("logging to file")
 
     # initialize panda dataframe
-    sct.log.debug("Init dataframe")
+    # sct.printv("Init dataframe")
     param_test.results = DataFrame(index=[subject_folder],
                                    data={'status': 0,
                                          'duration': 0,
@@ -641,12 +639,6 @@ def test_function(param_test):
             param_test.output += str(err)
             write_to_log_file(param_test.fname_log, param_test.output)
             return update_param(param_test)
-
-    # manage stdout
-    if param_test.redirect_stdout:
-        sct.remove_handler(file_handler)
-        write_to_log_file(param_test.fname_log, param_test.output, prepend=True)
-
 
     return update_param(param_test)
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -155,7 +155,7 @@ def server_log_handler(client):
     """
     from raven.handlers.logging import SentryHandler
 
-    sh = SentryHandler(client=client, level=logger.ERROR)
+    sh = SentryHandler(client=client, level=logging.ERROR)
 
     # Don't send Sentry events for command-line usage errors
     old_emit = sh.emit
@@ -169,7 +169,7 @@ def server_log_handler(client):
 
     fmt = ("[%(asctime)s][%(levelname)s] %(filename)s: %(lineno)d | "
             "%(message)s")
-    formatter = logger.Formatter(fmt=fmt, datefmt="%H:%M:%S")
+    formatter = logging.Formatter(fmt=fmt, datefmt="%H:%M:%S")
     formatter.converter = time.gmtime
     sh.setFormatter(formatter)
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -964,27 +964,24 @@ def check_if_same_space(fname_1, fname_2):
 
 
 def printv(string, verbose=1, type='normal'):
-    """enables to print (color coded messages, depending on verbose status)
+    """
+    Enables to print color coded messages, depending on verbose status. Only use in APIs (e.g., sct_propseg).
     """
 
     colors = {'normal': bcolors.normal, 'info': bcolors.green, 'warning': bcolors.yellow, 'error': bcolors.red,
               'code': bcolors.blue, 'bold': bcolors.bold, 'process': bcolors.magenta}
 
-    if verbose or type=="error":
-        # Print color only if the output is the terminal
-        # Note jcohen: i added a try/except in case stdout does not have isatty field (it did happen to me)
+    if verbose:
+        # The try/except is there in case stdout does not have isatty field (it did happen to me)
         try:
+            # Print color only if the output is the terminal
             if sys.stdout.isatty():
                 color = colors.get(type, bcolors.normal)
-                log.info('{0}{1}{2}'.format(color, string, bcolors.normal))
-
+                print(color + string + bcolors.normal)
             else:
-                log.info(string)
+                print(string)
         except Exception as e:
-            log.info(string)
-
-    if type == 'error':
-        raise RuntimeError("printv(..., type=\"error\")")
+            print(string)
 
 
 def send_email(addr_to, addr_from, passwd, subject, message='', filename=None, html=False, smtp_host=None, smtp_port=None, login=None):

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -965,7 +965,8 @@ def check_if_same_space(fname_1, fname_2):
 
 def printv(string, verbose=1, type='normal'):
     """
-    Enables to print color coded messages, depending on verbose status. Only use in APIs (e.g., sct_propseg).
+    Enables to print color-coded messages, depending on verbose status. Only use in command-line programs (e.g.,
+    sct_propseg).
     """
 
     colors = {'normal': bcolors.normal, 'info': bcolors.green, 'warning': bcolors.yellow, 'error': bcolors.red,

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -207,7 +207,8 @@ def main(args=None):
     warp_spinal_levels = int(arguments["-s"])
     folder_out = arguments['-ofolder']
     path_template = arguments['-t']
-    verbose = int(arguments['-v'])
+    verbose = int(arguments.get('-v'))
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
     path_qc = arguments.get("-qc", None)
     qc_dataset = arguments.get("-qc-dataset", None)
     qc_subject = arguments.get("-qc-subject", None)

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -13,11 +13,11 @@ import operator
 import functools
 import csv
 import datetime
+import logging
 
-import sct_utils as sct
 from spinalcordtoolbox.template import get_slices_from_vertebral_levels, get_vertebral_level_from_slice
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import parse_num_list_inv
+from spinalcordtoolbox.utils import __version__, parse_num_list_inv
 
 
 class Metric:
@@ -145,7 +145,7 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], persli
                 # here we create a field with name: FUNC(METRIC_NAME). Example: MEAN(CSA)
                 agg_metric[slicegroup]['{}({})'.format(name, metric.label)] = result
             except Exception as e:
-                sct.log.warning(e)
+                logging.warning(e)
                 agg_metric[slicegroup]['{}({})'.format(name, metric.label)] = e.message
     return agg_metric
 
@@ -161,7 +161,7 @@ def check_labels(indiv_labels_ids, selected_labels):
 
         # Check if the selected labels are in the available labels ids
         if not set(list_ids_of_labels_of_interest).issubset(set(indiv_labels_ids)):
-            sct.log.error(
+            logging.error(
                 'At least one of the selected labels (' + str(list_ids_of_labels_of_interest) + ') is not available \
                 according to the label list from the text file in the atlas folder.')
 
@@ -431,7 +431,7 @@ def save_as_csv(agg_metric, fname_out, fname_in=None, append=False):
         for slicegroup in sorted(agg_metric.keys()):
             line = list()
             line.append(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))  # Timestamp
-            line.append(sct.__version__)  # SCT Version
+            line.append(__version__)  # SCT Version
             line.append(fname_in)  # file name associated with the results
             line.append(parse_num_list_inv(slicegroup))  # list all slices in slicegroup
             line.append(parse_num_list_inv(agg_metric[slicegroup]['VertLevel']))  # list vertebral levels

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -4,12 +4,14 @@
 
 from __future__ import absolute_import, division
 
-import os, datetime
+import os, datetime, logging
 
 import numpy as np
 
 import sct_utils as sct
 from ..image import Image
+
+logger = logging.getLogger(__name__)
 
 
 def centerline2roi(fname_image, folder_output='./', verbose=0):

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -72,7 +72,7 @@ def detect_centerline(img, contrast, verbose=1):
     # Fetch path to Optic model based on contrast
     optic_models_path = os.path.join(sct.__sct_dir__, 'data', 'optic_models', '{}_model'.format(contrast))
 
-    sct.log.debug('Detecting the spinal cord using OptiC')
+    logger.debug('Detecting the spinal cord using OptiC')
     img_orientation = img.orientation
 
     temp_folder = sct.TempFolder()
@@ -123,7 +123,7 @@ def detect_centerline(img, contrast, verbose=1):
     # return to initial folder
     temp_folder.chdir_undo()
     if verbose < 2:
-        sct.log.info("Remove temporary files...")
+        logger.info("Remove temporary files...")
         temp_folder.cleanup()
 
     return img_ctl

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+import logging
 import numpy as np
 
 from scipy.ndimage.measurements import center_of_mass, label
@@ -18,6 +19,8 @@ from spinalcordtoolbox.centerline import optic
 from spinalcordtoolbox.deepseg_sc.core import find_centerline, crop_image_around_centerline, uncrop_image, _normalize_data
 from spinalcordtoolbox import resampling
 from spinalcordtoolbox.deepseg_sc.cnn_models import nn_architecture_ctr
+
+logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 4
 MODEL_LST = ['t2', 't2_ax', 't2s']

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8
 # Functions dealing with deepseg_sc
 
-import os, sys
+import os, sys, logging
 
 import numpy as np
 from scipy.ndimage.measurements import center_of_mass, label
@@ -19,6 +19,8 @@ import sct_utils as sct
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 BATCH_SIZE = 4
+
+logger = logging.getLogger(__name__)
 
 
 def find_centerline(algo, image_fname, contrast_type, brain_bool, folder_output, remove_temp_files, centerline_fname):

--- a/spinalcordtoolbox/gui/centerline.py
+++ b/spinalcordtoolbox/gui/centerline.py
@@ -47,7 +47,7 @@ class CenterlineController(base.BaseController):
         # if the starting slice is of invalid value then use default value
         if self.START_SLICE > max_x or self.START_SLICE < 0:
             self.START_SLICE = self.default_position[0]
-            sct.log.warning('Starting slice value is out of range')
+            logger.warning('Starting slice value is out of range')
         # if the starting slice is a fraction, recalculate the starting slice as a ratio.
         elif 0 < self.START_SLICE < 1:
             self.START_SLICE = max_z // self.START_SLICE

--- a/spinalcordtoolbox/gui/widgets.py
+++ b/spinalcordtoolbox/gui/widgets.py
@@ -18,8 +18,6 @@ from PyQt4 import QtCore, QtGui
 
 from spinalcordtoolbox.gui.base import MissingLabelWarning
 
-
-# logging.basicConfig(level=logging.WARNING)  # default mode: WARNING. debug mode: DEBUG
 logger = logging.getLogger(__name__)
 
 

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -13,7 +13,7 @@
 
 from __future__ import division, absolute_import
 
-import sys, io, os, math, itertools, warnings
+import sys, os, itertools, warnings, logging
 
 import nibabel
 import nibabel.orientations
@@ -25,6 +25,8 @@ import transforms3d.affines as affines
 
 from msct_types import Coordinate
 import sct_utils as sct
+
+logger = logging.getLogger(__name__)
 
 
 def _get_permutations(im_src_orientation, im_dst_orientation):
@@ -122,6 +124,7 @@ class Slicer(object):
            raise IndexError("I just have {} slices!".format(self._nb_slices))
 
        return self._data[:,:,idx]
+
 
 class SlicerOneAxis(object):
     """
@@ -322,9 +325,9 @@ class Image(object):
         self.hdr = self.im_file.header
         self.absolutepath = path
         if path != self.absolutepath:
-            sct.log.debug("Loaded %s (%s) orientation %s shape %s", path, self.absolutepath, self.orientation, self.data.shape)
+            logger.debug("Loaded %s (%s) orientation %s shape %s", path, self.absolutepath, self.orientation, self.data.shape)
         else:
-            sct.log.debug("Loaded %s orientation %s shape %s", path, self.orientation, self.data.shape)
+            logger.debug("Loaded %s orientation %s shape %s", path, self.orientation, self.data.shape)
 
     def change_shape(self, shape, generate_path=False):
         """
@@ -449,10 +452,10 @@ class Image(object):
 
         # save file
         if os.path.isabs(path):
-            sct.log.debug("Saving image to %s orientation %s shape %s",
+            logger.debug("Saving image to %s orientation %s shape %s",
              path, self.orientation, data.shape)
         else:
-            sct.log.debug("Saving image to %s (%s) orientation %s shape %s",
+            logger.debug("Saving image to %s (%s) orientation %s shape %s",
              path, os.path.abspath(path), self.orientation, data.shape)
 
         nibabel.save(img, path)
@@ -780,7 +783,7 @@ def find_zmin_zmax(im, threshold=0.1):
 
     # Make sure image is not empty
     if not np.any(slicer):
-        sct.log.error('Input image is empty')
+        logger.error('Input image is empty')
 
     # Iterate from bottom to top until we find data
     for zmin in range(0, len(slicer)):

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -6,15 +6,13 @@ from __future__ import absolute_import
 
 import math
 import numpy as np
-from skimage import measure, filters, transform
+from skimage import measure, transform
 from tqdm import tqdm
+import logging
 
-import sct_utils as sct
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.aggregate_slicewise import Metric
 from spinalcordtoolbox.centerline.core import get_centerline
-
-# TODO: only use logging, don't use printing, pass images, not filenames, do imports at beginning of file, no chdir()
 
 
 def compute_shape(segmentation, algo_fitting='bspline', angle_correction=True, verbose=1):
@@ -98,7 +96,7 @@ def compute_shape(segmentation, algo_fitting='bspline', angle_correction=True, v
             for property_name in property_list:
                 shape_properties[property_name][iz] = shape_property[property_name]
         else:
-            sct.log.warning('\nNo properties for slice: {}'.format(iz))
+            logging.warning('\nNo properties for slice: {}'.format(iz))
 
         """ DEBUG
         from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
@@ -132,7 +130,7 @@ def _properties2d(image, dim):
     pad = 3  # padding used for cropping
     # Check if slice is empty
     if not image.any():
-        sct.log.debug('The slice is empty.')
+        logging.debug('The slice is empty.')
         return None
     # Normalize between 0 and 1 (also check if slice is empty)
     image_norm = (image - image.min()) / (image.max() - image.min())
@@ -144,7 +142,7 @@ def _properties2d(image, dim):
     regions = measure.regionprops(image_bin, intensity_image=image_norm)
     # Check number of regions
     if len(regions) > 1:
-        sct.log.debug('There is more than one object on this slice.')
+        logging.debug('There is more than one object on this slice.')
         return None
     region = regions[0]
     # Get bounding box of the object

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -28,7 +28,8 @@ import sct_utils as sct
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.reports.slice as qcslice
 
-logger = logging.getLogger("sct.{}".format(__file__))
+logger = logging.getLogger(__name__)
+
 
 class QcImage(object):
     """

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -17,7 +17,7 @@ from spinalcordtoolbox.resampling import resample_nipy
 from nibabel.nifti1 import Nifti1Image
 from nipy.io.nifti_ref import nifti2nipy, nipy2nifti
 
-logger = logging.getLogger("sct.{}".format(__file__))
+logger = logging.getLogger(__name__)
 
 
 class Slice(object):

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -12,11 +12,14 @@
 
 from __future__ import division, absolute_import
 
+import logging
 import nipy
 import numpy as np
 from nipy.algorithms.registration.resample import resample as n_resample
 
 import sct_utils as sct
+
+logger = logging.getLogger(__name__)
 
 
 def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpolation='linear', dtype=np.float64,

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -71,12 +71,12 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
             # compute new shape as: shape_r = shape * (p_r / p)
             shape_r = tuple([int(np.round(shape[i] * float(p[i]) / float(new_size[i]))) for i in range(img.ndim)])
         else:
-            sct.log.error('new_size_type is not recognized.')
+            logger.error('new_size_type is not recognized.')
 
         # Generate 3d affine transformation: R
         affine = img.affine[:4, :4]
         affine[3, :] = np.array([0, 0, 0, 1])  # satisfy to nifti convention. Otherwise it grabs the temporal
-        sct.log.debug('Affine matrix: \n' + str(affine))
+        logger.debug('Affine matrix: \n' + str(affine))
         R = np.eye(4)
         for i in range(3):
             R[i, i] = img.shape[i] / float(shape_r[i])

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -22,6 +22,8 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import get_centerline
 
+logger = logging.getLogger(__name__)
+
 
 class SpinalCordStraightener(object):
 
@@ -154,7 +156,7 @@ class SpinalCordStraightener(object):
         number_of_points = centerline.number_of_points
 
         # ==========================================================================================
-        logging.info('Create the straight space and the safe zone')
+        logger.info('Create the straight space and the safe zone')
         # 3. compute length of centerline
         # compute the length of the spinal cord based on fitted centerline and size of centerline in z direction
 
@@ -195,11 +197,11 @@ class SpinalCordStraightener(object):
         bound_straight = [(z_centerline[inferior_bound] - middle_slice) * factor_curved_straight + middle_slice,
                           (z_centerline[superior_bound] - middle_slice) * factor_curved_straight + middle_slice]
 
-        logging.info('Length of spinal cord: {}'.format(length_centerline))
-        logging.info('Size of spinal cord in z direction: {}'.format(size_z_centerline))
-        logging.info('Ratio length/size: {}'.format(factor_curved_straight))
-        logging.info('Safe zone boundaries (curved space): {}'.format(bound_curved))
-        logging.info('Safe zone boundaries (straight space): {}'.format(bound_straight))
+        logger.info('Length of spinal cord: {}'.format(length_centerline))
+        logger.info('Size of spinal cord in z direction: {}'.format(size_z_centerline))
+        logger.info('Ratio length/size: {}'.format(factor_curved_straight))
+        logger.info('Safe zone boundaries (curved space): {}'.format(bound_curved))
+        logger.info('Safe zone boundaries (straight space): {}'.format(bound_straight))
 
         # 4. compute and generate straight space
         # points along curved centerline are already regularly spaced.
@@ -247,7 +249,7 @@ class SpinalCordStraightener(object):
                 centerline_straight.save_centerline(image=discs_ref_image, fname_output='discs_ref_image.nii.gz')
 
         else:
-            logging.info('Pad input volume to account for spinal cord length...')
+            logger.info('Pad input volume to account for spinal cord length...')
 
             start_point, end_point = bound_straight[0], bound_straight[1]
             offset_z = 0
@@ -331,7 +333,7 @@ class SpinalCordStraightener(object):
             end_point_coord = image_centerline_pad.transfo_phys2pix([[0, 0, end_point]])[0]
 
             number_of_voxel = nx * ny * nz
-            logging.debug('Number of voxels: {}'.format(number_of_voxel))
+            logger.debug('Number of voxels: {}'.format(number_of_voxel))
 
             time_centerlines = time.time()
 
@@ -349,7 +351,7 @@ class SpinalCordStraightener(object):
                                              dx_straight, dy_straight, dz_straight)
 
             time_centerlines = time.time() - time_centerlines
-            logging.info('Time to generate centerline: {} ms'.format(np.round(time_centerlines * 1000.0)))
+            logger.info('Time to generate centerline: {} ms'.format(np.round(time_centerlines * 1000.0)))
 
         if verbose == 2:
             # TODO: use OO
@@ -513,16 +515,16 @@ class SpinalCordStraightener(object):
         if self.curved2straight:
             img = Nifti1Image(data_warp_curved2straight, None, hdr_warp_s)
             save(img, 'tmp.curve2straight.nii.gz')
-            logging.info('Warping field generated: tmp.curve2straight.nii.gz')
+            logger.info('Warping field generated: tmp.curve2straight.nii.gz')
 
         if self.straight2curved:
             img = Nifti1Image(data_warp_straight2curved, None, hdr_warp)
             save(img, 'tmp.straight2curve.nii.gz')
-            logging.info('Warping field generated: tmp.straight2curve.nii.gz')
+            logger.info('Warping field generated: tmp.straight2curve.nii.gz')
 
         image_centerline_straight.save(fname_ref)
         if self.curved2straight:
-            logging.info('Apply transformation to input image...')
+            logger.info('Apply transformation to input image...')
             sct.run(['isct_antsApplyTransforms',
                      '-d', '3',
                      '-r', fname_ref,
@@ -538,7 +540,7 @@ class SpinalCordStraightener(object):
             # compute the error between the straightened centerline/segmentation and the central vertical line.
             # Ideally, the error should be zero.
             # Apply deformation to input image
-            logging.info('Apply transformation to centerline image...')
+            logger.info('Apply transformation to centerline image...')
             sct.run(['isct_antsApplyTransforms',
                      '-d', '3',
                      '-r', fname_ref,
@@ -584,7 +586,7 @@ class SpinalCordStraightener(object):
 
         # Generate output file (in current folder)
         # TODO: do not uncompress the warping field, it is too time consuming!
-        logging.info('Generate output files...')
+        logger.info('Generate output files...')
         if self.curved2straight:
             sct.generate_output_file(os.path.join(path_tmp, "tmp.curve2straight.nii.gz"),
                                      os.path.join(self.path_output, "warp_curve2straight.nii.gz"), verbose)
@@ -608,12 +610,12 @@ class SpinalCordStraightener(object):
 
         # Remove temporary files
         if remove_temp_files:
-            logging.info('Remove temporary files...')
+            logger.info('Remove temporary files...')
             sct.rmtree(path_tmp)
 
         if self.accuracy_results:
-            logging.info('Maximum x-y error: {} mm'.format(self.max_distance_straightening))
-            logging.info('Accuracy of straightening (MSE): {} mm'.format(self.mse_straightening))
+            logger.info('Maximum x-y error: {} mm'.format(self.max_distance_straightening))
+            logger.info('Accuracy of straightening (MSE): {} mm'.format(self.mse_straightening))
 
         # display elapsed time
         self.elapsed_time = int(np.round(time.time() - start_time))

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -8,7 +8,7 @@
 
 from __future__ import absolute_import
 
-import os, sys, time, logging
+import os, time, logging
 import bisect
 import numpy as np
 from tqdm import tqdm

--- a/spinalcordtoolbox/template.py
+++ b/spinalcordtoolbox/template.py
@@ -4,9 +4,11 @@
 
 from __future__ import absolute_import
 
+import logging
 import numpy as np
 
-from sct_utils import log
+logger = logging.getLogger(__name__)
+
 
 def get_slices_from_vertebral_levels(im_vertlevel, level):
     """
@@ -49,7 +51,7 @@ def get_vertebral_level_from_slice(im_vertlevel, idx_slice):
         vert_level = int(np.round(np.mean(data_vertlevel[indx, indy, idx_slice])))
     except ValueError as e:
         # slice is empty (no indx found). Do nothing.
-        log.debug('Empty slice: z=%s (%s)', idx_slice, e)
+        logger.debug('Empty slice: z=%s (%s)', idx_slice, e)
         vert_level = None
     return vert_level
 

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -4,10 +4,7 @@
 
 from __future__ import absolute_import
 
-import sys, io, os, re
-import time, datetime
-import platform
-import logging
+import io, os, re
 import subprocess
 
 
@@ -112,7 +109,6 @@ __sct_dir__ = os.getenv("SCT_DIR", os.path.dirname(os.path.dirname(os.path.realp
 __version__ = _version_string()
 __data_dir__ = os.getenv("SCT_DATA_DIR", os.path.join(__sct_dir__, 'data'))
 
-logger = logging.getLogger('sct')
 
 def parse_num_list(str_num):
     """

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 
 import os
+import logging
 import sct_utils as sct
 from sct_flatten_sagittal import flatten_sagittal
 import numpy as np
@@ -28,6 +29,8 @@ from skimage.measure import label as label_regions
 
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image, zeros_like
+
+logger = logging.getLogger(__name__)
 
 
 def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -50,7 +50,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     nii_seg_flat = flatten_sagittal(nii_seg, nii_seg, verbose=verbose)
 
     # create temporary folder with intermediate results
-    sct.log.info("Creating temporary folder...")
+    logger.info("Creating temporary folder...")
     tmp_folder = sct.TempFolder()
     tmp_folder.chdir()
 
@@ -119,7 +119,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     # remove temporary files
     tmp_folder.chdir_undo()
     if verbose < 2:
-        sct.log.info("Remove temporary files...")
+        logger.info("Remove temporary files...")
         tmp_folder.cleanup()
 
     nii_c2c3.change_orientation(orientation_init)

--- a/testing/test_sct_label_utils.py
+++ b/testing/test_sct_label_utils.py
@@ -28,7 +28,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    sct.log.debug('init test {}'.format(param_test))
+    logger.debug('init test {}'.format(param_test))
     folder_data = ['t2']
     file_data = ['t2_seg.nii.gz', 't2_seg_labeled.nii.gz']
 
@@ -48,7 +48,7 @@ def test_integrity(param_test):
     Test integrity of function
     """
 
-    sct.log.debug('test integrity {}'.format(param_test.__dict__))
+    logger.debug('test integrity {}'.format(param_test.__dict__))
     # find the test that is performed and check the integrity of the output
     index_args = param_test.default_args.index(param_test.args)
 

--- a/testing/test_sct_label_utils.py
+++ b/testing/test_sct_label_utils.py
@@ -28,7 +28,6 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    logger.debug('init test {}'.format(param_test))
     folder_data = ['t2']
     file_data = ['t2_seg.nii.gz', 't2_seg_labeled.nii.gz']
 
@@ -47,14 +46,12 @@ def test_integrity(param_test):
     """
     Test integrity of function
     """
-
-    logger.debug('test integrity {}'.format(param_test.__dict__))
     # find the test that is performed and check the integrity of the output
     index_args = param_test.default_args.index(param_test.args)
 
     # Removed because of:
     # https://travis-ci.org/neuropoly/spinalcordtoolbox/jobs/482061826
-    param_test.output = "NOT TESTED-- SHOULD BE REACTIVATED ASAP"
+    param_test.output += "NOT TESTED-- SHOULD BE REACTIVATED ASAP"
     # if index_args == 1:
     #     # compute center of mass of labeled segmentation
     #     centers_of_mass_image = sct_label_utils.main(['-i', 'test_centerofmass.nii.gz', '-display', '-v', '0'])

--- a/testing/test_sct_segment_graymatter.py
+++ b/testing/test_sct_segment_graymatter.py
@@ -76,7 +76,7 @@ def test_integrity(param_test):
         except ValueError:
             # Hack to avoid "too many values to unpack" due to the recent addition of "Total processing time:" at the
             # end of a process. In the future we should simply output dice results as external csv file.
-            sct.log.debug("ValueError: Ignoring this line.")
+            logger.debug("ValueError: Ignoring this line.")
     result_dice_gm = np.mean(gm_dice)
 
     # extracting dice on WM
@@ -97,7 +97,7 @@ def test_integrity(param_test):
         except ValueError:
             # Hack to avoid "too many values to unpack" due to the recent addition of "Total processing time:" at the
             # end of a process. In the future we should simply output dice results as external csv file.
-            sct.log.debug("ValueError: Ignoring this line.")
+            logger.debug("ValueError: Ignoring this line.")
     result_dice_wm = np.mean(wm_dice)
 
     # Extracting hausdorff distance results


### PR DESCRIPTION
SCT has used several methods to communicate and raise exceptions (sct_utils.printv, sct_utils.log, logger module, sct_utils.class Error, try/except). The purpose of this PR is to establish convention and update the code and wiki accordingly. 

A prototype of the proposed solution is available [here](https://github.com/neuropoly/spinalcordtoolbox/issues/2213#issue-429798413).

DONE:
- Updated command-line functions to only use `printv`
- Established strategy for redirecting and cleaning logging into stdout when running API from Terminal. Could print in another color.
- Established strategy for filtering logging redirection following hierarchical approach (e.g., exclude child calls)
- Updated [wiki](https://github.com/neuropoly/spinalcordtoolbox/wiki/logging)
- Removed option to set default config via .sctrc file (not very useful)

TODO:
- Move printing-related stuff from `sct_utils` to `spinalcordtoolbox.utils` --> will do in subsequent PR

Fixes #2213
