### PR TITLE
Added output file and/or folder flag

### DIFF
--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -41,7 +41,7 @@ def main(args=None):
     # Initialization
     fname_mt0 = ''
     fname_mt1 = ''
-    file_out = param.file_out
+    fname_mtr = ''
     # register = param.register
     # remove_temp_files = param.remove_temp_files
     # verbose = param.verbose
@@ -57,8 +57,6 @@ def main(args=None):
     fname_mt0 = arguments['-mt0']
     fname_mt1 = arguments['-mt1']
     fname_mtr = arguments['-o']
-    file_out = os.path.basename(fname_mtr)[:os.path.basename(fname_mtr).rfind('.nii')]
-    ext_out = os.path.basename(fname_mtr)[os.path.basename(fname_mtr).rfind('.nii'):]
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
 
@@ -72,7 +70,7 @@ def main(args=None):
     nii_mtr = nii_mt1
     nii_mtr.data = data_mtr
     nii_mtr.save(fname_mtr)
-    # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 file_out.nii', verbose)
+    # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 fname_mtr', verbose)
 
     # if changing output file name or location, create folder with mt0.nii.gz and mt1.nii.gz files at precised location
     if os.path.dirname(fname_mtr) != '.':
@@ -84,9 +82,9 @@ def main(args=None):
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join('.', file_out + ext_out), '.')
+    sct.generate_output_file(os.path.join('.', os.path.basename(fname_mtr)), '.')
 
-    sct.display_viewer_syntax([fname_mt0, fname_mt1, file_out + ext_out])
+    sct.display_viewer_syntax([fname_mt0, fname_mt1, os.path.basename(fname_mtr)])
 
 
 # ==========================================================================================

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -63,22 +63,6 @@ def main(args=None):
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
 
-    # Copying input data to output folder and convert to nii
-    sct.printv('\nCopying input data to output folder and convert to nii...', verbose)
-    from sct_convert import convert
-    convert(fname_mt0, os.path.join(os.path.dirname(fname_mtr), "mt0.nii"), dtype=np.float32)
-    convert(fname_mt1, os.path.join(os.path.dirname(fname_mtr), "mt1.nii"), dtype=np.float32)
-
-    # if changing output file name or location, create folder with mt0 and mt1 files at precised location
-    if os.path.dirname(fname_mtr) != '.':
-        startdir = os.getcwd()
-        os.chdir(os.path.dirname(fname_mtr))
-        shutil.copy(os.path.join(startdir, fname_mt0), os.path.dirname(fname_mtr))
-        shutil.copy(os.path.join(startdir, fname_mt1), os.path.dirname(fname_mtr))
-
-    # go to output file directory
-    os.chdir(os.path.dirname(fname_mtr))
-
     # compute MTR
     sct.printv('\nCompute MTR...', verbose)
     nii_mt1 = msct_image.Image('mt1.nii')
@@ -88,8 +72,16 @@ def main(args=None):
     # save MTR file
     nii_mtr = nii_mt1
     nii_mtr.data = data_mtr
-    nii_mtr.save(file_out + ext_out)
+    nii_mtr.save(fname_mtr)
     # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 file_out.nii', verbose)
+
+    # if changing output file name or location, create folder with mt0.nii.gz and mt1.nii.gz files at precised location
+    if os.path.dirname(fname_mtr) != '.':
+        shutil.copy(os.path.join('.', fname_mt0), os.path.dirname(fname_mtr))
+        shutil.copy(os.path.join('.', fname_mt1), os.path.dirname(fname_mtr))
+
+    # go to output file directory
+    os.chdir(os.path.dirname(fname_mtr))
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -72,9 +72,6 @@ def main(args=None):
     nii_mtr.save(fname_mtr)
     # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 fname_mtr', verbose)
 
-    # go to output file directory
-    os.chdir(os.path.dirname(fname_mtr))
-
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
     sct.generate_output_file(os.path.join('.', fname_mtr), '.')

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import, division
 
 import sys
 import os
-import shutil
 
 import sct_utils as sct
 from msct_parser import Parser
@@ -65,9 +64,9 @@ def main(args=None):
 
     # compute MTR
     sct.printv('\nCompute MTR...', verbose)
