### PR TITLE
Added flag to combine all labels

### DIFF
--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -217,7 +217,7 @@ To compute average MTR in a region defined by a single label file (could be bina
     return parser
 
 
-def main(fname_data, path_label, method, slices, levels, fname_output, labels_user, append,
+def main(fname_data, path_label, method, slices, levels, fname_output, labels_user, append_csv,
          fname_vertebral_labeling="", perslice=1, perlevel=1, verbose=1):
     """
     Extract metrics from MRI data based on mask (could be single file of folder to atlas)
@@ -231,7 +231,7 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
            (e.g. PAM50/template/) or a specified file: fname_vertebral_labeling. Same format as slices_of_interest.
     :param fname_output:
     :param labels_user:
-    :param append: Append to csv file
+    :param append_csv: Append to csv file
     :param fname_normalizing_label:
     :param fname_vertebral_labeling: vertebral labeling to be used with vertebral_levels
     :param perslice: if user selected several slices, then the function outputs a metric within each slice
@@ -249,9 +249,6 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
         indiv_labels_ids = [0]
         indiv_labels_files = [path_label]
         combined_labels_ids = []
-        combined_labels_names = []
-        combined_labels_id_groups = []
-        map_clusters = []
         label_struc = {0: LabelStruc(id=0,
                                      name=sct.extract_fname(path_label)[1],
                                      filename=path_label)}
@@ -328,8 +325,8 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
                                     perlevel=perlevel, vert_level=im_vertebral_labeling, method=method,
                                     label_struc=label_struc, id_label=id_label, indiv_labels_ids=indiv_labels_ids)
 
-        save_as_csv(agg_metric, fname_output, fname_in=fname_data, append=append)
-        append = True  # when looping across labels, need to append results in the same file
+        save_as_csv(agg_metric, fname_output, fname_in=fname_data, append=append_csv)
+        append_csv = True  # when looping across labels, need to append results in the same file
     sct.display_open(fname_output)
 
 
@@ -348,9 +345,9 @@ if __name__ == "__main__":
     method = arguments['-method']
     fname_output = arguments['-o']
     if '-append' in arguments:
-        append = int(arguments['-append'])
+        append_csv = int(arguments['-append'])
     else:
-        append = 0
+        append_csv = 0
     if '-l' in arguments:
         labels_user = arguments['-l']
     else:
@@ -404,5 +401,6 @@ if __name__ == "__main__":
 
     # call main function
     main(fname_data=fname_data, path_label=path_label, method=method, slices=parse_num_list(slices_of_interest),
-         levels=parse_num_list(vertebral_levels), fname_output=fname_output, labels_user=labels_user, append=append,
-         fname_vertebral_labeling=fname_vertebral_labeling, perslice=perslice, perlevel=perlevel, verbose=verbose)
+         levels=parse_num_list(vertebral_levels), fname_output=fname_output, labels_user=labels_user,
+         append_csv=append_csv, fname_vertebral_labeling=fname_vertebral_labeling, perslice=perslice,
+         perlevel=perlevel, verbose=verbose)

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -288,7 +288,7 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
                                                                    map_cluster=[indiv_labels_ids[i_label] in map_cluster for
                                                                                 map_cluster in map_clusters].index(True))
     else:
-        sct.printv('\nERROR: ' + path_label + ' does not exist.', 1, 'error')
+        raise RuntimeError(path_label + ' does not exist')
 
     # check syntax of labels asked by user
     labels_id_user = check_labels(indiv_labels_ids + combined_labels_ids, parse_num_list(labels_user))

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -218,34 +218,26 @@ To compute average MTR in a region defined by a single label file (could be bina
 
 
 def main(fname_data, path_label, method, slices, levels, fname_output, labels_user, append,
-         fname_normalizing_label, normalization_method, label_to_fix, adv_param_user, fname_output_metric_map,
-         fname_mask_weight, fname_vertebral_labeling="", perslice=1, perlevel=1, discard_negative_values=False,
-         verbose=1):
+         fname_vertebral_labeling="", perslice=1, perlevel=1, verbose=1):
     """
     Extract metrics from MRI data based on mask (could be single file of folder to atlas)
     :param fname_data: data to extract metric from
     :param path_label: mask: could be single file or folder to atlas (which contains info_label.txt)
-    :param method:
-    :param slices_of_interest. Accepted format:
+    :param method {'wa', 'bin', 'ml', 'map'}
+    :param slices. Slices of interest. Accepted format:
            "0,1,2,3": slices 0,1,2,3
            "0:3": slices 0,1,2,3
-    :param vertebral_levels: Vertebral levels to extract metrics from. Should be associated with a template
+    :param levels: Vertebral levels to extract metrics from. Should be associated with a template
            (e.g. PAM50/template/) or a specified file: fname_vertebral_labeling. Same format as slices_of_interest.
     :param fname_output:
     :param labels_user:
-    :param overwrite:
+    :param append: Append to csv file
     :param fname_normalizing_label:
-    :param normalization_method:
-    :param label_to_fix:
-    :param adv_param_user:
-    :param fname_output_metric_map:
-    :param fname_mask_weight:
     :param fname_vertebral_labeling: vertebral labeling to be used with vertebral_levels
     :param perslice: if user selected several slices, then the function outputs a metric within each slice
            instead of a single average output.
     :param perlevel: if user selected several levels, then the function outputs a metric within each vertebral level
            instead of a single average output.
-    :param discard_negative_values: Bool: Discard negative voxels when computing metrics statistics
     :param verbose
     :return:
     """
@@ -255,7 +247,6 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
     if os.path.isfile(path_label):
         # Label is a single file
         indiv_labels_ids = [0]
-        indiv_labels_names = [path_label]
         indiv_labels_files = [path_label]
         combined_labels_ids = []
         combined_labels_names = []
@@ -412,7 +403,6 @@ if __name__ == "__main__":
     sct.init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
-    main(fname_data, path_label, method, parse_num_list(slices_of_interest), parse_num_list(vertebral_levels),
-         fname_output, labels_user, append, fname_normalizing_label, normalization_method, label_to_fix,
-         adv_param_user, fname_output_metric_map, fname_mask_weight, fname_vertebral_labeling=fname_vertebral_labeling,
-         perslice=perslice, perlevel=perlevel, discard_negative_values=discard_negative_values, verbose=verbose)
+    main(fname_data=fname_data, path_label=path_label, method=method, slices=parse_num_list(slices_of_interest),
+         levels=parse_num_list(vertebral_levels), fname_output=fname_output, labels_user=labels_user, append=append,
+         fname_vertebral_labeling=fname_vertebral_labeling, perslice=perslice, perlevel=perlevel, verbose=verbose)

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -206,7 +206,7 @@ def extract_metric(data, labels=None, slices=None, levels=None, perslice=True, p
     func_methods = {'ml': ('ML', func_ml), 'map': ('MAP', func_map)}  # TODO: complete dict with other methods
     # If label_struc[id_label].id is a list (i.e. comes from a combined labels), sum all labels
     if isinstance(label_struc[id_label].id, list):
-        labels_sum = np.sum(labels[..., label_struc[id_label].id], axis=3)  # (nx, ny, nz, 1)
+        labels_sum = np.sum(labels[..., label_struc[id_label].id], axis=labels.ndim-1)  # (nx, ny, nz, 1)
     else:
         labels_sum = labels[..., label_struc[id_label].id]
     # expand dim: labels_sum=(..., 1)

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -195,22 +195,19 @@ def extract_metric(data, labels=None, slices=None, levels=None, perslice=True, p
     :param perlevel:
     :param vert_level:
     :param method:
-    :param label_struc: Label structure defined in sct_extract_metric
+    :param label_struc: LabelStruc class defined above
     :param id_label: int: ID of label to select
     :param indiv_labels_ids: list of int: IDs of labels corresponding to individual (as opposed to combined) labels for
     use with ML or MAP estimation.
-    :param map_clusters: list of list of int: See func_map()
     :return: aggregate_per_slice_or_level()
     """
     # Initializations
     map_clusters = None
-    func_methods = {'ml': ('ML', func_ml), 'map': ('MAP', func_map)}
-    # If label_struc[id_label].id is a list, it means that it comes from a combined labels
+    func_methods = {'ml': ('ML', func_ml), 'map': ('MAP', func_map)}  # TODO: complete dict with other methods
+    # If label_struc[id_label].id is a list (i.e. comes from a combined labels), sum all labels
     if isinstance(label_struc[id_label].id, list):
-        # Sum across labels
         labels_sum = np.sum(labels[..., label_struc[id_label].id], axis=3)  # (nx, ny, nz, 1)
     else:
-        # Simply extract
         labels_sum = labels[..., label_struc[id_label].id]
     # expand dim: labels_sum=(..., 1)
     ndim = labels_sum.ndim
@@ -218,13 +215,23 @@ def extract_metric(data, labels=None, slices=None, levels=None, perslice=True, p
 
     # Maximum Likelihood or Maximum a Posteriori
     if method in ['ml', 'map']:
+        # Get the complementary list of labels (the ones not asked by the user)
         id_label_compl = diff_between_list_or_int(indiv_labels_ids, label_struc[id_label].id)
-        # Generate a list of map_clusters for each label in mask.
-        # Start with the first label (the one chosed by the user)
-        map_clusters = [label_struc[id_label].map_cluster]
-        # Then append the remaining cluster IDs
-        map_clusters += [label_struc[i].map_cluster for i in id_label_compl]
-        # Concatenate labels: the one asked by the user, followed by the remaining ones
+        # Generate a list of map_clusters for each label. Start with the first label (the one chosen by the user).
+        # Note that the first label could be a combination of several labels (e.g., WM and GM).
+        if isinstance(label_struc[id_label].id, list):
+            # in case there are several labels for this id_label
+            map_clusters = [list(set([label_struc[i].map_cluster for i in label_struc[id_label].id]))]
+        else:
+            # in case there is only one label for this id_label
+            map_clusters = [[label_struc[id_label].map_cluster]]
+        # Append the cluster for each remaining labels (i.e. the ones not included in the combined labels)
+        for i_cluster in [label_struc[i].map_cluster for i in id_label_compl]:
+            map_clusters.append([i_cluster])
+        # Concatenate labels: first, the one asked by the user, then the remaining ones.
+        # Examples of scenario:
+        #   labels_sum = [[0], [1:36]]
+        #   labels_sum = [[3,4], [0,2,5:36]]
         labels_sum = np.concatenate([labels_sum, labels[..., id_label_compl]], axis=ndim)
         mask = Metric(data=labels_sum, label=label_struc[id_label].name)
         group_funcs = (func_methods[method], ('STD', func_std))
@@ -273,38 +280,73 @@ def func_max(data, mask=None, map_clusters=None):
 
 def func_map(data, mask, map_clusters):
     """
-    Compute maximum a posteriori (MAP) for the first label of mask.
+    Compute maximum a posteriori (MAP) by aggregating the last dimension of mask according to a clustering method
+    defined by map_clusters
     :param data: nd-array: input data
     :param mask: (n+1)d-array: input mask. Note: this mask should include ALL labels to satisfy the necessary condition for
     ML-based estimation, i.e., at each voxel, the sum of all labels (across the last dimension) equals the probability
     to be inside the tissue. For example, for a pixel within the spinal cord, the sum of all labels should be 1.
     :param map_clusters: list of list of int: Each sublist corresponds to a cluster of labels where ML estimation will
     be performed to provide the prior beta_0 for MAP estimation.
-    :return: float: beta corresponding to the first label
+    :return: float: beta corresponding to the first label (beta[0])
+    :return: nd-array: matrix of all beta
     """
     # Check number of labels and map_clusters
     assert mask.shape[-1] == len(map_clusters)
-    # Sum across each clustered labels, then concatenate
+
+    # Iterate across all labels (excluding the first one) and generate cluster labels. Examples of input/output:
+    #   [[0], [0], [0], [1], [2], [0]] --> [0, 0, 0, 1, 2, 0]
+    #   [[0, 1], [0], [0], [1], [2]] --> [0, 0, 0, 0, 1]
+    #   [[0, 1], [0], [1], [2], [3]] --> [0, 0, 0, 1, 2]
+    possible_clusters = [map_clusters[0]]
+    id_clusters = [0]  # this one corresponds to the first cluster
+    for i_cluster in map_clusters[1:]:  # skip the first
+        found_index = False
+        for possible_cluster in possible_clusters:
+            if i_cluster[0] in possible_cluster:
+                id_clusters.append(possible_clusters.index(possible_cluster))
+                found_index = True
+        if not found_index:
+            possible_clusters.append(i_cluster)
+            id_clusters.append(possible_clusters.index([i_cluster[0]]))
+
+    # Sum across each clustered labels, then concatenate to generate mask_clusters
+    # mask_clusters has dimension: x, y, z, n_clustered_labels, with n_clustered_labels being equal to the number of
+    # clusters that need to be estimated for ML method. Let's assume:
+    # label_struc = [
+    #   LabelStruc(id=0, map_cluster=0),
+    #   LabelStruc(id=1, map_cluster=0),
+    #   LabelStruc(id=2, map_cluster=0),
+    #   LabelStruc(id=3, map_cluster=1),
+    #   LabelStruc(id=4, map_cluster=2),
+    # ]
+    #
+    # Examples of scenario below for ML estimation:
+    #   labels_id_user = [0,1], mask_clusters = [np.sum(label[0:2]), label[3], label[4]]
+    #   labels_id_user = [3], mask_clusters = [np.sum(label[0:2]), label[3], label[4]]
+    #   labels_id_user = [0,1,2,3], mask_clusters = [np.sum(label(0:3)), label[4]]
     mask_l = []
-    for i_cluster in list(set(map_clusters)):
-        # Get indices for given cluster
-        i_clusters = [i for i in range(len(map_clusters)) if i_cluster == map_clusters[i]]
+    for i_cluster in list(set(id_clusters)):
+        # Get label indices for given cluster
+        id_label_cluster = [i for i in range(len(id_clusters)) if i_cluster == id_clusters[i]]
         # Sum all labels for this cluster
-        mask_l.append(np.expand_dims(np.sum(mask[..., i_clusters], axis=(mask.ndim - 1)), axis=(mask.ndim - 1)))
+        mask_l.append(np.expand_dims(np.sum(mask[..., id_label_cluster], axis=(mask.ndim - 1)), axis=(mask.ndim - 1)))
     mask_clusters = np.concatenate(mask_l, axis=(mask.ndim-1))
+
     # Run ML estimation for each clustered labels
     _, beta_cluster = func_ml(data, mask_clusters)
+
     # MAP estimation:
     #   y [nb_vox x 1]: measurements vector (to which weights are applied)
     #   x [nb_vox x nb_labels]: linear relation between the measurements y
     #   beta_0 [nb_labels]: A priori values estimated per cluster using ML.
-    #   beta [nb_labels] = beta_0 + (Xt . X + 1)^(-1) . Xt . (y - X . beta_0) : The estimated metric value in each label
+    #   beta [nb_labels] = beta_0 + (Xt . X + 1)^(-1) . Xt . (y - X . beta_0): The estimated metric value in each label
     #
     # Note: for simplicity we consider that sigma_noise = sigma_label
     n_vox = functools.reduce(operator.mul, data.shape, 1)
     y = np.reshape(data, n_vox)
     x = np.reshape(mask, (n_vox, mask.shape[mask.ndim-1]))
-    beta_0 = [beta_cluster[map_clusters[i_label]] for i_label in range(mask.shape[-1])]
+    beta_0 = [beta_cluster[id_clusters[i_label]] for i_label in range(mask.shape[-1])]
     beta = beta_0 + np.dot(np.linalg.pinv(np.dot(x.T, x) + np.diag(np.ones(mask.shape[-1]))),
                            np.dot(x.T,
                                   (y - np.dot(x, beta_0))))

--- a/unit_testing/test_aggregate_slicewise.py
+++ b/unit_testing/test_aggregate_slicewise.py
@@ -13,14 +13,12 @@ import csv
 import numpy as np
 import nibabel as nib
 
-from spinalcordtoolbox.utils import __sct_dir__
+from spinalcordtoolbox.utils import __sct_dir__, __version__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
 
 from spinalcordtoolbox import aggregate_slicewise
 from spinalcordtoolbox.process_seg import Metric
 from spinalcordtoolbox.image import Image
-
-import sct_utils as sct
 
 
 @pytest.fixture(scope="session")
@@ -215,15 +213,15 @@ def test_save_as_csv(dummy_metrics):
     with open('tmp_file_out.csv', 'r') as csvfile:
         spamreader = csv.reader(csvfile, delimiter=',')
         next(spamreader)  # skip header
-        assert next(spamreader)[1:] == [sct.__version__, 'FakeFile.txt', '3:4', '', '45.5', '4.5']
+        assert next(spamreader)[1:] == [__version__, 'FakeFile.txt', '3:4', '', '45.5', '4.5']
     # with appending
     aggregate_slicewise.save_as_csv(agg_metric, 'tmp_file_out.csv')
     aggregate_slicewise.save_as_csv(agg_metric, 'tmp_file_out.csv', append=True)
     with open('tmp_file_out.csv', 'r') as csvfile:
         spamreader = csv.reader(csvfile, delimiter=',')
         next(spamreader)  # skip header
-        assert next(spamreader)[1:] == [sct.__version__, '', '3:4', '', '45.5', '4.5']
-        assert next(spamreader)[1:] == [sct.__version__, '', '3:4', '', '45.5', '4.5']
+        assert next(spamreader)[1:] == [__version__, '', '3:4', '', '45.5', '4.5']
+        assert next(spamreader)[1:] == [__version__, '', '3:4', '', '45.5', '4.5']
 
 
 # noinspection 801,PyShadowingNames
@@ -301,4 +299,4 @@ def test_save_as_csv_extract_metric(dummy_data_and_labels):
     with open('tmp_file_out.csv', 'r') as csvfile:
         spamreader = csv.reader(csvfile, delimiter=',')
         next(spamreader)  # skip header
-        assert next(spamreader)[1:-1] == [sct.__version__, '', '0:4', '', 'label_0', '2.5', '38.0']
+        assert next(spamreader)[1:-1] == [__version__, '', '0:4', '', 'label_0', '2.5', '38.0']

--- a/unit_testing/test_aggregate_slicewise.py
+++ b/unit_testing/test_aggregate_slicewise.py
@@ -189,7 +189,7 @@ def test_extract_metric(dummy_data_and_labels):
     agg_metric = aggregate_slicewise.extract_metric(dummy_data_and_labels[0], labels=dummy_data_and_labels[1],
                                                     label_struc=dummy_data_and_labels[2], id_label=99,
                                                     indiv_labels_ids=[0, 1, 2], perslice=False, method='map')
-    assert agg_metric[list(agg_metric)[0]]['MAP()'] == 20.0
+    assert agg_metric[list(agg_metric)[0]]['MAP()'] == pytest.approx(20.0, rel=0.01)
 
 
 # noinspection 801,PyShadowingNames

--- a/unit_testing/test_aggregate_slicewise.py
+++ b/unit_testing/test_aggregate_slicewise.py
@@ -45,7 +45,8 @@ def dummy_data_and_labels():
     # Create label_struc{}
     label_struc = {0: aggregate_slicewise.LabelStruc(id=0, name='label_0', map_cluster=0),
                    1: aggregate_slicewise.LabelStruc(id=1, name='label_1', map_cluster=1),
-                   2: aggregate_slicewise.LabelStruc(id=2, name='label_2', map_cluster=1)}
+                   2: aggregate_slicewise.LabelStruc(id=2, name='label_2', map_cluster=1),
+                   99: aggregate_slicewise.LabelStruc(id=[1, 2], name='label_1,2', map_cluster=None)}
     return data, labels, label_struc
 
 
@@ -151,7 +152,6 @@ def test_aggregate_per_level(dummy_metrics, dummy_vert_level):
 
 # noinspection 801,PyShadowingNames
 def test_extract_metric(dummy_data_and_labels):
-    # TODO: test with combined labels
     """Test different estimation methods."""
     # Weighted average
     agg_metric = aggregate_slicewise.extract_metric(dummy_data_and_labels[0], labels=dummy_data_and_labels[1],
@@ -182,6 +182,16 @@ def test_extract_metric(dummy_data_and_labels):
                                                     label_struc=dummy_data_and_labels[2], id_label=0,
                                                     indiv_labels_ids=[0, 1], perslice=False, method='max')
     assert agg_metric[list(agg_metric)[0]]['MAX()'] == 41.0
+
+    # Combined labels
+    agg_metric = aggregate_slicewise.extract_metric(dummy_data_and_labels[0], labels=dummy_data_and_labels[1],
+                                                    label_struc=dummy_data_and_labels[2], id_label=99,
+                                                    perslice=False, method='wa')
+    assert agg_metric[list(agg_metric)[0]]['WA()'] == 22.0
+    agg_metric = aggregate_slicewise.extract_metric(dummy_data_and_labels[0], labels=dummy_data_and_labels[1],
+                                                    label_struc=dummy_data_and_labels[2], id_label=99,
+                                                    indiv_labels_ids=[0, 1, 2], perslice=False, method='map')
+    assert agg_metric[list(agg_metric)[0]]['MAP()'] == 20.0
 
 
 # noinspection 801,PyShadowingNames


### PR DESCRIPTION
Currently, when listing flags with -l, estimation is done for each tract separately. This PR makes it possible to combine all tracts within a single estimation. Fixes #2193 

Also address the following points:
- In the previous implementation of MAP estimation, the ML estimation (part of MAP) was using the first label of the combined labels. For example, if user asked for metric in the spinal cord, the beta_0[0] (from ML) would be only based on the first label (WM), not on all the labels (in that case, WM + GM). This PR fixes it.

