### PR TITLE
Fixed installation error caused by old SSL module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ xlutils
 xlwt
 tqdm
 transforms3d
+urllib3[secure]
 portalocker

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ xlutils
 xlwt
 tqdm
 transforms3d
-urllib3
+urllib3[secure]
 portalocker

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ xlutils
 xlwt
 tqdm
 transforms3d
-urllib3[secure]
+urllib3
 portalocker

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -67,6 +67,7 @@ def resolve_module(framework_name):
         'opencv': ('cv2', False),
         'mkl-service': (None, False),
         'pytest-cov': ('pytest_cov', False),
+        'urllib3[secure]': ('urllib3', False),
     }
 
     try:


### PR DESCRIPTION
This PR fixes an issue which happens on Python 2 platforms that have an outdated ssl module. These older ssl modules can cause some insecure requests to succeed where they should fail and secure requests to fail where they should succeed. 

Source: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings

Fixes #2222
