### PR TITLE
Fix regression related to output straight FOV size

### DIFF
--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -254,8 +254,7 @@ def main(args=None):
         cmd = ['sct_straighten_spinalcord',
                '-i', 'data.nii',
                '-s', 'segmentation.nii',
-               '-r', str(remove_temp_files),
-               '-xy_size', '60']
+               '-r', str(remove_temp_files)]
         if param.path_qc is not None and os.environ.get("SCT_RECURSIVE_QC", None) == "1":
             cmd += ['-qc', param.path_qc]
         s, o = sct.run(cmd)

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -145,7 +145,7 @@ def get_parser():
                       description="""Algorithm used by the cord straightening procedure for fitting the centerline.""",
                       mandatory=False,
                       default_value='bspline',
-                      example=['nurbs', 'bspline'])
+                      example=['bspline', 'polyfit'])
     parser.add_option(name='-qc',
                       type_value='folder_creation',
                       description='The path where the quality control generated content will be saved',
@@ -215,7 +215,6 @@ def main(args=None):
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both
-    # if '-straighten-fitting' in arguments:
     param.straighten_fitting = arguments['-straighten-fitting']
     # if '-cpu-nb' in arguments:
     #     arg_cpu = ' -cpu-nb '+str(arguments['-cpu-nb'])

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -30,7 +30,7 @@ from msct_parser import Parser
 class Param:
     # The constructor
     def __init__(self):
-        self.algo_fitting = 'nurbs'  # Fitting algorithm for centerline. See sct_straighten_spinalcord.
+        self.algo_fitting = 'bspline'  # Fitting algorithm for centerline. See sct_straighten_spinalcord.
 
     # update constructor with user's parameters
     def update(self, param_user):
@@ -82,7 +82,7 @@ def get_parser():
     parser.add_option(name='-param',
                       type_value=[[','], 'str'],
                       description="Advanced parameters. Assign value with \"=\"; Separate params with \",\"\n"
-                                  "algo_fitting {hanning,nurbs}: Algorithm for curve fitting. For more information, see sct_straighten_spinalcord. Default="+ param_default.algo_fitting + ".\n",
+                                  "algo_fitting {bspline, polyfit}: Algorithm for curve fitting. For more information, see sct_straighten_spinalcord. Default="+ param_default.algo_fitting + ".\n",
                       mandatory=False)
     parser.usage.addSection('MISC')
     parser.add_option(name="-r",

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -139,14 +139,14 @@ def get_parser():
     parser.add_option(name="-param",
                       type_value=[[','], 'str'],
                       description="Parameters for spinal cord straightening. Separate arguments with ','."
-                                  "\nalgo_fitting: {polyfit,bspline,nurbs} algorithm for curve fitting. Default=bspline"
-                                  "\ndegree: int: Maximum degree of polynomial function for fitting centerline. Default=3"
+                                  "\nalgo_fitting: {polyfit,bspline} algorithm for curve fitting. Default=bspline"
+                                  "\ndegree: int: Maximum degree of polynomial function for fitting centerline. Default=5"
                                   "\nprecision: [1.0,inf[. Precision factor of straightening, related to the number of slices. Increasing this parameter increases the precision along with increased computational time. Not taken into account with hanning fitting method. Default=2"
                                   "\nthreshold_distance: [0.0,inf[. Threshold at which voxels are not considered into displacement. Increase this threshold if the image is blackout around the spinal cord too much. Default=10"
                                   "\naccuracy_results: {0, 1} Disable/Enable computation of accuracy results after straightening. Default=0"
                                   "\ntemplate_orientation: {0, 1} Disable/Enable orientation of the straight image to be the same as the template. Default=0",
                       mandatory=False,
-                      example="algo_fitting=nurbs,accuracy_results=1")
+                      example="algo_fitting=bspline,accuracy_results=1")
 
     return parser
 

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -48,7 +48,7 @@ class SpinalCordStraightener(object):
         self.discs_input_filename = ""
         self.discs_ref_filename = ""
         self.speed_factor = 1.0  # Speed parameter
-        self.xy_size = 35  # in mm
+        self.xy_size = 70  # in mm
 
         # QC metrics
         self.accuracy_results = 0


### PR DESCRIPTION
## Description

In a previous implementation of spinal cord straightening, the parameter `xy_size` was misleading, as it produced a dimension that was `2*xy_size` instead of `xy_size`. In PR https://github.com/neuropoly/spinalcordtoolbox/pull/2238, this has been corrected: [before](https://github.com/neuropoly/spinalcordtoolbox/pull/2214/files#diff-06511e50890a7fbffb44629b754dc3f7L370), [after](https://github.com/neuropoly/spinalcordtoolbox/pull/2214/files#diff-2f9350cd76070039f9105b8259030cb4R267). 

However, the default value for `xy_size` was not updated, causing different default behaviours, such as having an output warping field that spans a XY area twice smaller than previously. 

Also see: http://forum.spinalcordmri.org/t/sct-v4-0-0-beta-2-is-out/43/8?u=jcohenadad

## Proposed solution

- Double the default `xy_size` in `straightening.py`. Fixes #2256
- Clarify fitting options for straightening in various SCT functions. Fixes #2255 
