### PR TITLE
batch_processing.sh: QC report is now generated locally

### DIFF
--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -42,7 +42,7 @@ fi
 
 # QC folder
 if [[ -z "$SCT_BP_QC_FOLDER" ]]; then
-	SCT_BP_QC_FOLDER=~/qc_batch_processing
+	SCT_BP_QC_FOLDER=`pwd`/"qc_example_data"
 fi
 
 # Remove QC folder


### PR DESCRIPTION
When running batch_processing.sh, QC folder is saved under ~/qc. The problem is that ~/ is not shared between Docker and the Windows host, therefore users cannot easily open the QC.

The proposed solution is to save the QC locally, and ask users to run the batch_processing.sh once they are under the shared folder.

Fixes #2368
