### PR TITLE
Make consistent STD calculation between sct_fmri_compute_tsnr and sct_compute_snr

### DIFF
--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -137,7 +137,7 @@ def main():
     if method == 'mult':
         # Compute mean and STD across time
         data_mean = np.mean(data[:, :, :, index_vol], axis=3)
-        data_std = np.std(data[:, :, :, index_vol], axis=3)
+        data_std = np.std(data[:, :, :, index_vol], axis=3, ddof=1)
         # Generate mask where std is different from 0
         mask_std_nonzero = np.where(data_std > param.almost_zero)
         snr_map = np.zeros_like(data_mean)


### PR DESCRIPTION
This PR aims to fix the inconsistency between ` sct_fmri_compute_tsnr` and `sct_compute_snr` which was caused by a difference in the way standard deviation was calculated as described in [https://sourceforge.net/p/spinalcordtoolbox/help/10/](https://sourceforge.net/p/spinalcordtoolbox/help/10/)
Fixes #2110 

The resulting values of 'sct_fmri_compute_tsnr -i fmri.nii.gz' and 'sct_compute_snr -i fmri.nii.gz -method mult' would slightly differ due to `sct_compute_snr` using N (ddof = 0) instead of N-1
(ddof = 1) as the denominator when calculating the standard deviation as ` sct_fmri_compute_tsnr` did.

For the sake of consistency,`sct_compute_snr` now uses N-1 (ddof = 1) when calculating the standard deviation.