-    nii_mt1 = msct_image.Image('mt1.nii')
+    nii_mt1 = msct_image.Image(fname_mt1)
     data_mt1 = nii_mt1.data
-    data_mt0 = msct_image.Image('mt0.nii').data
+    data_mt0 = msct_image.Image(fname_mt0).data
     data_mtr = 100 * (data_mt0 - data_mt1) / data_mt0
     # save MTR file
     nii_mtr = nii_mt1
@@ -77,8 +76,8 @@ def main(args=None):
 
     # if changing output file name or location, create folder with mt0.nii.gz and mt1.nii.gz files at precised location
     if os.path.dirname(fname_mtr) != '.':
-        shutil.copy(os.path.join('.', fname_mt0), os.path.dirname(fname_mtr))
-        shutil.copy(os.path.join('.', fname_mt1), os.path.dirname(fname_mtr))
+        sct.copy(os.path.join('.', fname_mt0), os.path.dirname(fname_mtr))
+        sct.copy(os.path.join('.', fname_mt1), os.path.dirname(fname_mtr))
 
     # go to output file directory
     os.chdir(os.path.dirname(fname_mtr))

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -157,7 +157,7 @@ def get_parser():
                       default_value='1')
     parser.add_option(name="-o",
                       type_value="str",
-                      description="Creates output file with the specified path.",
+                      description="Creates output file with the specified path. Add extension '.nii.gz' to output file name.",
                       mandatory=False,
                       example='My_File_Folder/My_New_File',
                       default_value=os.path.join(os.getcwd(),'mtr'))

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -104,7 +104,7 @@ def main(args=None):
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join(path_tmp, file_out + ".nii"), os.path.join(path_out, file_out + ext_out))
+    sct.generate_output_file(os.path.join(path_tmp, file_out + ".nii"), os.path.join(path_out, file_out))
 
     # Remove temporary files
     if remove_temp_files == 1:

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -100,12 +100,6 @@ def get_parser():
                       description="Image with MT pulse (MT1)",
                       mandatory=False,
                       deprecated_by="-mt1")
-    parser.add_option(name="-r",
-                      type_value="multiple_choice",
-                      description='Remove temporary files.',
-                      mandatory=False,
-                      default_value='1',
-                      example=['0', '1'])
     parser.add_option(name="-v",
                       type_value='multiple_choice',
                       description="verbose: 0 = nothing, 1 = classic, 2 = expended",

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division
 
 import sys
 import os
+import shutil
 
 import sct_utils as sct
 from msct_parser import Parser
@@ -78,7 +79,6 @@ def main(args=None):
     # if changing output file name or location, create folder with mt0 and mt1 files at precised location
     curdir = os.getcwd()
     if os.path.split(fname_mtr)[0] != curdir:
-        import shutil
         startdir = os.getcwd()
         os.chdir(os.path.split(fname_mtr)[0])
         shutil.copy(os.path.join(startdir,fname_mt0),os.path.join(os.path.split(fname_mtr)[0]))

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -160,7 +160,7 @@ def get_parser():
                       description="Creates output file with the specified path. Add extension '.nii.gz' to output file name.",
                       mandatory=False,
                       example='Users/john/data/My_New_File.nii.gz',
-                      default_value=os.path.join(os.getcwd(),'mtr'))
+                      default_value=os.path.join(os.getcwd(),'mtr.nii.gz'))
 
     return parser
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -56,6 +56,8 @@ def main(args=None):
 
     fname_mt0 = arguments['-mt0']
     fname_mt1 = arguments['-mt1']
+    fname_mtr = arguments['-omtr']
+    param.file_out, file_out = os.path.split(fname_mtr)[1], os.path.split(fname_mtr)[1]
     remove_temp_files = int(arguments['-r'])
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
@@ -74,7 +76,7 @@ def main(args=None):
     convert(fname_mt1, os.path.join(path_tmp, "mt1.nii"), dtype=np.float32)
 
     # go to tmp folder
-    curdir = os.getcwd()
+    curdir = os.path.split(fname_mtr)[0]
     os.chdir(path_tmp)
 
     # compute MTR
