### PR TITLE
Fixed creation of output folder and introduced new argparse class

### DIFF
--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -19,7 +19,7 @@ from skimage.measure import label
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
 
 import sct_utils as sct
 from sct_utils import extract_fname, printv, tmp_create
@@ -80,6 +80,7 @@ def get_parser():
         "-ofolder",
         help='Output folder (e.g. "./")',
         metavar=Metavar.folder,
+        action=ActionCreateFolder,
         default='./',
         required=False)
     optional.add_argument(

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -23,7 +23,7 @@ from skimage.feature import greycomatrix, greycoprops
 import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
 
 def get_parser():
     # Initialize the parser
@@ -85,6 +85,7 @@ def get_parser():
         "-ofolder",
         metavar=Metavar.folder,
         help='Output folder. Example: /my_texture/',
+        action=ActionCreateFolder,
         required=False,
         default=Param().path_results)
     optional.add_argument(

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -18,7 +18,7 @@ import os
 import sys
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
 
 import sct_utils as sct
 
@@ -79,6 +79,7 @@ def get_parser():
         "-ofolder",
         help='Output folder. Example: My_Output_Folder/ ',
         required=False,
+        action=ActionCreateFolder,
         metavar=Metavar.str,
         default=os.getcwd())
     optional.add_argument(

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -18,7 +18,7 @@ import sys
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
 
 
 def get_parser():
@@ -75,6 +75,7 @@ def get_parser():
         "-ofolder",
         metavar=Metavar.str,
         help='Output folder. Example: My_Output_Folder/ ',
+        action=ActionCreateFolder,
         default=os.getcwd())
     optional.add_argument(
         "-r",

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -23,7 +23,7 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
 
 
 def get_parser():
@@ -68,6 +68,7 @@ def get_parser():
         "-ofolder",
         metavar=Metavar.folder,
         help='Output folder. Example: My_Output_Folder/',
+        action=ActionCreateFolder,
         required=False)
     optional.add_argument(
         '-qc',

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -19,6 +19,36 @@ logger = logging.getLogger(__name__)
 # TODO: add test
 
 
+class ActionCreateFolder(argparse.Action):
+    """
+    Custom action: creates a new folder if it does not exist. If the folder
+    already exists, do nothing.
+
+    The action will strip off trailing slashes from the folder's name.
+    Source: https://argparse-actions.readthedocs.io/en/latest/
+    """
+    @staticmethod
+    def create_folder(folder_name):
+        """
+        Create a new directory if not exist. The action might throw
+        OSError, along with other kinds of exception
+        """
+        if not os.path.isdir(folder_name):
+            os.mkdir(folder_name)
+
+        folder_name = os.path.normpath(folder_name)
+        return folder_name
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if type(values) == list:
+            folders = list(map(self.create_folder, values))
+        else:
+            folders = self.create_folder(values)
+
+        # Add the attribute
+        setattr(namespace, self.dest, folders)
+
+
 class Metavar(Enum):
     """
     This class is used to display intuitive input types via the metavar field of argparse


### PR DESCRIPTION
With the passage of the old parser to Python's argparse, output folders now need to be created otherwise it crashes (see #2372). Instead of adding lines of code in the CLI everytime we need to create a folder, a new class `ActionCreateFolder` is now available in `spinalcordtoolbox.utils`, to create the folder when parsing input arguments.

Fixes #2372 