### PR TITLE
Fixed compatibility of skimage.regionprop on OSX Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       name: "OSX 10.11 (El Capitan)"
       osx_image: xcode8
   allow_failures:
-      name: "OSX 10.11 (El Capitan)"
+    - name: "OSX 10.11 (El Capitan)"
 
 before_install:
   - echo "HOME="

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ matrix:
     - os: osx
       name: "OSX 10.12 (Sierra)"
       osx_image: xcode9.2
+    - os: osx
+      name: "OSX 10.11 (El Capitan)"
+      osx_image: xcode8
   allow_failures:
-    - name: "Ubuntu 14.04 (Trusty)"
-    - name: "OSX 10.12 (Sierra)"
+      name: "OSX 10.11 (El Capitan)"
 
 before_install:
   - echo "HOME="

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import
 
 import math
+import platform
 import numpy as np
 from skimage import measure, transform
 from tqdm import tqdm
@@ -166,6 +167,11 @@ def _properties2d(image, dim):
         _find_AP_and_RL_diameter(region.major_axis_length, region.minor_axis_length, orientation,
                                  [i / upscale for i in dim])
     # TODO: compute major_axis_length/minor_axis_length by summing weighted voxels along axis
+    # Deal with https://github.com/neuropoly/spinalcordtoolbox/issues/2307
+    if 'Darwin-16' in platform.platform():
+        solidity = np.nan
+    else:
+        solidity = region.solidity
     # Fill up dictionary
     properties = {'area': area,
                   'diameter_AP': diameter_AP,
@@ -173,7 +179,7 @@ def _properties2d(image, dim):
                   'centroid': region.centroid,
                   'eccentricity': region.eccentricity,
                   'orientation': orientation,
-                  'solidity': region.solidity  # convexity measure
+                  'solidity': solidity  # convexity measure
     }
 
     return properties

--- a/unit_testing/test_process_seg.py
+++ b/unit_testing/test_process_seg.py
@@ -78,7 +78,7 @@ im_segs = [
     (dummy_segmentation(size_arr=(128, 128, 5), pixdim=(1, 1, 1), shape='ellipse', radius_RL=50.0, radius_AP=30.0,
                         debug=DEBUG),
      {'area': 4701, 'angle_AP': 0.0, 'angle_RL': 0.0, 'diameter_AP': 60.0, 'diameter_RL': 100.0, 'eccentricity': 0.8,
-      'orientation': 0.0, 'solidity': 1.0},
+      'orientation': 0.0},
      {'angle_corr': False}),
     # test with one empty slice
     (dummy_segmentation(size_arr=(32, 32, 5), zeroslice=[2], debug=DEBUG),


### PR DESCRIPTION
Weirdly, when inspecting the variable region.solidity [here](https://github.com/neuropoly/spinalcordtoolbox/blob/master/spinalcordtoolbox/process_seg.py#L176), the program exits with segmentation violation (exit code 139). This has only been observed on Sierra.

Travis build: https://travis-ci.org/neuropoly/spinalcordtoolbox/jobs/542929536#L903

A proposed solution is to discard solidity for Sierra distribution.

Fixes #2307