### PR TITLE
Added possibility to remove or keep labels by specifying values

### DIFF
--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -604,13 +604,9 @@ class ProcessLabels(object):
 
     def remove_or_keep_labels(self, labels, action):
         """
-        Remove or keep specific labels from a reference image by specifying their values.
-        :param labels: List of all the labels to be kept or removed
-        :type labels: list[int]
-        :param str action: Action to be performed by function, can be 'remove' or 'keep'
-        :return: image_output: Image with labels.
-        :raises ValueError: if certain elements within labels are not in reference image
-        :raises TypeError: if labels are not of type int
+        Create or remove labels from self.image_input
+        :param list(int): Labels to add or remove
+        :param str: 'remove': remove labels (i.e. set to zero), 'keep': keep labels
         """
         image_output = msct_image.zeros_like(self.image_input) if action == 'keep' else  self.image_input.copy()
         coordinates_input = self.image_input.getNonZeroCoordinates()

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -125,10 +125,8 @@ class ProcessLabels(object):
             self.output_image = self.continuous_vertebral_levels()
         if type_process == 'create-viewer':
             self.output_image = self.launch_sagittal_viewer(self.value)
-        if type_process == 'remove':
-            self.output_image = self.remove_or_keep_labels(self.value, action='remove')
-        if type_process == 'keep':
-            self.output_image = self.remove_or_keep_labels(self.value, action='keep')
+        if type_process in ['remove', 'keep']:
+            self.output_image = self.remove_or_keep_labels(self.value, action=type_process)
 
         if self.fname_output is not None:
             if change_orientation:

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -98,7 +98,7 @@ class ProcessLabels(object):
         if type_process == 'MSE':
             self.MSE()
             self.fname_output = None
-        if type_process == 'remove':
+        if type_process == 'remove-reference':
             self.output_image = self.remove_label()
         if type_process == 'remove-symm':
             self.output_image = self.remove_label(symmetry=True)
@@ -125,7 +125,7 @@ class ProcessLabels(object):
             self.output_image = self.continuous_vertebral_levels()
         if type_process == 'create-viewer':
             self.output_image = self.launch_sagittal_viewer(self.value)
-        if type_process == 'remove-reference':
+        if type_process == 'remove':
             self.output_image = self.remove_labels(self.value)
         if type_process == 'keep':
             self.output_image = self.remove_labels(self.value,isKeep = True)
@@ -685,7 +685,7 @@ def get_parser():
                       type_value='file',
                       description='Compute Mean Square Error between labels from input and reference image. Specify reference image here.',
                       mandatory=False)
-    parser.add_option(name='-remove',
+    parser.add_option(name='-remove-reference',
                       type_value='file',
                       description='Remove labels from input image (-i) that are not in reference image (specified here).',
                       mandatory=False)
@@ -693,7 +693,7 @@ def get_parser():
                       type_value='file',
                       description='Remove labels from input image (-i) and reference image (specified here) that don\'t match. You must provide two output names separated by ",".',
                       mandatory=False)
