### PR TITLE
Fixed resampling method with reference image and improved speed for generating QC report

### DIFF
--- a/scripts/sct_resample.py
+++ b/scripts/sct_resample.py
@@ -129,9 +129,8 @@ def run_main():
     param.verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
-    spinalcordtoolbox.resampling.resample_file(param.fname_data,
-                                               param.fname_out, param.new_size, param.new_size_type, param.ref,
-                                               param.interpolation, param.verbose)
+    spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
+                                               param.interpolation, param.verbose, fname_ref=param.ref)
 
 
 if __name__ == "__main__":

--- a/scripts/sct_resample.py
+++ b/scripts/sct_resample.py
@@ -31,6 +31,7 @@ class Param:
         self.new_size = ''
         self.new_size_type = ''
         self.interpolation = 'linear'
+        self.ref = None
         self.x_to_order = {'nn': 0, 'linear': 1, 'spline': 2}
         self.mode = 'reflect'  # How to fill the points outside the boundaries of the input, possible options: constant, nearest, reflect or wrap
         # constant put the superior edges to 0, wrap does something weird with the superior edges, nearest and reflect are fine
@@ -66,7 +67,10 @@ def get_parser():
                       type_value="str",
                       description="Resampling size in number of voxels in each dimensions (x,y,z). Separate with \"x\"",
                       mandatory=False)
-                      # example='50x50x20')
+    parser.add_option(name="-ref",
+                      type_value="str",
+                      description="Reference image to resample input image to. Uses world coordinates.",
+                      mandatory=False)
     parser.usage.addSection('MISC')
     parser.add_option(name="-x",
                       type_value='multiple_choice',
@@ -106,6 +110,9 @@ def run_main():
         param.new_size = arguments["-vox"]
         param.new_size_type = 'vox'
         arg += 1
+    elif "-ref" in arguments:
+        param.ref = arguments["-ref"]
+        arg += 1
     else:
         sct.printv(parser.usage.generate(error='ERROR: you need to specify one of those three arguments : -f, -mm or -vox'))
 
@@ -123,7 +130,7 @@ def run_main():
     sct.init_sct(log_level=param.verbose, update=True)  # Update log level
 
     spinalcordtoolbox.resampling.resample_file(param.fname_data,
-                                               param.fname_out, param.new_size, param.new_size_type,
+                                               param.fname_out, param.new_size, param.new_size_type, param.ref,
                                                param.interpolation, param.verbose)
 
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -213,7 +213,7 @@ class QcImage(object):
             aspect_img, self.aspect_mask = sct_slice.aspect()[:2]
 
             self.qc_report.make_content_path()
-            logger.info('QC: %s with %s slice', func.__name__, sct_slice.get_name())
+            logger.info('QcImage: %s with %s slice', func.__name__, sct_slice.get_name())
 
             img, mask = func(sct_slice, *args)
 
@@ -463,7 +463,7 @@ def add_entry(src, process, args, path_qc, plane, background=None, foreground=No
               dataset=None,
               subject=None):
     """
-    Starting point to QC report creation.
+    Create QC report.
 
     :param src: Path to input file (only used to populate report metadata)
     :param process:
@@ -523,7 +523,8 @@ def add_entry(src, process, args, path_qc, plane, background=None, foreground=No
 def generate_qc(fname_in1, fname_in2=None, fname_seg=None, args=None, path_qc=None, dataset=None, subject=None,
                 process=None):
     """
-    Generate a QC entry allowing to quickly review results. This function is called by SCT scripts (e.g. sct_propseg).
+    Generate a QC entry allowing to quickly review results. This function is the entry point and is called by SCT
+    scripts (e.g. sct_propseg).
 
     :param fname_in1: str: File name of input image #1 (mandatory)
     :param fname_in2: str: File name of input image #2
@@ -535,6 +536,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, args=None, path_qc=No
     :param process: str: Name of SCT function. e.g., sct_propseg
     :return: None
     """
+    logger.info('\n*** Generate Quality Control (QC) html report ***')
     dpi = 300
     # Get QC specifics based on SCT process
     # Axial orientation, switch between two input images

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -211,12 +211,13 @@ class Slice(object):
         :returns: centers of mass in the x and y axis (tuple of numpy.ndarray of int)
             .
         """
-        axial_dim = self.axial_dim(image)
-        centers_x = np.zeros(axial_dim)
-        centers_y = np.zeros(axial_dim)
-        for i in range(axial_dim):
-            aslice = self.axial_slice(np.array(image.data), i)  # we cast np.array to overcome
-            centers_x[i], centers_y[i] = ndimage.measurements.center_of_mass(aslice)
+        logger.info('Compute center of at each slice.')
+        data = np.array(image.data)  # we cast np.array to overcome problem if inputing nii format
+        nz = image.dim[2]
+        centers_x = np.zeros(nz)
+        centers_y = np.zeros(nz)
+        for i in range(nz):
+            centers_x[i], centers_y[i] = ndimage.measurements.center_of_mass(data[:, :, i])
         try:
             Slice.nan_fill(centers_x)
             Slice.nan_fill(centers_y)

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -258,6 +258,7 @@ class Slice(object):
                 x = int(centers_x[i])
                 y = int(centers_y[i])
                 # crop slice around center of mass and add slice to the matrix layout
+                # TODO: resample there after cropping based on physical dimensions
                 self.add_slice(matrix, i, nb_column, size, self.crop(self.get_slice(image.data, i), x, y, size, size))
 
             matrices.append(matrix)

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -210,15 +210,14 @@ class Slice(object):
 
         :param image : input Image
         :returns: centers of mass in the x and y axis (tuple of numpy.ndarray of int)
-            .
         """
         logger.info('Compute center of mass at each slice')
         data = np.array(image.data)  # we cast np.array to overcome problem if inputing nii format
-        nz = image.dim[2]
+        nz = image.dim[0]  # SAL orientation
         centers_x = np.zeros(nz)
         centers_y = np.zeros(nz)
         for i in range(nz):
-            centers_x[i], centers_y[i] = ndimage.measurements.center_of_mass(data[:, :, i])
+            centers_x[i], centers_y[i] = ndimage.measurements.center_of_mass(data[i, :, :])
         try:
             Slice.nan_fill(centers_x)
             Slice.nan_fill(centers_y)

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -43,6 +43,7 @@ class Slice(object):
         """
         :param images: list of 3D volumes to be separated into slices.
         """
+        logger.info('Resample images to {}x{} mm'.format(p_resample, p_resample))
         self._images = list()
         image_ref = None  # first pass: we don't have a reference image to resample to
         for i, image in enumerate(images):
@@ -211,7 +212,7 @@ class Slice(object):
         :returns: centers of mass in the x and y axis (tuple of numpy.ndarray of int)
             .
         """
-        logger.info('Compute center of at each slice.')
+        logger.info('Compute center of mass at each slice')
         data = np.array(image.data)  # we cast np.array to overcome problem if inputing nii format
         nz = image.dim[2]
         centers_x = np.zeros(nz)

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -86,15 +86,20 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
         affine_r = np.dot(affine, R)
 
         reference = (shape_r, affine_r)
+        mov_voxel_coords =True
+        ref_voxel_coords = True
 
     else:
         # If reference is provided
         reference = img_dest
         R = None
+        mov_voxel_coords = False
+        ref_voxel_coords = False
 
     if img.ndim == 3:
-        img_r = n_resample(img, transform=R, reference=reference, mov_voxel_coords=True, ref_voxel_coords=True,
-                           dtype=dtype, interp_order=dict_interp[interpolation], mode='nearest')
+        img_r = n_resample(img, transform=R, reference=reference, mov_voxel_coords=mov_voxel_coords,
+                           ref_voxel_coords=ref_voxel_coords, dtype=dtype, interp_order=dict_interp[interpolation],
+                           mode='nearest')
 
     elif img.ndim == 4:
         # TODO: Cover img_dest with 4D volumes
@@ -107,7 +112,7 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
             # Create dummy 3d nipy image
             nii_tmp = nib.nifti1.Nifti1Image(img.get_data()[..., it], affine)
             img3d_r = n_resample(nifti2nipy(nii_tmp), transform=R, reference=(shape_r[:-1], affine_r),
-                                 mov_voxel_coords=True, ref_voxel_coords=True, dtype=dtype,
+                                 mov_voxel_coords=mov_voxel_coords, ref_voxel_coords=ref_voxel_coords, dtype=dtype,
                                  interp_order=dict_interp[interpolation], mode='nearest')
             data4d[..., it] = img3d_r.get_data()
         # Create 4d nipy Image

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -121,7 +121,7 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
     return img_r
 
 
-def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation, verbose):
+def resample_file(fname_data, fname_out, new_size, new_size_type, fname_ref, interpolation, verbose):
     """This function will resample the specified input
     image file to the target size.
     Can deal with 2d, 3d or 4d image objects.
@@ -129,6 +129,7 @@ def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation,
     :param fname_out: The output image filename.
     :param new_size: The target size, i.e. 0.25x0.25
     :param new_size_type: Unit of resample (mm, vox, factor)
+    :param fname_ref: Reference image to resample input image to
     :param interpolation: The interpolation type
     :param verbose: verbosity level
     """