@@ -86,15 +88,15 @@ def main(args=None):
     # save MTR file
     nii_mtr = nii_mt1
     nii_mtr.data = data_mtr
-    nii_mtr.save("mtr.nii")
-    # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 mtr.nii', verbose)
+    nii_mtr.save(file_out + ".nii")
+    # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 file_out.nii', verbose)
 
     # come back
     os.chdir(curdir)
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join(path_tmp, "mtr.nii"), os.path.join(path_out, file_out + ext_out))
+    sct.generate_output_file(os.path.join(path_tmp, file_out + ".nii"), os.path.join(path_out, file_out + ext_out))
 
     # Remove temporary files
     if remove_temp_files == 1:
@@ -141,6 +143,12 @@ def get_parser():
                       mandatory=False,
                       example=['0', '1', '2'],
                       default_value='1')
+    parser.add_option(name="-omtr",
+                      type_value="str",
+                      description="Output file mtr. Default is mtr.nii.gz",
+                      mandatory=False,
+                      example='My_File_Folder/My_File',
+                      default_value=os.path.join(os.getcwd(),'mtr'))
 
     return parser
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -159,7 +159,7 @@ def get_parser():
                       type_value="str",
                       description="Creates output file with the specified path. Add extension '.nii.gz' to output file name.",
                       mandatory=False,
-                      example='My_File_Folder/My_New_File',
+                      example='Users/john/data/My_New_File.nii.gz',
                       default_value=os.path.join(os.getcwd(),'mtr'))
 
     return parser

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -58,14 +58,11 @@ def main(args=None):
     fname_mt0 = arguments['-mt0']
     fname_mt1 = arguments['-mt1']
     fname_mtr = arguments['-o']
-    param.file_out, file_out = os.path.split(fname_mtr)[1], os.path.split(fname_mtr)[1]
+    file_out = os.path.split(fname_mtr)[1][:os.path.split(fname_mtr)[1].rfind('.nii')]
+    ext_out = os.path.split(fname_mtr)[1][os.path.split(fname_mtr)[1].rfind('.nii'):]
     remove_temp_files = int(arguments['-r'])
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
-
-    # Extract path/file/extension
-    path_mt0, file_mt0, ext_mt0 = sct.extract_fname(fname_mt0)
-    path_out, file_out, ext_out = '', file_out, ext_mt0
 
     # create temporary folder
     path_tmp = sct.tmp_create()
@@ -104,14 +101,14 @@ def main(args=None):
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join(path_tmp, file_out + ".nii"), os.path.join(path_out, file_out))
+    sct.generate_output_file(os.path.join(path_tmp, file_out + ".nii"), os.path.join(file_out + ext_out))
 
     # Remove temporary files
     if remove_temp_files == 1:
         sct.printv('\nRemove temporary files...')
         sct.rmtree(path_tmp)
 
-    sct.display_viewer_syntax([fname_mt0, fname_mt1, file_out])
+    sct.display_viewer_syntax([fname_mt0, fname_mt1, file_out + ext_out])
 
 
 # ==========================================================================================

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -88,12 +88,12 @@ def main(args=None):
     # save MTR file
     nii_mtr = nii_mt1
     nii_mtr.data = data_mtr
-    nii_mtr.save(file_out + ".nii")
+    nii_mtr.save(file_out + ext_out)
     # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 file_out.nii', verbose)
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join('.', file_out + '.nii'), '.')
+    sct.generate_output_file(os.path.join('.', file_out + ext_out), '.')
 
     sct.display_viewer_syntax([fname_mt0, fname_mt1, file_out + ext_out])
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -72,10 +72,6 @@ def main(args=None):
     nii_mtr.save(fname_mtr)
     # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 fname_mtr', verbose)
 
-    # Generate output files
-    sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join('.', fname_mtr), '.')
-
     sct.display_viewer_syntax([fname_mt0, fname_mt1, fname_mtr])
 
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -56,7 +56,7 @@ def main(args=None):
 
     fname_mt0 = arguments['-mt0']
     fname_mt1 = arguments['-mt1']