-    parser.add_option(name='-remove-reference',
+    parser.add_option(name='-remove',
                       type_value=[[','], 'int'],
                       description='Remove labels of specific value (specified here) from reference image',
                       mandatory=False)
@@ -773,18 +773,18 @@ def main(args=None):
     elif '-MSE' in arguments:
         process_type = 'MSE'
         input_fname_ref = arguments['-r']
-    elif '-remove' in arguments:
-        process_type = 'remove'
-        input_fname_ref = arguments['-remove']
+    elif '-remove-reference' in arguments:
+        process_type = 'remove-reference'
+        input_fname_ref = arguments['-remove-reference']
     elif '-remove-symm' in arguments:
         process_type = 'remove-symm'
         input_fname_ref = arguments['-r']
     elif '-create-viewer' in arguments:
         process_type = 'create-viewer'
         value = arguments['-create-viewer']
-    elif '-remove-reference' in arguments:
-        process_type = 'remove-reference'
-        value = arguments['-remove-reference']
+    elif '-remove' in arguments:
+        process_type = 'remove'
+        value = arguments['-remove']
     elif '-keep' in arguments:
         process_type = 'keep'
         value = arguments['-keep']

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -604,8 +604,13 @@ class ProcessLabels(object):
 
     def remove_or_keep_labels(self, labels, action):
         """
-        If action == 'remove', this function sets the value of specified labels to 0.0 and removes them from the reference image.
-        If action == 'keep', this function keeps the labels specified from the reference image.
+        Remove or keep specific labels from a reference image by specifying their values.
+        :param labels: List of all the labels to be kept or removed
+        :type labels: list[int]
+        :param str action: Action to be performed by function, can be 'remove' or 'keep'
+        :return: image_output: Image with labels.
+        :raises ValueError: if certain elements within labels are not in reference image
+        :raises TypeError: if labels are not of type int
         """
         image_output = msct_image.zeros_like(self.image_input) if action == 'keep' else  self.image_input.copy()
         coordinates_input = self.image_input.getNonZeroCoordinates()

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -603,8 +603,8 @@ class ProcessLabels(object):
     def remove_or_keep_labels(self, labels, action):
         """
         Create or remove labels from self.image_input
-        :param list(int): Labels to add or remove
-        :param str: 'remove': remove labels (i.e. set to zero), 'keep': keep labels
+        :param list(int): Labels to keep or remove
+        :param str: 'remove': remove specified labels (i.e. set to zero), 'keep': keep specified labels and remove the others
         """
         image_output = msct_image.zeros_like(self.image_input) if action == 'keep' else  self.image_input.copy()
         coordinates_input = self.image_input.getNonZeroCoordinates()

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -126,9 +126,9 @@ class ProcessLabels(object):
         if type_process == 'create-viewer':
             self.output_image = self.launch_sagittal_viewer(self.value)
         if type_process == 'remove':
-            self.output_image = self.remove_labels(self.value)
+            self.output_image = self.remove_or_keep_labels(self.value, action='remove')
         if type_process == 'keep':
-            self.output_image = self.remove_labels(self.value,isKeep = True)
+            self.output_image = self.remove_or_keep_labels(self.value, action='keep')
 
         if self.fname_output is not None:
             if change_orientation:
@@ -602,12 +602,12 @@ class ProcessLabels(object):
 
         return output
 
-    def remove_labels(self, labels, isKeep = False):
+    def remove_or_keep_labels(self, labels, action={'remove','keep'}):
         """
-        This function sets the value of specified labels to 0.0 and removes them from the reference image.
-        The isKeep option keeps the labels specified from the reference image.
+        If action == 'remove', this function sets the value of specified labels to 0.0 and removes them from the reference image.
+        If action == 'keep', this function keeps the labels specified from the reference image.
         """
-        image_output = msct_image.zeros_like(self.image_input) if isKeep else  self.image_input.copy()
+        image_output = msct_image.zeros_like(self.image_input) if action == 'keep' else  self.image_input.copy()
         coordinates_input = self.image_input.getNonZeroCoordinates()
 
         for labelNumber in labels:
@@ -617,7 +617,7 @@ class ProcessLabels(object):
                     new_coord = coord
                     isInLabels = True
             if isInLabels:
-                if isKeep:
+                if action == 'keep':
                     image_output.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = new_coord.value
                 else:
                     image_output.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = 0.0

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -125,9 +125,9 @@ class ProcessLabels(object):
             self.output_image = self.continuous_vertebral_levels()
         if type_process == 'create-viewer':
             self.output_image = self.launch_sagittal_viewer(self.value)
-        if type_process == 'remove-specific':
+        if type_process == 'remove-reference':
             self.output_image = self.remove_labels(self.value)
-        if type_process == 'keep-specific':
+        if type_process == 'keep':
             self.output_image = self.remove_labels(self.value,isKeep = True)
 
         if self.fname_output is not None:
@@ -693,11 +693,11 @@ def get_parser():
                       type_value='file',
                       description='Remove labels from input image (-i) and reference image (specified here) that don\'t match. You must provide two output names separated by ",".',
                       mandatory=False)
