### PR TITLE
Fixed misplaced label in non-RPI data for initializing vertebral labeling

### DIFF
--- a/scripts/msct_types.py
+++ b/scripts/msct_types.py
@@ -43,6 +43,11 @@ class Point(object):
 
 
 class Coordinate(Point):
+    """
+    Class to represent 3D coordinates. To initialize:
+    coord = Coordinate([x, y, z])
+    coord = Coordinate([x, y, z, value])
+    """
     def __init__(self, coord=None, mode='continuous'):
         super(Coordinate, self).__init__()
         if coord is None:
@@ -50,7 +55,8 @@ class Coordinate(Point):
             return
 
         if not isinstance(coord, list) and not isinstance(coord, str):
-            raise TypeError("Coordinates parameter must be a list with coordinates [x, y, z] or [x, y, z, value] or a string with coordinates delimited by commas.")
+            raise TypeError("Coordinates parameter must be a list with coordinates [x, y, z] or [x, y, z, value] or a "
+                            "string with coordinates delimited by commas.")
 
         if isinstance(coord, str):
             # coordinate as a string. Values delimited by a comma.

--- a/scripts/msct_types.py
+++ b/scripts/msct_types.py
@@ -44,9 +44,12 @@ class Point(object):
 
 class Coordinate(Point):
     """
-    Class to represent 3D coordinates. To initialize:
-    coord = Coordinate([x, y, z])
-    coord = Coordinate([x, y, z, value])
+    Class to represent 3D coordinates.
+    :param Point: See class definition above
+    :param mode: 'index', 'continuous'  # TODO: document
+    Example:
+      coord = Coordinate([x, y, z])
+      coord = Coordinate([x, y, z, value])
     """
     def __init__(self, coord=None, mode='continuous'):
         super(Coordinate, self).__init__()
@@ -98,6 +101,33 @@ class Coordinate(Point):
 
     def hasEqualValue(self, other):
         return self.value == other.value
+
+    def permute(self, img, orient_dest, orient_src=None):
+        """
+        Permute coordinate based on source and destination orientation.
+
+        :param img : spinalcordtoolbox.Image() object
+        :param orient_dest:
+        :param orient_src:
+        :return:
+
+        Example:
+          coord.permute(Image('data.nii.gz'), 'RPI')
+          coord.permute(Image('data.nii.gz'), 'RPI', orient_src='SAL')
+        """
+        # convert coordinates to array
+        coord_arr = np.array([self.x, self.y, self.z])
+        dim_arr = np.array(img.dim[0:3])
+        # permutes
+        from spinalcordtoolbox.image import _get_permutations
+        perm, inversion = _get_permutations(orient_dest, img.orientation)  # we need to invert src and dest for this to work
+        coord_permute = np.array([coord_arr[perm[0]], coord_arr[perm[1]], coord_arr[perm[2]]])
+        dim_permute = np.array([dim_arr[perm[0]], dim_arr[perm[1]], dim_arr[perm[2]]])
+        # invert indices based on maximum dimension for each axis
+        for i in range(3):
+            if inversion[i] == -1:
+                coord_permute[i] = dim_permute[i] - coord_permute[i]
+        return coord_permute
 
     def __add__(self, other):
         if other == 0:  # this check is necessary for using the function sum() of list

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -75,6 +75,7 @@ class ProcessLabels(object):
         self.verbose = verbose
         self.value = value
         self.msg = msg
+        self.output_image = None
 
     def process(self, type_process):
         # for some processes, change orientation of input image to RPI

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -49,7 +49,7 @@ class ProcessLabels(object):
         :param fname_output:
         :param fname_ref:
         :param cross_radius:
-        :param dilate:
+        :param dilate:  # TODO: remove dilate (does not seem to be used)
         :param coordinates:
         :param verbose:
         :param vertebral_levels:

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -26,8 +26,8 @@ from scipy import ndimage
 
 from msct_parser import Parser
 import spinalcordtoolbox.image as msct_image
