### PR TITLE
Fixed compatibility with OSX 10.11 (El Capitan)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ matrix:
     - os: osx
       name: "OSX 10.11 (El Capitan)"
       osx_image: xcode8
-  allow_failures:
-    - name: "OSX 10.11 (El Capitan)"
 
 before_install:
   - echo "HOME="

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ requests
 scipy
 scikit-image
 scikit-learn
-tensorflow
+tensorflow; platform_system != 'Darwin' or '16.' not in platform_release
+tensorflow==1.3.0; platform_system == 'Darwin' and '16.' in platform_release
 xlrd
 xlutils
 xlwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ requests
 scipy
 scikit-image
 scikit-learn
-tensorflow; platform_system != 'Darwin' or '16.' not in platform_release
-tensorflow==1.3.0; platform_system == 'Darwin' and '16.' in platform_release
+tensorflow; platform_system != 'Darwin' or '15.' not in platform_release
+tensorflow==1.3.0; platform_system == 'Darwin' and '15.' in platform_release
 xlrd
 xlutils
 xlwt

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -168,7 +168,7 @@ def _properties2d(image, dim):
                                  [i / upscale for i in dim])
     # TODO: compute major_axis_length/minor_axis_length by summing weighted voxels along axis
     # Deal with https://github.com/neuropoly/spinalcordtoolbox/issues/2307
-    if 'Darwin-16' in platform.platform():
+    if any(x in platform.platform() for x in ['Darwin-15', 'Darwin-16']):
         solidity = np.nan
     else:
         solidity = region.solidity


### PR DESCRIPTION
With the recent move to 3.6 (https://github.com/neuropoly/spinalcordtoolbox/pull/2238), we had to upgrade Tensorflow. As a consequence, we lost compatibility with older OSs, such as OSX 10.11.

In this PR we introduce a conditional installation of tensorflow version for OSX 10.11. 

Fixes #2302 

<details><summary>Test this PR (run on El Capitan)</summary>

```bash
git clone -b jca/2302-osx10.11 --depth=1 https://github.com/neuropoly/spinalcordtoolbox.git sct-osx10.11
cd sct-osx10.11/
./install_sct
```

</details>