### PR TITLE
Fixed Keras/Tensorflow compatibility with CentOS 7 by downgrading to Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
     ls -lA bin  # Make sure all binaries and aliases are there
     sct_download_data -d sct_testing_data  # for tests
     source python/etc/profile.d/conda.sh  # to be able to call conda
-    conda activate py36  # reactivate conda for the pip install below
+    conda activate venv_sct  # reactivate conda for the pip install below
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ before_script:
     echo $PATH  # Make sure PATH includes sct/bin folder
     ls -lA bin  # Make sure all binaries and aliases are there
     sct_download_data -d sct_testing_data  # for tests
-    source python/bin/activate  # reactivate conda for the pip install below
+    source python/etc/profile.d/conda.sh  # to be able to call conda
+    conda activate py36  # reactivate conda for the pip install below
 
 script:
   - |

--- a/install_sct
+++ b/install_sct
@@ -437,11 +437,11 @@ echo -e Conda installation successful
 fi
 
 # create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-yes | python/bin/conda create -n py36 python=3.6
+yes | python/bin/conda create -n venv_sct python=3.6
 
 # activate miniconda
 source python/etc/profile.d/conda.sh
-conda activate py36
+conda activate venv_sct
 
 #  conda install --yes anaconda-client
 #  conda config --add channels conda-forge
@@ -467,7 +467,7 @@ fi
 ## Create launchers for Python scripts
 echo -e "\nCreating launchers for Python scripts..."
 mkdir -p ${SCT_DIR}/bin
