### PR TITLE
Changed source of nipy installation to fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ xlwt
 tqdm
 transforms3d
 urllib3[secure]
-nipy # need to install at the end otherwise won't install
+git+https://github.com/jcohenadad/nipy.git#egg=nipy # need to install at the end otherwise won't install

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -68,6 +68,7 @@ def resolve_module(framework_name):
         'mkl-service': (None, False),
         'pytest-cov': ('pytest_cov', False),
         'urllib3[secure]': ('urllib3', False),
+        'git+https://github.com/jcohenadad/nipy.git': ('nipy', False),
     }
 
     try:


### PR DESCRIPTION
In this PR, we are changing the source to the fork jcohenadad/nipy from nipy/nipy due to the new deprecation. (overcomes #2267)

We do this in order to keep an old version of nipy that still has the factorial function that is used in many of the scripts. 
 
At the moment, the PR is not working. Indeed, after using the function install_sct and verifying installation, we obtain the following log:
 Validate installation...
SCT info:
- version: git-HMY/2267-nipy-fork-79629ea34a2d61e335e8bf6dfedd87037bd909a7
- path: /Users/heyan_admin/2267/sct
OS: osx (Darwin-16.7.0-x86_64-i386-64bit)
CPU cores: Available: 4, Used by SCT: 4
RAM: Primary memory available: 12.00 gigabytes
Check Python executable.............................[OK]
  Using bundled python 3.7.3 (default, Mar 27 2019, 16:54:48) 
[Clang 4.0.1 (tags/RELEASE_401/final)] at /Users/heyan_admin/2267/sct/python/bin/python
Check if data are installed.........................[OK]
Check if numpy is installed.........................[OK] (1.16.3)
Check if cryptography is installed..................[OK] (2.6.1)
Check if dipy is installed..........................[OK] (0.16.0)
Check if futures is installed.......................[OK]
Check if h5py is installed..........................[OK] (2.9.0)
Check if Keras is installed.........................[OK] (2.2.4)
Check if matplotlib is installed....................[OK] (3.1.0)
Check if nibabel is installed.......................[OK] (2.4.0)
Check if pandas is installed........................[OK] (0.24.2)
Check if psutil is installed........................[OK] (5.6.2)
Check if pyqt5 is installed.........................[OK]
Check if raven is installed.........................[OK]
Check if requests is installed......................[OK] (2.21.0)
Check if scipy is installed.........................[OK] (1.3.0)
Check if scikit-image is installed..................[OK] (0.15.0)
Check if scikit-learn is installed..................[OK] (0.21.1)
Check if tensorflow is installed....................[OK] (1.13.1)
Check if xlrd is installed..........................[OK] (1.2.0)
Check if xlutils is installed.......................[OK]
Check if xlwt is installed..........................[OK] (1.3.0)
Check if tqdm is installed..........................[OK] (4.32.1)
Check if transforms3d is installed..................[OK] (0.3.1)
Check if urllib3[secure] is installed...............[OK] (1.24.1)
Check if git+https://github.com/jcohenadad/nipy.git is installed[FAIL]
Check if spinalcordtoolbox is installed.............[OK]
Check ANTs compatibility with OS ...................[OK]
Check PropSeg compatibility with OS ................[OK]
Check if figure can be opened.......................[OK]

Installation validation Failed!
Please copy the historic of this Terminal (starting with the command install_sct) and paste it in the SCT Help forum (create a new discussion):
http://forum.spinalcordmri.org/c/sct

Installation failed

The full log can be found in the pdf below:
[Issue 2267: installation log.pdf](https://github.com/neuropoly/spinalcordtoolbox/files/3208647/Issue.2267.installation.log.pdf)
