### PR TITLE
Make test_deepseg_lesion.py::test_intensity_normalization stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ alt="Fsleyes integration" width="240" height="180" border="10" /></a>
 - [Dupont SM, De Leener B, Taso M, Le Troter A, Stikov N, Callot V, Cohen-Adad J. Fully-integrated framework for the segmentation and registration of the spinal cord white and gray matter. Neuroimage 2017](https://www.ncbi.nlm.nih.gov/pubmed/27663988)
 - [Perone et al. Spinal cord gray matter segmentation using deep dilated convolutions. Sci Rep 2018](https://www.nature.com/articles/s41598-018-24304-3)
 - [Gros et al. Automatic spinal cord localization, robust to MRI contrasts using global curve optimization. Med Image Anal 2018](https://www.sciencedirect.com/science/article/pii/S136184151730186X)
-- [Gros et al. Automatic segmentation of the spinal cord and intramedullary multiple sclerosis lesions with convolutional neural networks. arXiv:1805.06349](https://arxiv.org/pdf/1805.06349.pdf)
+- [Gros et al. Automatic segmentation of the spinal cord and intramedullary multiple sclerosis lesions with convolutional neural networks. Neuroimage 2019](https://www.sciencedirect.com/science/article/pii/S1053811918319578)
 
 #### Registration
 - [Cohen-Adad et al. Slice-by-slice regularized registration for spinal cord MRI: SliceReg. Proc ISMRM 2015](https://www.dropbox.com/s/v3bb3etbq4gb1l1/cohenadad_ismrm15_slicereg.pdf?dl=0)

--- a/unit_testing/test_deepseg_lesion.py
+++ b/unit_testing/test_deepseg_lesion.py
@@ -47,7 +47,7 @@ def test_segment():
 def test_intensity_normalization():
     data_in = np.random.rand(10, 10)
     min_out, max_out = 0.0, 2611.0
-    landmarks_lst = sorted(list(np.random.uniform(low=0.0, high=2611.0, size=(11,))))
+    landmarks_lst = sorted(list(np.random.uniform(low=500.0, high=2000.0, size=(11,), )))
 
     data_out = deepseg_lesion.apply_intensity_normalization_model(data_in, landmarks_lst)
 


### PR DESCRIPTION
## Done:

- Make test_deepseg_lesion.py::test_intensity_normalization stable by modifying the range of random numbers so that it never fails.
- Update reference of Gros et al.: replace arxiv with NIMG

Fixes #2312, Fixes #2322 