-for file in ${SCT_DIR}/python/envs/py36/bin/*sct*; do
+for file in ${SCT_DIR}/python/envs/venv_sct/bin/*sct*; do
   cp "$file" "${SCT_DIR}/bin/"
   res=$?
   if [[ $res != 0 ]]; then

--- a/install_sct
+++ b/install_sct
@@ -417,6 +417,7 @@ unset PYTHONPATH
 export PYTHONNOUSERSITE=1
 
 if [ ${NO_CONDA_INSTALL} ]; then
+# TODO: remove this case
   echo "python/ will not be (re)-install"
   # activate miniconda
   cmd=". ${SCT_DIR}/${PYTHON_DIR}/bin/activate ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
@@ -446,11 +447,15 @@ else
     echo -e Conda installation successful
   fi
 
-  # activate miniconda
-  cmd=". ${SCT_DIR}/${PYTHON_DIR}/bin/activate ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
+  # create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
+  yes | python/bin/conda create -n py36 python=3.6
 
-  conda install --yes anaconda-client
-  conda config --add channels conda-forge
+  # activate miniconda
+  source python/etc/profile.d/conda.sh
+  conda activate py36
+
+#  conda install --yes anaconda-client
+#  conda config --add channels conda-forge
 
   # Install Python dependencies
   echo -e "\nInstalling Python dependencies..."
@@ -475,7 +480,7 @@ fi
 ## Create launchers for Python scripts
 echo -e "\nCreating launchers for Python scripts..."
 mkdir -p ${SCT_DIR}/bin
-for file in ${SCT_DIR}/python/bin/*sct*; do
+for file in ${SCT_DIR}/python/envs/py36/bin/*sct*; do
   cp "$file" "${SCT_DIR}/bin/"
   res=$?
   if [[ $res != 0 ]]; then

--- a/install_sct
+++ b/install_sct
@@ -151,10 +151,9 @@ download ()
 # Usage of this script
 usage()
 {
-  echo -e "\nUsage: $0 [-d] [-m] [-b] [-k] [-v] [--mpi]" 1>&2;
+  echo -e "\nUsage: $0 [-d] [-b] [-k] [-v] [--mpi]" 1>&2;
   echo -e "\nOPTION"
   echo -e "\t-d \v Prevent the (re)-installation of the \"data/\" directory "
-  echo -e "\n\t-m \v Prevent the (re)-installation of the \"python/\" directory "
   echo -e "\n\t-b \v Prevent the (re)-installation of the SCT binaries files "
   echo -e "\n\t-k \v Install SCT with Python 2.7 (Default is Python 3.x)"
   echo -e "\n\t-v \v Full verbose"
@@ -175,15 +174,11 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":dmhbpv" opt; do
+while getopts ":dhbpv" opt; do
   case $opt in
     d)
       echo " data directory will not be (re)-installed"
       NO_DATA_INSTALL=yes
-      ;;
-    m)
-      echo " miniconda python will not be (re)-installed "
-      NO_CONDA_INSTALL=yes
       ;;
     b)
       echo " SCT binaries will not be (re)-installed "
@@ -416,57 +411,49 @@ fi
 unset PYTHONPATH
 export PYTHONNOUSERSITE=1
 
-if [ ${NO_CONDA_INSTALL} ]; then
-# TODO: remove this case
-  echo "python/ will not be (re)-install"
-  # activate miniconda
-  cmd=". ${SCT_DIR}/${PYTHON_DIR}/bin/activate ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
+# Install Python conda
+echo -e "\nInstalling conda..."
+cmd="rm -rf ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
+cmd="mkdir -p ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
+# downloading
+
+case $OS in
+linux*)
+download ${TMP_DIR}/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+;;
+osx)
+download ${TMP_DIR}/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+;;
+esac
+
+# run conda installer
+cmd="bash ${TMP_DIR}/miniconda.sh -p ${SCT_DIR}/${PYTHON_DIR} -b -f"; echo ">> "$cmd; $cmd
+ret_code_conda=$?
+if [[ $ret_code_conda != 0 ]]; then
+echo -e Conda did not installed properly with return code $ret_code_conda
+exit $ret_code_conda
 else
-  # Install Python conda
-  echo -e "\nInstalling conda..."
-  cmd="rm -rf ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
-  cmd="mkdir -p ${SCT_DIR}/${PYTHON_DIR}"; echo ">> "$cmd; $cmd
-  # downloading
+echo -e Conda installation successful
+fi
 
-  case $OS in
-    linux*)
-    download ${TMP_DIR}/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    ;;
-    osx)
-    download ${TMP_DIR}/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-    ;;
-  esac
+# create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
+yes | python/bin/conda create -n py36 python=3.6
 
-  # run conda installer
-  cmd="bash ${TMP_DIR}/miniconda.sh -p ${SCT_DIR}/${PYTHON_DIR} -b -f"; echo ">> "$cmd; $cmd
-  ret_code_conda=$?
-  if [[ $ret_code_conda != 0 ]]; then
-    echo -e Conda did not installed properly with return code $ret_code_conda
-    exit $ret_code_conda
-  else
-    echo -e Conda installation successful
-  fi
-
-  # create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-  yes | python/bin/conda create -n py36 python=3.6
-
-  # activate miniconda
-  source python/etc/profile.d/conda.sh
-  conda activate py36
+# activate miniconda
+source python/etc/profile.d/conda.sh
+conda activate py36
 
 #  conda install --yes anaconda-client
 #  conda config --add channels conda-forge
 
-  # Install Python dependencies
-  echo -e "\nInstalling Python dependencies..."
-  pip install numpy  # need to install numpy first, otherwise nipy install within requirements.txt fails
-  pip install -r requirements.txt  # we do not include the requirements inside the setup.py because it is much faster to install all dependencies first (uses pre-compiled wheels)
+# Install Python dependencies
+echo -e "\nInstalling Python dependencies..."
+pip install numpy  # need to install numpy first, otherwise nipy install within requirements.txt fails
+pip install -r requirements.txt  # we do not include the requirements inside the setup.py because it is much faster to install all dependencies first (uses pre-compiled wheels)
 
-  if [[ ${SCT_MPI_MODE} ]] ; then
-    echo "Installing MPI libraries for HPC installation"
-      conda install -c conda-forge --yes --file ${SCT_SOURCE}/install/requirements/requirementsMPI.txt
-  fi
-
+if [[ ${SCT_MPI_MODE} ]] ; then
+echo "Installing MPI libraries for HPC installation"
+  conda install -c conda-forge --yes --file ${SCT_SOURCE}/install/requirements/requirementsMPI.txt
 fi
 
 ## Install the spinalcordtoolbox into the Conda venv

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -175,11 +175,10 @@ def main():
 
     # check if data folder is empty
     print_line('Check if data are installed')
-    if os.listdir(sct.__data_dir__):
+    if os.path.isdir(sct.__data_dir__):
         print_ok()
     else:
         print_fail()
-
 
     for dep_pkg, dep_ver_spec in get_dependencies():
         if dep_ver_spec is None:


### PR DESCRIPTION
As of today, Tensorflow is not compatible with Python 3.7 on Centos7 (see: tensorflow/tensorflow#26826).

In this PR, we downgrade SCT's Python from 3.7 to 3.6 to ensure cross-platform compatibility. In order to do this, we modified `install_sct` as follows: after miniconda install, a virtual environment is created with py3.6, and all SCT external and internal dependencies are installed within this venv. 

This approach offers more flexibility in the future, where similar issue could happen. That way, we will have the possibility to specify a Python version for SCT.

As of now, in order to activate SCT's python, the following should be done:
```bash
source ${SCT_DIR}/python/etc/profile.d/conda.sh
conda activate venv_sct
```