-    parser.add_option(name='-remove-specific',
+    parser.add_option(name='-remove-reference',
                       type_value=[[','], 'int'],
                       description='Remove labels of specific value (specified here) from reference image',
                       mandatory=False)
-    parser.add_option(name='-keep-specific',
+    parser.add_option(name='-keep',
                       type_value=[[','], 'int'],
                       description='Keep labels of specific value (specified here) from reference image',
                       mandatory=False)
@@ -782,12 +782,12 @@ def main(args=None):
     elif '-create-viewer' in arguments:
         process_type = 'create-viewer'
         value = arguments['-create-viewer']
-    elif '-remove-specific' in arguments:
-        process_type = 'remove-specific'
-        value = arguments['-remove-specific']
-    elif '-keep-specific' in arguments:
-        process_type = 'keep-specific'
-        value = arguments['-keep-specific']
+    elif '-remove-reference' in arguments:
+        process_type = 'remove-reference'
+        value = arguments['-remove-reference']
+    elif '-keep' in arguments:
+        process_type = 'keep'
+        value = arguments['-keep']
     else:
         # no process chosen
         sct.printv('ERROR: No process was chosen.', 1, 'error')

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -606,7 +606,10 @@ class ProcessLabels(object):
         :param list(int): Labels to keep or remove
         :param str: 'remove': remove specified labels (i.e. set to zero), 'keep': keep specified labels and remove the others
         """
-        image_output = msct_image.zeros_like(self.image_input) if action == 'keep' else  self.image_input.copy()
+        if action == 'keep':
+            image_output = msct_image.zeros_like(self.image_input)
+        elif action == 'remove':
+            image_output = self.image_input.copy()
         coordinates_input = self.image_input.getNonZeroCoordinates()
 
         for labelNumber in labels:

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -621,7 +621,7 @@ class ProcessLabels(object):
                 else:
                     image_output.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = 0.0
             else:
-                sct.printv("ERROR: Label " + str(float(labelNumber)) + " not found in input image.", type='error')
+                sct.printv("WARNING: Label " + str(float(labelNumber)) + " not found in input image.", type='warning')
 
         return image_output
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -126,9 +126,9 @@ class ProcessLabels(object):
         if type_process == 'create-viewer':
             self.output_image = self.launch_sagittal_viewer(self.value)
         if type_process == 'remove-specific':
-            self.output_image = self.remove_specific_labels(self.value)
+            self.output_image = self.remove_labels(self.value)
         if type_process == 'keep-specific':
-            self.output_image = self.remove_specific_labels(self.value,isKeep = True)
+            self.output_image = self.remove_labels(self.value,isKeep = True)
 
         if self.fname_output is not None:
             if change_orientation:
@@ -602,7 +602,7 @@ class ProcessLabels(object):
 
         return output
 
-    def remove_specific_labels(self, labels, isKeep = False):
+    def remove_labels(self, labels, isKeep = False):
         """
         This function sets the value of specified labels to 0.0 and removes them from the reference image.
         The isKeep option keeps the labels specified from the reference image.

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -618,7 +618,7 @@ class ProcessLabels(object):
             if isInLabels:
                 if action == 'keep':
                     image_output.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = new_coord.value
-                else:
+                elif action == 'remove':
                     image_output.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = 0.0
             else:
                 sct.printv("WARNING: Label " + str(float(labelNumber)) + " not found in input image.", type='warning')

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -602,7 +602,7 @@ class ProcessLabels(object):
 
         return output
 
-    def remove_or_keep_labels(self, labels, action={'remove','keep'}):
+    def remove_or_keep_labels(self, labels, action):
         """
         If action == 'remove', this function sets the value of specified labels to 0.0 and removes them from the reference image.
         If action == 'keep', this function keeps the labels specified from the reference image.

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -442,7 +442,7 @@ def main(args=None):
             # --------------------------------------------------------------------------------
             # Remove unused label on template. Keep only label present in the input label image
             sct.printv('\nRemove unused label on template. Keep only label present in the input label image...', verbose)
-            sct.run(['sct_label_utils', '-i', ftmp_template_label, '-o', ftmp_template_label, '-remove', ftmp_label])
+            sct.run(['sct_label_utils', '-i', ftmp_template_label, '-o', ftmp_template_label, '-remove-reference', ftmp_label])
 
             # Dilating the input label so they can be straighten without losing them
             sct.printv('\nDilating input labels using 3vox ball radius')
@@ -586,7 +586,7 @@ def main(args=None):
 
         # Remove unused label on template. Keep only label present in the input label image
         sct.printv('\nRemove unused label on template. Keep only label present in the input label image...', verbose)
-        sct.run(['sct_label_utils', '-i', ftmp_template_label, '-o', ftmp_template_label, '-remove', ftmp_label])
+        sct.run(['sct_label_utils', '-i', ftmp_template_label, '-o', ftmp_template_label, '-remove-reference', ftmp_label])
 
         # Add one label because at least 3 orthogonal labels are required to estimate an affine transformation. This
         # new label is added at the level of the upper most label (lowest value), at 1cm to the right.


### PR DESCRIPTION
At the moment, the function `sct_label_utils` did not have a way to remove or keep specific labels based on their values. 

This PR introduces a feature that allows one to remove one or many specific labels with the `-remove-specific` flag and to keep labels from a reference image with the `-keep-specific` flag when using the sct_label_utils command. (fixes #2247)

Example use of removing labels of value 1,2,3 from file `t2_label.nii.gz`:
```
sct_label_utils -i t2_label.nii.gz -remove-specific 1,2,3
```
Example use of keeping labels of value 7,11 from file `labeled_disc.nii`:
```
sct_label_utils -i labeled_disc.nii -keep-specific 7,11 
```

