### PR TITLE
Added possibility to keep temporary folders in detect_c2c3 and quit if detection fails

### DIFF
--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -323,7 +323,11 @@ def main(args=None):
             # automatically finds C2-C3 disc
             im_data = Image('data.nii')
             im_seg = Image('segmentation.nii')
-            im_label_c2c3 = detect_c2c3(im_data, im_seg, contrast, verbose=verbose)
+            if not remove_temp_files:  # because verbose is here also used for keeping temp files
+                verbose_detect_c2c3 = 2
+            else:
+                verbose_detect_c2c3 = 0
+            im_label_c2c3 = detect_c2c3(im_data, im_seg, contrast, verbose=verbose_detect_c2c3)
             ind_label = np.where(im_label_c2c3.data)
             if not np.size(ind_label) == 0:
                 # subtract "1" to label value because due to legacy, in this code the disc C2-C3 has value "2", whereas in the

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -331,6 +331,7 @@ def main(args=None):
                 im_label_c2c3.data[ind_label] = 2
             else:
                 sct.printv('Automatic C2-C3 detection failed. Please provide manual label with sct_label_utils', 1, 'error')
+                sys.exit()
             im_label_c2c3.save(fname_labelz)
 
         # dilate label so it is not lost when applying warping

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -323,7 +323,7 @@ def main(args=None):
             # automatically finds C2-C3 disc
             im_data = Image('data.nii')
             im_seg = Image('segmentation.nii')
-            im_label_c2c3 = detect_c2c3(im_data, im_seg, contrast)
+            im_label_c2c3 = detect_c2c3(im_data, im_seg, contrast, verbose=verbose)
             ind_label = np.where(im_label_c2c3.data)
             if not np.size(ind_label) == 0:
                 # subtract "1" to label value because due to legacy, in this code the disc C2-C3 has value "2", whereas in the

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -125,6 +125,8 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     if verbose < 2:
         logger.info("Remove temporary files...")
         tmp_folder.cleanup()
+    else:
+        logger.info("Temporary files saved to "+tmp_folder.get_path())
 
     nii_c2c3.change_orientation(orientation_init)
     return nii_c2c3

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -82,6 +82,8 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
         nii_pred_before_postPro = nii_midSlice.copy()
         nii_pred_before_postPro.data = pred  # 2D data with orientation, mid sag slice of the original data
         nii_pred_before_postPro.save("pred_midSlice_before_postPro.nii.gz")  # save it)
+    # DEBUG trick: check if the detection succeed by running: fsleyes data_midSlice data_midSlice_pred_svm -cm red -dr 0 100
+    # If a "red cluster" is observed in the neighbourhood of C2C3, then the model detected it.
 
     # Create mask along centerline
     midSlice_mask = np.zeros(midSlice_seg.shape)


### PR DESCRIPTION
This PR aims at:
1. `sct_label_vertebrae`: Input verbose value to `detect_c2c3` when called in `sct_label_vertebrae` in order to facilitate the debugging.
2. `detect_c2c3`: Display temp folder path in terminal for verbose >= 2, so that we can easily check the temp files.
3. `sct_label_vertebrae`: Quit if detection fails.

To reproduce:
```
cd sct_testing/t2
sct_label_vertebrae -i t2.nii.gz -c t2 -s t2_seg.nii.gz -v 2
```

Before:
<details>

```
C2-C3 not detected...
Temporary files saved to /tmp/sct-20190605214813.450715-c3o5rovb
Automatic C2-C3 detection failed. Please provide manual label with sct_label_utils
Saving image to /tmp/sct-20190605214807.853906-label_vertebrae-ta3i_v8s/labelz.nii.gz orientation AIL shape (60, 55, 52)
WARNING: File /tmp/sct-20190605214807.853906-label_vertebrae-ta3i_v8s/labelz.nii.gz already exists. Will overwrite it.

Done! To view results, type:
fsleyes /tmp/sct-20190605214807.853906-label_vertebrae-ta3i_v8s/labelz.nii.gz &


And apply straightening to label...
/home/charley/sct/bin/isct_antsApplyTransforms -d 3 -i labelz.nii.gz -r data_straightr.nii -t warp_curve2straight.nii.gz -o labelz_straight.nii.gz -n NearestNeighbor # in /tmp/sct-20190605214807.853906-label_vertebrae-ta3i_v8s

Get z and disc values from straight label...
Traceback (most recent call last):
  File "/home/charley/sct/scripts/sct_label_vertebrae.py", line 422, in <module>
    main()
  File "/home/charley/sct/scripts/sct_label_vertebrae.py", line 352, in main
    init_disc = get_z_and_disc_values_from_label('labelz_straight.nii.gz')
  File "/home/charley/sct/spinalcordtoolbox/vertebrae/core.py", line 290, in get_z_and_disc_values_from_label
    x_label, y_label, z_label = center_of_mass(nii.data)
  File "/home/charley/sct/spinalcordtoolbox/vertebrae/core.py", line 253, in center_of_mass
    raise ValueError("Array has no mass")
ValueError: Array has no mass
```

</details>


Now:
<details>

```
C2-C3 not detected...
Temporary files saved to /tmp/sct-20190605220114.868348-shzsyepy
Automatic C2-C3 detection failed. Please provide manual label with sct_label_utils
```

</details>

Fixes #2242.