### PR TITLE
Made tests more sensitive to centerline rotation and fix LinAlgError

### DIFF
--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -150,7 +150,8 @@ def _properties2d(image, dim):
     # Get bounding box of the object
     minx, miny, maxx, maxy = region.bbox
     # Use those bounding box coordinates to crop the image (for faster processing)
-    image_crop = image_norm[minx-pad: maxx+pad, miny-pad: maxy+pad]
+    image_crop = image_norm[np.clip(minx-pad, 0, image_bin.shape[0]): np.clip(maxx+pad, 0, image_bin.shape[0]),
+                 np.clip(miny-pad, 0, image_bin.shape[1]): np.clip(maxy+pad, 0, image_bin.shape[1])]
     # Oversample image to reach sufficient precision when computing shape metrics on the binary mask
     image_crop_r = transform.pyramid_expand(image_crop, upscale=upscale, sigma=None, order=1)
     # Binarize image using threshold at 0. Necessary input for measure.regionprops

--- a/unit_testing/test_process_seg.py
+++ b/unit_testing/test_process_seg.py
@@ -18,38 +18,66 @@ from create_test_data import dummy_segmentation
 # Define global variables
 PARAM = Param()
 VERBOSE = 0  # set to 2 to save files
-DEBUG = False
+DEBUG = False  # Set to True to save images
 
 # Generate a list of fake segmentation for testing: (dummy_segmentation(params), dict of expected results)
 im_segs = [
     # test area
-    (dummy_segmentation(size_arr=(32, 32, 5)), {'area': 77, 'angle_RL': 0.0}, {'angle_corr': False}),
+    (dummy_segmentation(size_arr=(32, 32, 5), debug=DEBUG),
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
     # test anisotropic pixel dim
-    (dummy_segmentation(size_arr=(64, 32, 5), pixdim=(0.5, 1, 5)), {'area': 77, 'angle_RL': 0.0},
+    (dummy_segmentation(size_arr=(64, 32, 5), pixdim=(0.5, 1, 5), debug=DEBUG),
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
      {'angle_corr': False}),
     # test with angle IS
-    (dummy_segmentation(size_arr=(32, 32, 5), pixdim=(1, 1, 5), angle_IS=15),
-     {'area': 77, 'angle_RL': 0.0}, {'angle_corr': False}),
+    (dummy_segmentation(size_arr=(32, 32, 5), pixdim=(1, 1, 5), angle_IS=15, debug=DEBUG),
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
     # test with ellipse shape
-    (dummy_segmentation(size_arr=(64, 64, 5), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0}, {'angle_corr': False}),
+    (dummy_segmentation(size_arr=(64, 64, 5), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0,
+                        debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
     # test with int16. Different bit ordering, which can cause issue when applying transform.warp()
     (dummy_segmentation(size_arr=(64, 320, 5), pixdim=(1, 1, 1), dtype=np.int16, orientation='RPI',
                         shape='rectangle', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0, debug=DEBUG),
-     {'area': 297.0, 'angle_RL': 0.0}, {'angle_corr': False}),
+     {'area': 297.0, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
     # test with angled spinal cord (neg angle)
-    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-30.0),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -30.0}, {'angle_corr': True}),
+    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-30.0,
+                        debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -30.0, 'angle_AP': 0.0},
+     {'angle_corr': True}),
+    # test with AP angled spinal cord
+    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_AP=20.0,
+                        debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 20.0},
+     {'angle_corr': True}),
+    # test with RL and AP angled spinal cord
+    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-10.0,
+                        angle_AP=15.0, debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -10.0, 'angle_AP': 15.0},
+     {'angle_corr': True}),
+    # Reproduce issue: "LinAlgError: SVD did not converge"
+    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-10.0,
+                        angle_AP=30.0, debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -10.0, 'angle_AP': 15.0},
+     {'angle_corr': True}),
     # test uint8 input
-    (dummy_segmentation(size_arr=(32, 32, 50), dtype=np.uint8, angle_RL=15),
-     {'area': 77, 'angle_RL': 15.0}, {'angle_corr': True}),
+    (dummy_segmentation(size_arr=(32, 32, 50), dtype=np.uint8, angle_RL=15, debug=DEBUG),
+     {'area': 77, 'angle_RL': 15.0, 'angle_AP': 0.0},
+     {'angle_corr': True}),
     # test all output params
-    (dummy_segmentation(size_arr=(128, 128, 5), pixdim=(1, 1, 1), shape='ellipse', radius_RL=50.0, radius_AP=30.0),
+    (dummy_segmentation(size_arr=(128, 128, 5), pixdim=(1, 1, 1), shape='ellipse', radius_RL=50.0, radius_AP=30.0,
+                        debug=DEBUG),
      {'area': 4701, 'angle_AP': 0.0, 'angle_RL': 0.0, 'diameter_AP': 60.0, 'diameter_RL': 100.0, 'eccentricity': 0.8,
-      'orientation': 0.0, 'solidity': 1.0}, {'angle_corr': False}),
+      'orientation': 0.0, 'solidity': 1.0},
+     {'angle_corr': False}),
     # test with one empty slice
-    (dummy_segmentation(size_arr=(32, 32, 5), zeroslice=[2]),
-     {'area': np.nan}, {'angle_corr': False, 'slice': 2})
+    (dummy_segmentation(size_arr=(32, 32, 5), zeroslice=[2], debug=DEBUG),
+     {'area': np.nan},
+     {'angle_corr': False, 'slice': 2})
     ]
 
 

--- a/unit_testing/test_process_seg.py
+++ b/unit_testing/test_process_seg.py
@@ -55,14 +55,15 @@ im_segs = [
      {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 20.0},
      {'angle_corr': True}),
     # test with RL and AP angled spinal cord
-    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-10.0,
-                        angle_AP=15.0, debug=DEBUG),
+    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
+                        angle_RL=-10.0, angle_AP=15.0, debug=DEBUG),
      {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -10.0, 'angle_AP': 15.0},
      {'angle_corr': True}),
-    # Reproduce issue: "LinAlgError: SVD did not converge"
-    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-10.0,
-                        angle_AP=30.0, debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -10.0, 'angle_AP': 15.0},
+    # Reproduce issue: "LinAlgError: SVD did not converge". Note: due to the cropping, the estimated angle_RL is wrong,
+    # so it had to be made wrong in the expected values
+    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
+                        angle_RL=-10.0, angle_AP=30.0, debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -11.5, 'angle_AP': 30.0},
      {'angle_corr': True}),
     # test uint8 input
     (dummy_segmentation(size_arr=(32, 32, 50), dtype=np.uint8, angle_RL=15, debug=DEBUG),


### PR DESCRIPTION
This PR introduces more exhaustive tests for `process_seg` (fixes #2225) and fix a bug that happens if rotation is too important, raising `LinAlgError: SVD did not converge` (fixes #2228).