### PR TITLE
Fixed wrong scaling factor for output XY size

### DIFF
--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -266,8 +266,8 @@ class SpinalCordStraightener(object):
                 nx, ny, nz, nt, px, py, pz, pt = image_centerline_pad.dim
                 start_point_coord_native = image_centerline_pad.transfo_phys2pix([[0, 0, start_point]])[0]
                 end_point_coord_native = image_centerline_pad.transfo_phys2pix([[0, 0, end_point]])[0]
-                straight_size_x = int(0.5 * self.xy_size / px)
-                straight_size_y = int(0.5 * self.xy_size / py)
+                straight_size_x = int(self.xy_size / px)
+                straight_size_y = int(self.xy_size / py)
                 warp_space_x = [int(np.round(nx / 2)) - straight_size_x, int(np.round(nx / 2)) + straight_size_x]
                 warp_space_y = [int(np.round(ny / 2)) - straight_size_y, int(np.round(ny / 2)) + straight_size_y]
                 if warp_space_x[0] < 0:
@@ -299,8 +299,8 @@ class SpinalCordStraightener(object):
             start_point_coord = image_centerline_pad.transfo_phys2pix([[0, 0, start_point]])[0]
             end_point_coord = image_centerline_pad.transfo_phys2pix([[0, 0, end_point]])[0]
 
-            straight_size_x = int(0.5 * self.xy_size / px)
-            straight_size_y = int(0.5 * self.xy_size / py)
+            straight_size_x = int(self.xy_size / px)
+            straight_size_y = int(self.xy_size / py)
             warp_space_x = [int(np.round(nx / 2)) - straight_size_x, int(np.round(nx / 2)) + straight_size_x]
             warp_space_y = [int(np.round(ny / 2)) - straight_size_y, int(np.round(ny / 2)) + straight_size_y]
 


### PR DESCRIPTION
This PR fixes a regression bug likely introduced in https://github.com/neuropoly/spinalcordtoolbox/pull/2257. This bug yields a 2x smaller XY FOV in the straight space, reducing the performance of `sct_label_vertebrae` function.

Fixes #2265 