-    fname_mtr = arguments['-omtr']
+    fname_mtr = arguments['-o']
     param.file_out, file_out = os.path.split(fname_mtr)[1], os.path.split(fname_mtr)[1]
     remove_temp_files = int(arguments['-r'])
     verbose = int(arguments.get('-v'))
@@ -155,7 +155,7 @@ def get_parser():
                       mandatory=False,
                       example=['0', '1', '2'],
                       default_value='1')
-    parser.add_option(name="-omtr",
+    parser.add_option(name="-o",
                       type_value="str",
                       description="Creates output file with the specified path.",
                       mandatory=False,

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -111,10 +111,6 @@ def main(args=None):
         sct.printv('\nRemove temporary files...')
         sct.rmtree(path_tmp)
 
-    # if output file location changed, notify user to move to file location
-    if os.path.split(fname_mtr)[0] != curdir:
-        sct.printv("\n\033[1;31mNotice: \033[0;0mOutput file location has changed. Before issuing the command to view the results, type:")
-        sct.printv("\033[0;32mcd " + os.path.split(fname_mtr)[0])
     sct.display_viewer_syntax([fname_mt0, fname_mt1, file_out])
 
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -160,7 +160,7 @@ def get_parser():
                       description="Creates output file with the specified path.",
                       mandatory=False,
                       example='My_File_Folder/My_New_File',
-                      default_value=os.path.join(os.getcwd(),param.file_out))
+                      default_value=os.path.join(os.getcwd(),'mtr'))
 
     return parser
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -75,8 +75,17 @@ def main(args=None):
     convert(fname_mt0, os.path.join(path_tmp, "mt0.nii"), dtype=np.float32)
     convert(fname_mt1, os.path.join(path_tmp, "mt1.nii"), dtype=np.float32)
 
+    curdir = os.getcwd()
+    sct.printv(curdir)
+    #if changing output file name or location, create folder with mt0 and mt1 files at precised location
+    if os.path.split(fname_mtr)[0] != curdir:
+        import shutil
+        startdir = os.getcwd()
+        os.chdir(os.path.split(fname_mtr)[0])
+        shutil.copy(os.path.join(startdir,fname_mt0),os.path.join(os.path.split(fname_mtr)[0]))
+        shutil.copy(os.path.join(startdir, fname_mt1), os.path.join(os.path.split(fname_mtr)[0]))
+
     # go to tmp folder
-    curdir = os.path.split(fname_mtr)[0]
     os.chdir(path_tmp)
 
     # compute MTR
@@ -92,7 +101,7 @@ def main(args=None):
     # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 file_out.nii', verbose)
 
     # come back
-    os.chdir(curdir)
+    os.chdir(os.path.split(fname_mtr)[0])
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
@@ -103,6 +112,10 @@ def main(args=None):
         sct.printv('\nRemove temporary files...')
         sct.rmtree(path_tmp)
 
+    #if output file location changed, notify user to move to file location
+    if os.path.split(fname_mtr)[0] != curdir:
+        sct.printv("\n\033[1;31mNotice: \033[0;0mOutput file location has changed. Before issuing the command to view the results, type:")
+        sct.printv("\033[0;32mcd " + os.path.split(fname_mtr)[0])
     sct.display_viewer_syntax([fname_mt0, fname_mt1, file_out])
 
 
@@ -145,10 +158,10 @@ def get_parser():
                       default_value='1')
     parser.add_option(name="-omtr",
                       type_value="str",
-                      description="Output file mtr. Default is mtr.nii.gz",
+                      description="Creates output file with the specified path.",
                       mandatory=False,
-                      example='My_File_Folder/My_File',
-                      default_value=os.path.join(os.getcwd(),'mtr'))
+                      example='My_File_Folder/My_New_File',
+                      default_value=os.path.join(os.getcwd(),param.file_out))
 
     return parser
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -153,7 +153,7 @@ def get_parser():
                       default_value='1')
     parser.add_option(name="-o",
                       type_value="str",
-                      description="Creates output file with the specified path. Add extension '.nii.gz' to output file name.",
+                      description="Creates output file with the specified path. Add extension to output file name.",
                       mandatory=False,
                       example='Users/john/data/My_New_File.nii.gz',
                       default_value=os.path.join(os.getcwd(),'mtr.nii.gz'))

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -75,9 +75,8 @@ def main(args=None):
     convert(fname_mt0, os.path.join(path_tmp, "mt0.nii"), dtype=np.float32)
     convert(fname_mt1, os.path.join(path_tmp, "mt1.nii"), dtype=np.float32)
 
