### PR TITLE
Fixed broken compatibility with sct_concat_transfo

### DIFF
--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -153,7 +153,7 @@ def get_parser():
         help='Affine transformation(s) listed in flag -w which should be inverted before being used. Note that this '
              'only concerns affine transformation (not warping fields). If you would like to use an inverse warping'
              'field, then directly input the inverse warping field in flag -w.',
-        nargs='+',
+        nargs='*',
         metavar=Metavar.file,
         default=[])
     optional.add_argument(


### PR DESCRIPTION
Due to the recent change in `sct_concat_transfo`'s CLIs, `sct_register_multimodal` broke. This PR fixes it.

Fixes #2381 