-from spinalcordtoolbox.image import Image
-from msct_types import CoordinateValue
+from spinalcordtoolbox.image import Image, zeros_like
+from msct_types import Coordinate, CoordinateValue
 import sct_utils as sct
 
 
@@ -128,6 +128,7 @@ class ProcessLabels(object):
         if type_process in ['remove', 'keep']:
             self.output_image = self.remove_or_keep_labels(self.value, action=type_process)
 
+        # TODO: do not save here. Create another function save() for that
         if self.fname_output is not None:
             if change_orientation:
                 self.output_image.change_orientation(input_orientation)
@@ -138,6 +139,7 @@ class ProcessLabels(object):
                 self.output_image.save(dtype='minimize_int')
             else:
                 self.output_image.save()
+        return self.output_image
 
     def add(self, value):
         """
@@ -183,37 +185,41 @@ class ProcessLabels(object):
 
     def create_label_along_segmentation(self):
         """
-        Create an image with labels defined along the spinal cord segmentation (or centerline)
+        Create an image with labels defined along the spinal cord segmentation (or centerline).
+        Input image does **not** need to be RPI (re-orientation is done within this function).
         Example:
         object_define=ProcessLabels(fname_segmentation, coordinates=[coord_1, coord_2, coord_i]), where coord_i='z,value'. If z=-1, then use z=nz/2 (i.e. center of FOV in superior-inferior direction)
         Returns
-        -------
-        image_output: Image object with labels.
         """
-
-        image_output = msct_image.zeros_like(self.image_input)
-
+        # reorient input image to RPI
+        im_rpi = self.image_input.copy().change_orientation('RPI')
+        im_output_rpi = zeros_like(im_rpi)
         # loop across labels
-        for i, coord in enumerate(self.coordinates):
+        for ilabel, coord in enumerate(self.coordinates):
             # split coord string
             list_coord = coord.split(',')
             # convert to int() and assign to variable
             z, value = [int(i) for i in list_coord]
+            # update z based on native image orientation (z should represent superior-inferior axis)
+            coord = Coordinate([z, z, z])  # since we don't know which dimension corresponds to the superior-inferior
+            # axis, we put z in all dimensions (we don't care about x and y here)
+            _, _, z_rpi = coord.permute(self.image_input, 'RPI')
             # if z=-1, replace with nz/2
             if z == -1:
-                z = int(np.round(image_output.dim[2] / 2.0))
+                z_rpi = int(np.round(im_output_rpi.dim[2] / 2.0))
             # get center of mass of segmentation at given z
-            x, y = ndimage.measurements.center_of_mass(np.array(self.image_input.data[:, :, z]))
+            x, y = ndimage.measurements.center_of_mass(np.array(im_rpi.data[:, :, z_rpi]))
             # round values to make indices
             x, y = int(np.round(x)), int(np.round(y))
             # display info
-            sct.printv('Label #' + str(i) + ': ' + str(x) + ',' + str(y) + ',' + str(z) + ' --> ' + str(value), 1)
-            if len(image_output.data.shape) == 3:
-                image_output.data[x, y, z] = value
-            elif len(image_output.data.shape) == 2:
+            sct.printv('Label #' + str(ilabel) + ': ' + str(x) + ',' + str(y) + ',' + str(z_rpi) + ' --> ' + str(value), 1)
+            if len(im_output_rpi.data.shape) == 3:
+                im_output_rpi.data[x, y, z_rpi] = value
+            elif len(im_output_rpi.data.shape) == 2:
                 assert str(z) == '0', "ERROR: 2D coordinates should have a Z value of 0. Z coordinate is :" + str(z)
-                image_output.data[x, y] = value
-        return image_output
+                im_output_rpi.data[x, y] = value
+        # change orientation back to native
+        return im_output_rpi.change_orientation(self.image_input.orientation)
 
     def plan(self, width, offset=0, gap=1):
         """

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -300,7 +300,10 @@ def main(args=None):
         sct.printv('\nCreate label to identify disc...', verbose)
         fname_labelz = os.path.join(path_tmp, file_labelz)
         if initz:
