### PR TITLE
Add CSA results on QC report 

### DIFF
--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -173,8 +173,8 @@ def _make_figure(metric):
     ax.plot(z, angle_rl, 'r')
     ax.plot(z, angle_rl, 'r.')
     ax.grid(True)
-    ax.set_xlabel('Slice (in superior-inferior direction)')
-    ax.set_ylabel('Angle [deg]')
+    ax.set_xlabel('Slice (Inferior-Superior direction)')
+    ax.set_ylabel('Angle [$deg$]')
     fig.savefig(fname_img)
     return fname_img
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -142,6 +142,43 @@ def get_parser():
     return parser
 
 
+def _make_figure(metric):
+    """
+    Make a graph showing CSA and angles per slice.
+    :param metric: Dictionary of metrics
+    :return: image object
+    """
+    import tempfile
+    from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+    from matplotlib.figure import Figure
+
+    fname_img = tempfile.NamedTemporaryFile().name + '.png'
+    z, csa, angle_ap, angle_rl = [], [], [], []
+    for key, value in metric.items():
+        z.append(key[0])
+        csa.append(value['MEAN(area)'])
+        angle_ap.append(value['MEAN(angle_AP)'])
+        angle_rl.append(value['MEAN(angle_RL)'])
+    # Make figure
+    fig = Figure()
+    FigureCanvas(fig)
+    ax = fig.add_subplot(211)
+    ax.plot(z, csa, 'k')
+    ax.plot(z, csa, 'k.')
+    ax.grid(True)
+    ax.set_ylabel('CSA [$mm^2$]')
+    ax = fig.add_subplot(212)
+    ax.plot(z, angle_ap, 'b')
+    ax.plot(z, angle_ap, 'b.')
+    ax.plot(z, angle_rl, 'r')
+    ax.plot(z, angle_rl, 'r.')
+    ax.grid(True)
+    ax.set_xlabel('Slice (in superior-inferior direction)')
+    ax.set_ylabel('Angle [deg]')
+    fig.savefig(fname_img)
+    return fname_img
+
+
 def main(args):
     parser = get_parser()
     arguments = parser.parse(args)
@@ -211,7 +248,7 @@ def main(args):
     # QC report (only show CSA for clarity)
     if path_qc is not None:
         generate_qc(fname_segmentation, args=args, path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
-                    subject=qc_subject, metric=metrics_agg_merged, process='sct_process_segmentation')
+                    subject=qc_subject, path_img=_make_figure(metrics_agg_merged), process='sct_process_segmentation')
 
     sct.display_open(file_out)
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -26,6 +26,7 @@ from spinalcordtoolbox import process_seg
 from spinalcordtoolbox.aggregate_slicewise import aggregate_per_slice_or_level, save_as_csv, func_wa, func_std, \
     _merge_dict
 from spinalcordtoolbox.utils import parse_num_list
+from spinalcordtoolbox.reports.qc import generate_qc
 
 
 # TODO: Move this class somewhere else
@@ -115,6 +116,18 @@ def get_parser():
                       mandatory=False,
                       example=['0', '1'],
                       default_value='1')
+    parser.add_option(name='-qc',
+                      type_value='folder_creation',
+                      description='The path where the quality control generated content will be saved',
+                      default_value=None)
+    parser.add_option(name='-qc-dataset',
+                      type_value='str',
+                      description='If provided, this string will be mentioned in the QC report as the dataset the process was run on',
+                      )
+    parser.add_option(name='-qc-subject',
+                      type_value='str',
+                      description='If provided, this string will be mentioned in the QC report as the subject the process was run on',
+                      )
     parser.add_option(name='-v',
                       type_value='multiple_choice',
                       description='1: display on, 0: display off (default)',
@@ -171,6 +184,9 @@ def main(args):
             angle_correction = True
         elif arguments['-angle-corr'] == '0':
             angle_correction = False
+    path_qc = arguments.get("-qc", None)
+    qc_dataset = arguments.get("-qc-dataset", None)
+    qc_subject = arguments.get("-qc-subject", None)
 
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
@@ -191,6 +207,12 @@ def main(args):
                                                         group_funcs=group_funcs)
     metrics_agg_merged = _merge_dict(metrics_agg)
     save_as_csv(metrics_agg_merged, file_out, fname_in=fname_segmentation, append=append)
+
+    # QC report (only show CSA for clarity)
+    if path_qc is not None:
+        generate_qc(fname_segmentation, args=args, path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
+                    subject=qc_subject, metric=metrics_agg_merged, process='sct_process_segmentation')
+
     sct.display_open(file_out)
 
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -315,7 +315,7 @@ class QcImage(object):
 
 
 class Params(object):
-    """Parses and stores the variables that will be  sincluded into the QC details
+    """Parses and stores the variables that will be included into the QC details
     """
     def __init__(self, input_file, command, args, orientation, dest_folder, dpi=300, dataset=None, subject=None):
         """

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -452,7 +452,7 @@ class QcReport(object):
                              dest_full_path)
 
 
-def add_entry(src, process, args, path_qc, plane, background=None, path_img=None,
+def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overlay=None,
               qcslice=None,
               qcslice_operations=[],
               qcslice_layout=None,
@@ -468,8 +468,8 @@ def add_entry(src, process, args, path_qc, plane, background=None, path_img=None
     :param args:
     :param path_qc:
     :param plane:
-    :param background:
     :param path_img: Path to image to display
+    :param path_img_overlay: Path to image to display on top of path_img (will flip between the two)
     :param qcslice: spinalcordtoolbox.reports.slice:Axial
     :param qcslice_operations:
     :param qcslice_layout:
@@ -491,19 +491,16 @@ def add_entry(src, process, args, path_qc, plane, background=None, path_img=None
         layout(qcslice)
     elif path_img is not None:
         report.make_content_path()
-
-        # def normalized(img):
-        #     return np.uint8(skimage.exposure.rescale_intensity(img, out_range=np.uint8))
-
-        # skimage.io.imsave(qc_param.abs_overlay_img_path(), normalized(foreground))
-        #
-        # if background is None:
-        #     qc_param.bkg_img_path = qc_param.overlay_img_path
-        # else:
-        #     skimage.io.imsave(qc_param.abs_bkg_img_path(), normalized(background))
-        #
         report.update_description_file((640, 480))  # TODO: fetch dim
-        copyfile(path_img, qc_param.abs_overlay_img_path())
+        copyfile(path_img, qc_param.abs_bkg_img_path())
+        if path_img_overlay is not None:
+            # User specified a second image to overlay
+            copyfile(path_img_overlay, qc_param.abs_overlay_img_path())
+        else:
+            # Copy the image both as "overlay" and "path_img_overlay", so it appears static.
+            # TODO: Leave the possibility in the reports/assets/js files to have static images (instead of having to
+            #  flip between two images).
+            copyfile(path_img, qc_param.abs_overlay_img_path())
 
     sct.printv('Successfully generated the QC results in %s' % qc_param.qc_results)
     sct.printv('Use the following command to see the results in a browser:')


### PR DESCRIPTION
This PR features a new entry to the QC report: CSA results. 

This report would also facilitate the optimization of default parameter for `get_centerline` (used for angle correction in CSA computation), see https://github.com/neuropoly/spinalcordtoolbox/pull/2299

To test:
```bash
sct_download_data -d sct_testing_data
cd sct_testing_data/t2
sct_process_segmentation -i t2_seg.nii.gz -qc qc-csa
```
