### PR TITLE
Output segmentation in uint8

### DIFF
--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -239,6 +239,9 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     seg_initres_nii.data[np.where(seg_initres_nii.data >= thr)] = 1
     seg_initres_nii.data[np.where(seg_initres_nii.data < thr)] = 0
 
+    # change data type
+    seg_initres_nii.change_type(np.uint8)
+
     # reorient to initial orientation
     logger.info("\nReorienting the segmentation to the original image orientation...")
     tmp_folder.chdir_undo()

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -685,6 +685,9 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # post processing step to z_regularized
     im_image_res_seg_downsamp_postproc = post_processing_volume_wise(im_in=im_image_res_seg_downsamp)
 
+    # change data type
+    im_image_res_seg_downsamp_postproc.change_type(np.uint8)
+
     tmp_folder.chdir_undo()
 
     # remove temporary files


### PR DESCRIPTION
This PR simply changes output segmentation data type to `uint8` for `deepseg_sc` and `deepseg_lesion`.

To reproduce:
```
cd duke/sct_testing/bids/sct-users/sub-20190427/anat
sct_deepseg_sc -i sub-20190427_acq-MTon_MTS.nii.gz -c t2s
```

Fixes #2243.