+    # if changing output file name or location, create folder with mt0 and mt1 files at precised location
     curdir = os.getcwd()
-    sct.printv(curdir)
-    #if changing output file name or location, create folder with mt0 and mt1 files at precised location
     if os.path.split(fname_mtr)[0] != curdir:
         import shutil
         startdir = os.getcwd()
@@ -112,7 +111,7 @@ def main(args=None):
         sct.printv('\nRemove temporary files...')
         sct.rmtree(path_tmp)
 
-    #if output file location changed, notify user to move to file location
+    # if output file location changed, notify user to move to file location
     if os.path.split(fname_mtr)[0] != curdir:
         sct.printv("\n\033[1;31mNotice: \033[0;0mOutput file location has changed. Before issuing the command to view the results, type:")
         sct.printv("\033[0;32mcd " + os.path.split(fname_mtr)[0])

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -72,19 +72,14 @@ def main(args=None):
     nii_mtr.save(fname_mtr)
     # sct.run(fsloutput+'fslmaths -dt double mt0.nii -sub mt1.nii -mul 100 -div mt0.nii -thr 0 -uthr 100 fname_mtr', verbose)
 
-    # if changing output file name or location, create folder with mt0.nii.gz and mt1.nii.gz files at precised location
-    if os.path.dirname(fname_mtr) != '.':
-        sct.copy(os.path.join('.', fname_mt0), os.path.dirname(fname_mtr))
-        sct.copy(os.path.join('.', fname_mt1), os.path.dirname(fname_mtr))
-
     # go to output file directory
     os.chdir(os.path.dirname(fname_mtr))
 
     # Generate output files
     sct.printv('\nGenerate output files...', verbose)
-    sct.generate_output_file(os.path.join('.', os.path.basename(fname_mtr)), '.')
+    sct.generate_output_file(os.path.join('.', fname_mtr), '.')
 
-    sct.display_viewer_syntax([fname_mt0, fname_mt1, os.path.basename(fname_mtr)])
+    sct.display_viewer_syntax([fname_mt0, fname_mt1, fname_mtr])
 
 
 # ==========================================================================================


### PR DESCRIPTION
At the moment, the script [sct_compute_mtr.py](https://github.com/neuropoly/spinalcordtoolbox/blob/53b81c4b73fa65ad55ac391649ecb44744c077ad/scripts/sct_compute_mtr.py) does not have a flag to change the output filename or its location ([it would default to mtr.nii.gz in the active directory](https://github.com/neuropoly/spinalcordtoolbox/blob/53b81c4b73fa65ad55ac391649ecb44744c077ad/scripts/sct_compute_mtr.py#L85)).

This PR makes it possible to change the output file name and/or location with the flag `-o`. Fixes #2178 

To do so, the user simply needs to follow the following format when adding the `-o` flag to the rest of the [sct_compute_mtr](https://sourceforge.net/p/spinalcordtoolbox/wiki/sct_compute_mtr/) command:
`-o /path_Leading_To_Output_File/output_File`

Example use with output file name changed to "custom_name" but location (default) unchanged:
```
sct_compute_mtr -mt0 mt0.nii.gz -mt1 mt1.nii.gz -r 0 -v 0 -o /Users/heyan_admin/sct_course-london19/single_subject/data/mt/custom_name
```
Example use with output file location changed to the user's "Desktop"  folder but name ("mtr") unchanged: 

```
sct_compute_mtr -mt0 mt0.nii.gz -mt1 mt1.nii.gz -r 1 -v 0 -o /Users/heyan_admin/Desktop/mtr
```
Example use with output file location changed to the user's "Downloads" folder and name changed to "testing":
````
sct_compute_mtr -mt0 mt0.nii.gz -mt1 mt1.nii.gz -r 0 -v 2 -o /Users/heyan_admin/Downloads/testing