### PR TITLE
Travis: Adding distribs and displaying allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     - os: osx
       name: "OSX 10.13 (High Sierra)"
       osx_image: xcode9.4
+    - os: osx
+      name: "OSX 10.12 (Sierra)"
+      osx_image: xcode9.2
   allow_failures:
     - os: linux
       name: "Ubuntu 14.04 (Trusty)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ matrix:
     - os: osx
       name: "OSX 10.13 (High Sierra)"
       osx_image: xcode9.4
-    - os: osx
-      name: "OSX 10.12 (Sierra)"
-      osx_image: xcode9.2
   allow_failures:
     - os: linux
       name: "Ubuntu 14.04 (Trusty)"
       dist: trusty
+    - os: osx
+      name: "OSX 10.12 (Sierra)"
+      osx_image: xcode9.2
 
 before_install:
   - echo "HOME="

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,21 @@ matrix:
     - os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
       name: "Ubuntu 16.04 (Xenial)"
       dist: xenial
+    - os: linux
+      name: "Ubuntu 14.04 (Trusty)"
+      dist: trusty
     - os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       name: "OSX 10.14 (Mojave)"
       osx_image: xcode10.2
     - os: osx
       name: "OSX 10.13 (High Sierra)"
       osx_image: xcode9.4
-  allow_failures:
-    - os: linux
-      name: "Ubuntu 14.04 (Trusty)"
-      dist: trusty
     - os: osx
       name: "OSX 10.12 (Sierra)"
       osx_image: xcode9.2
+  allow_failures:
+    - name: "Ubuntu 14.04 (Trusty)"
+    - name: "OSX 10.12 (Sierra)"
 
 before_install:
   - echo "HOME="


### PR DESCRIPTION
This PR adds test for Sierra and displays all builds on the Travis Web UI (even the one with `allow_failures`). Regarding the latter point, [a ticket has been opened](https://travis-ci.community/t/allow-failures-does-not-appear-on-the-web-ui/3638) on the Travis forum.

