### PR TITLE
Fixed corruption of QC json file when running parallel jobs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Keras
 matplotlib
 nibabel
 pandas
-portalocker
 psutil
 pyqt5
 raven

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -1315,22 +1315,3 @@ def cache_save(cachefile, sig):
     with io.open(cachefile, "wb") as f:
         f.write(sig)
 
-class open_with_exclusive_lock(object):
-    """
-    Utility class to prevent the writing of a file by multiple processes.
-
-    :param filename: name of the file to lock
-    :param mode: permission of the file ('w', 'r', 'a', etc.)
-    """
-    def __init__(self, filename, mode):
-        self.filename = filename
-        self.mode = mode
-
-    def __enter__(self):
-        fd = os.open(self.filename, os.O_RDWR|os.O_CREAT)
-        self._f = os.fdopen(fd, self.mode)
-        portalocker.lock(self._f, portalocker.LOCK_EX)
-        return self._f
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        portalocker.unlock(self._f)

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -23,7 +23,6 @@ import subprocess
 import tempfile
 
 import numpy as np
-import portalocker
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -26,6 +26,7 @@ import matplotlib.colors as color
 
 import sct_utils as sct
 from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.utils import open_with_exclusive_lock
 import spinalcordtoolbox.reports.slice as qcslice
 
 logger = logging.getLogger(__name__)
@@ -423,7 +424,7 @@ class QcReport(object):
         }
         logger.debug('Description file: %s', self.qc_params.qc_results)
         results = []
-        with sct.open_with_exclusive_lock(self.qc_params.qc_results, 'r+') as lck_qc_file:
+        with open_with_exclusive_lock(self.qc_params.qc_results, 'r+') as lck_qc_file:
             if os.path.getsize(self.qc_params.qc_results) != 0:
                 results = json.load(lck_qc_file)
             results.append(output)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function, absolute_import, division
 
+import glob
 import sys
 import os
 import json
@@ -26,7 +27,6 @@ import matplotlib.colors as color
 
 import sct_utils as sct
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import open_with_exclusive_lock
 import spinalcordtoolbox.reports.slice as qcslice
 
 logger = logging.getLogger(__name__)
@@ -351,7 +351,7 @@ class Params(object):
         self.dpi = dpi
         self.root_folder = dest_folder
         self.mod_date = datetime.datetime.strftime(datetime.datetime.now(), '%Y_%m_%d_%H%M%S.%f')
-        self.qc_results = os.path.join(dest_folder, 'qc_results.json')
+        self.qc_results = os.path.join(dest_folder, '_json/qc_'+self.mod_date+'.json')
         self.bkg_img_path = os.path.join(dataset, subject, contrast, command, self.mod_date, 'bkg_img.png')
         self.overlay_img_path = os.path.join(dataset, subject, contrast, command, self.mod_date, 'overlay_img.png')
 
@@ -423,16 +423,15 @@ class QcReport(object):
             'moddate': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         }
         logger.debug('Description file: %s', self.qc_params.qc_results)
-        results = []
-        with open_with_exclusive_lock(self.qc_params.qc_results, 'r+') as lck_qc_file:
-            if os.path.getsize(self.qc_params.qc_results) != 0:
-                results = json.load(lck_qc_file)
-            results.append(output)
-            lck_qc_file.seek(0)
-            lck_qc_file.truncate()
-            json.dump(results, lck_qc_file, indent=2)
-        self._update_html_assets(results)
-
+        # results = []
+        # Create path to store json files
+        path_json, _ = os.path.split(self.qc_params.qc_results)
+        if not os.path.exists(path_json):
+            os.makedirs(path_json)
+        # Create json file
+        with open(self.qc_params.qc_results, 'w+') as qc_file:
+            json.dump(output, qc_file, indent=1)
+        self._update_html_assets(get_json_data_from_path(path_json))
 
     def _update_html_assets(self, json_data):
         """Update the html file and assets"""
@@ -586,3 +585,13 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, args=None, path_qc=No
         qcslice_layout=qcslice_layout,
         stretch_contrast_method='equalized',
     )
+
+
+def get_json_data_from_path(path_json):
+    """Read all json files present in the given path, and output an aggregated json structure"""
+    results = []
+    for file_json in glob.iglob(os.path.join(path_json, '*.json')):
+        logger.debug('Opening: '+file_json)
+        with open(file_json, 'r+') as fjson:
+            results.append(json.load(fjson))
+    return results

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -12,44 +12,6 @@ logger = logging.getLogger(__name__)
 
 # TODO: add test
 
-class open_with_exclusive_lock(object):
-    """
-    Utility class to prevent the writing of a file by multiple processes.
-
-    :param filename: name of the file to lock
-    :param mode: permission of the file ('w', 'r', 'a', etc.)
-    """
-
-    def __init__(self, filename, mode):
-        self.filename = filename
-        self.mode = mode
-        self.lock_name = filename + ".lock/locked_by_sct"
-
-    def __enter__(self):
-        while True:
-            try:
-                os.mkdir(os.path.dirname(self.lock_name))
-            except OSError as e:
-                logger.warning("Access to %s prevented by dir lock", self.filename)
-                time.sleep(0.001)
-                continue
-
-            try:
-                os.symlink("locked_by_sct", self.lock_name)
-            except OSError:
-                logger.warning("Access to %s prevented by link lock", self.filename)
-                time.sleep(0.001)
-                continue
-
-            break
-        fd = os.open(self.filename, os.O_RDWR | os.O_CREAT)
-        self._f = os.fdopen(fd, self.mode)
-        return self._f
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        os.unlink(self.lock_name)
-        os.rmdir(os.path.dirname(self.lock_name))
-
 
 def check_exe(name):
     """

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -19,26 +19,36 @@ class open_with_exclusive_lock(object):
     :param filename: name of the file to lock
     :param mode: permission of the file ('w', 'r', 'a', etc.)
     """
+
     def __init__(self, filename, mode):
         self.filename = filename
         self.mode = mode
-        self.lock_name = filename + ".lock~"
+        self.lock_name = filename + ".lock/locked_by_sct"
 
     def __enter__(self):
         while True:
             try:
+                os.mkdir(os.path.dirname(self.lock_name))
+            except OSError as e:
+                logger.warning("Access to %s prevented by dir lock", self.filename)
+                time.sleep(0.001)
+                continue
+
+            try:
                 os.symlink("locked_by_sct", self.lock_name)
             except OSError:
-                logger.warning("Access to %s prevented by lock", self.filename)
+                logger.warning("Access to %s prevented by link lock", self.filename)
                 time.sleep(0.001)
-            else:
-                break
-        fd = os.open(self.filename, os.O_RDWR|os.O_CREAT)
+                continue
+
+            break
+        fd = os.open(self.filename, os.O_RDWR | os.O_CREAT)
         self._f = os.fdopen(fd, self.mode)
         return self._f
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.unlink(self.lock_name)
+        os.rmdir(os.path.dirname(self.lock_name))
 
 
 def check_exe(name):


### PR DESCRIPTION
When running several subjects in parallel (using GNU parallel), during QC generation, a `JSONDecodeError` is observed. This error was caused by parallel writing on the json file of the QC report. It was supposed to be fixed by the use of `portalocker` (see https://github.com/neuropoly/spinalcordtoolbox/issues/2205), but in some file systems (OSX, Ubuntu), it is not. 

Another (unsuccessful) locking strategy was tried: create a temporary locked file, and then copy the content in the json file. However, it also failed in some OSs (OSX, Ubuntu).

The fix was to create an individual json file for each instance, instead of appending all the QC metadata within the same json file. 

Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/2248