@@ -136,8 +137,12 @@ def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation,
     # Load data
     sct.printv('\nLoad data...', verbose)
     nii = nipy.load_image(fname_data)
+    if fname_ref is not None:
+        nii_ref = nipy.load_image(fname_ref)
+    else:
+        nii_ref = None
 
-    nii_r = resample_nipy(nii, new_size, new_size_type, img_dest=None, interpolation=interpolation, verbose=verbose)
+    nii_r = resample_nipy(nii, new_size, new_size_type, img_dest=nii_ref, interpolation=interpolation, verbose=verbose)
 
     # build output file name
     if fname_out == '':

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -126,7 +126,7 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
     return img_r
 
 
-def resample_file(fname_data, fname_out, new_size, new_size_type, fname_ref, interpolation, verbose):
+def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation, verbose, fname_ref=None):
     """This function will resample the specified input
     image file to the target size.
     Can deal with 2d, 3d or 4d image objects.
@@ -134,9 +134,9 @@ def resample_file(fname_data, fname_out, new_size, new_size_type, fname_ref, int
     :param fname_out: The output image filename.
     :param new_size: The target size, i.e. 0.25x0.25
     :param new_size_type: Unit of resample (mm, vox, factor)
-    :param fname_ref: Reference image to resample input image to
     :param interpolation: The interpolation type
     :param verbose: verbosity level
+    :param fname_ref: Reference image to resample input image to
     """
 
     # Load data


### PR DESCRIPTION
This PR brings a few improvements in the resampling routines and QC report. More specifically:

- When using `n_resample(reference=img_ref)`, the output resampled image was not what it is was expected to be. Fixes #2284
- Added new `-ref` flag for `sct_resample` CLI. Fixes #2284 
- Fixed slow generation of QC reports caused by slow resampling method. Fixes #2217 

There is still some improvements to be done, which will be done in a subsequent PR. See: https://github.com/neuropoly/spinalcordtoolbox/issues/2286