-            create_label_z('segmentation.nii', initz[0], initz[1], fname_labelz=fname_labelz)  # create label located at z_center
+            from .sct_label_utils import ProcessLabels
+            im_label = ProcessLabels('segmentation.nii', coordinates=['{},{}'.format(initz[0], initz[1])])
+
+            # create_label_z('segmentation.nii', initz[0], initz[1], fname_labelz=fname_labelz)  # create label located at z_center
         elif initcenter:
             # find z centered in FOV
             nii = Image('segmentation.nii').change_orientation("RPI")

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -17,6 +17,7 @@ import sys, os
 
 import numpy as np
 import sct_maths
+from sct_label_utils import ProcessLabels
 from msct_parser import Parser
 from spinalcordtoolbox.image import Image
 import sct_utils as sct
@@ -292,24 +293,26 @@ def main(args=None):
                  verbose=verbose,
                  is_sct_binary=True,
                 )
-
         label_vert('segmentation_straight.nii', 'labeldisc_straight.nii.gz', verbose=1)
 
     else:
         # create label to identify disc
         sct.printv('\nCreate label to identify disc...', verbose)
         fname_labelz = os.path.join(path_tmp, file_labelz)
-        if initz:
-            from .sct_label_utils import ProcessLabels
-            im_label = ProcessLabels('segmentation.nii', coordinates=['{},{}'.format(initz[0], initz[1])])
-
-            # create_label_z('segmentation.nii', initz[0], initz[1], fname_labelz=fname_labelz)  # create label located at z_center
-        elif initcenter:
-            # find z centered in FOV
-            nii = Image('segmentation.nii').change_orientation("RPI")
-            nx, ny, nz, nt, px, py, pz, pt = nii.dim  # Get dimensions
-            z_center = int(np.round(nz / 2))  # get z_center
-            create_label_z('segmentation.nii', z_center, initcenter, fname_labelz=fname_labelz)  # create label located at z_center
+        if initz or initcenter:
+            if initcenter:
+                # find z centered in FOV
+                nii = Image('segmentation.nii').change_orientation("RPI")
+                nx, ny, nz, nt, px, py, pz, pt = nii.dim  # Get dimensions
+                z_center = int(np.round(nz / 2))  # get z_center
+                initz = [z_center, initcenter]
+            # create single label and output as labels.nii.gz
+            label = ProcessLabels('segmentation.nii', fname_output='tmp.labelz.nii.gz',
+                                      coordinates=['{},{}'.format(initz[0], initz[1])])
+            im_label = label.process('create-seg')
+            im_label.data = sct_maths.dilate(im_label.data, [3])  # TODO: create a dilation method specific to labels,
+            # which does not apply a convolution across all voxels (highly inneficient)
+            im_label.save(fname_labelz)
         elif fname_initlabel:
             import sct_label_utils
             # subtract "1" to label value because due to legacy, in this code the disc C2-C3 has value "2", whereas in the

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -31,7 +31,9 @@ logger = logging.getLogger(__name__)
 
 def _get_permutations(im_src_orientation, im_dst_orientation):
     """
-    :return: list of axes permutations and list of inversions to achive an orientation change
+    :param im_src_orientation str: Orientation of source image. Example: 'RPI'
+    :param im_dest_orientation str: Orientation of destination image. Example: 'SAL'
+    :return: list of axes permutations and list of inversions to achieve an orientation change
     """
 
     opposite_character = {'L': 'R', 'R': 'L', 'A': 'P', 'P': 'A', 'I': 'S', 'S': 'I'}


### PR DESCRIPTION
If input image has Z defined as SI instead of IS, the input Z coordinate used to initialize disc location is wrongly interpreted. 

This PR introduces an internal function that converts Z (or any other coordinate) based on the input and destination orientation. This function is located in `msct_types.Coordinate.permute()`.

Fixes #2236 

