### PR TITLE
Fixed wrong morphometric measures with anisotropic in-plane resolution

### DIFF
--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -85,7 +85,7 @@ sct_register_to_template -i t2.nii.gz -s t2_seg.nii.gz -l labels_vert.nii.gz -c 
 # Warp template without the white matter atlas (we don't need it at this point)
 sct_warp_template -d t2.nii.gz -w warp_template2anat.nii.gz -a 0
 # Compute cross-sectional area (and other morphometry measures) for each slice
-sct_process_segmentation -i t2_seg.nii.gz
+sct_process_segmentation -i t2_seg.nii.gz -qc "$SCT_BP_QC_FOLDER"
 # Compute cross-sectional area and average between C2 and C3 levels
 sct_process_segmentation -i t2_seg.nii.gz -vert 2:3 -o csa_c2c3.csv
 # Go back to root folder

--- a/spinalcordtoolbox/deepseg_gm/deepseg_gm.py
+++ b/spinalcordtoolbox/deepseg_gm/deepseg_gm.py
@@ -309,7 +309,7 @@ def segment_file(input_filename, output_filename,
     """
     nii_original = nipy.load_image(input_filename)
     pixdim = nii_original.header["pixdim"][3]
-    target_resample = "0.25x0.25x{:.5f}".format(pixdim)
+    target_resample = [0.25, 0.25, pixdim]
 
     nii_resampled = resampling.resample_nipy(nii_original, new_size=target_resample, new_size_type='mm',
                                              interpolation='linear', verbose=verbosity)
@@ -317,10 +317,10 @@ def segment_file(input_filename, output_filename,
     pred_slices = segment_volume(nii_resampled, model_name, threshold,
                                  use_tta)
 
-    original_res = "{:.5f}x{:.5f}x{:.5f}".format(
+    original_res = [
         nii_original.header["pixdim"][1],
         nii_original.header["pixdim"][2],
-        nii_original.header["pixdim"][3])
+        nii_original.header["pixdim"][3]]
 
     volume_affine = nii_resampled.affine
     volume_header = nii_resampled.header

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -10,10 +10,13 @@ import numpy as np
 from skimage import measure, transform
 from tqdm import tqdm
 import logging
+import nibabel
+from nipy.io.nifti_ref import nifti2nipy, nipy2nifti
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.aggregate_slicewise import Metric
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
+from spinalcordtoolbox.resampling import resample_nipy
 
 
 def compute_shape(segmentation, angle_correction=True, param_centerline=None, verbose=1):
@@ -39,12 +42,30 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
                      ]
 
     im_seg = Image(segmentation).change_orientation('RPI')
-
     # Getting image dimensions. x, y and z respectively correspond to RL, PA and IS.
     nx, ny, nz, nt, px, py, pz, pt = im_seg.dim
+    pr = min([px, py])
+    # Resample to isotropic resolution in the axial plane. Use the minimum pixel dimension as target dimension.
+    # Note: need to convert to nibabel, then nipy (input type of resample_nipy)
+    im_seg_nibabel = nibabel.nifti1.Nifti1Image(im_seg.data, im_seg.hdr.get_best_affine())
+    im_segr_nipy = resample_nipy(
+        nifti2nipy(im_seg_nibabel), new_size=[pr, pr, pz], new_size_type='mm', interpolation='linear')
+    # Convert back to Image type
+    im_segr_nibabel = nipy2nifti(im_segr_nipy)
+    im_segr = Image(im_segr_nibabel.get_data(), hdr=im_segr_nibabel.header, orientation='RPI', dim=im_segr_nibabel.header.get_data_shape())
+
+
+    # img = msct_image.Image(i.get_data(), hdr=i.header,
+    #  orientation="LPI",
+    #  dim=i.header.get_data_shape(),
+    # )
+
+
+    # Update dimensions from resampled image.
+    nx, ny, nz, nt, px, py, pz, pt = im_segr.dim
 
     # Extract min and max index in Z direction
-    data_seg = im_seg.data
+    data_seg = im_segr.data
     X, Y, Z = (data_seg > 0).nonzero()
     min_z_index, max_z_index = min(Z), max(Z)
 
@@ -54,7 +75,7 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
     if angle_correction:
         # compute the spinal cord centerline based on the spinal cord segmentation
         # here, param_centerline.minmax needs to be False because we need to retrieve the total number of input slices
-        _, arr_ctl, arr_ctl_der, fit_results = get_centerline(im_seg, param=param_centerline, verbose=verbose)
+        _, arr_ctl, arr_ctl_der, fit_results = get_centerline(im_segr, param=param_centerline, verbose=verbose)
     else:
         fit_results = None
 
@@ -62,7 +83,7 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
     for iz in tqdm(range(min_z_index, max_z_index + 1), unit='iter', unit_scale=False, desc="Compute shape analysis",
                    ascii=True, ncols=80):
         # Extract 2D patch
-        current_patch = im_seg.data[:, :, iz]
+        current_patch = im_segr.data[:, :, iz]
         if angle_correction:
             # Extract tangent vector to the centerline (i.e. its derivative)
             tangent_vect = np.array([arr_ctl_der[0][iz - min_z_index] * px,

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -54,13 +54,6 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
     im_segr_nibabel = nipy2nifti(im_segr_nipy)
     im_segr = Image(im_segr_nibabel.get_data(), hdr=im_segr_nibabel.header, orientation='RPI', dim=im_segr_nibabel.header.get_data_shape())
 
-
-    # img = msct_image.Image(i.get_data(), hdr=i.header,
-    #  orientation="LPI",
-    #  dim=i.header.get_data_shape(),
-    # )
-
-
     # Update dimensions from resampled image.
     nx, ny, nz, nt, px, py, pz, pt = im_segr.dim
 
@@ -72,12 +65,12 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
     # Initialize dictionary of property_list, with 1d array of nan (default value if no property for a given slice).
     shape_properties = {key: np.full_like(np.empty(nz), np.nan, dtype=np.double) for key in property_list}
 
+    fit_results = None
+
     if angle_correction:
         # compute the spinal cord centerline based on the spinal cord segmentation
         # here, param_centerline.minmax needs to be False because we need to retrieve the total number of input slices
         _, arr_ctl, arr_ctl_der, fit_results = get_centerline(im_segr, param=param_centerline, verbose=verbose)
-    else:
-        fit_results = None
 
     # Loop across z and compute shape analysis
     for iz in tqdm(range(min_z_index, max_z_index + 1), unit='iter', unit_scale=False, desc="Compute shape analysis",

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -309,8 +309,8 @@ class Slice(object):
         # If no reference image is provided, resample to specified resolution
         if image_ref is None:
             # Resample to px x p_resample x p_resample mm (orientation is SAL by convention in QC module)
-            img_r = resample_nipy(img, new_size=str(image.dim[4]) + 'x' + str(p_resample) + 'x' + str(p_resample),
-                                  new_size_type='mm', interpolation=dict_interp[type_img])
+            img_r = resample_nipy(img, new_size=[image.dim[4], p_resample, p_resample], new_size_type='mm',
+                                  interpolation=dict_interp[type_img])
         # Otherwise, resampling to the space of the reference image
         else:
             # Create nibabel object for reference image

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -28,7 +28,6 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
     Can deal with 2d, 3d or 4d image objects.
     :param img: nipy Image.
     :param new_size: list of float: Resampling factor, final dimension or resolution, depending on new_size_type.
-    TODO: implement as list.
     :param new_size_type: {'vox', 'factor', 'mm'}: Feature used for resampling. Examples:
       new_size=[128, 128, 90], new_size_type='vox' --> Resampling to a dimension of 128x128x90 voxels
       new_size=[2, 2, 2], new_size_type='factor' --> 2x isotropic upsampling
@@ -49,9 +48,6 @@ def resample_nipy(img, new_size=None, new_size_type=None, img_dest=None, interpo
         # Get dimensions of data
         p = img.header.get_zooms()
         shape = img.header.get_data_shape()
-
-        # parse input argument
-        new_size = new_size.split('x')
 
         if img.ndim == 4:
             new_size += ['1']  # needed because the code below is general, i.e., does not assume 3d input and uses img.shape
@@ -147,7 +143,7 @@ def resample_file(fname_data, fname_out, new_size, new_size_type, interpolation,
     else:
         nii_ref = None
 
-    nii_r = resample_nipy(nii, new_size, new_size_type, img_dest=nii_ref, interpolation=interpolation, verbose=verbose)
+    nii_r = resample_nipy(nii, new_size.split('x'), new_size_type, img_dest=nii_ref, interpolation=interpolation, verbose=verbose)
 
     # build output file name
     if fname_out == '':

--- a/unit_testing/create_test_data.py
+++ b/unit_testing/create_test_data.py
@@ -150,8 +150,7 @@ def dummy_segmentation(size_arr=(256, 256, 256), pixdim=(1, 1, 1), dtype=np.floa
     nii = nib.nifti1.Nifti1Image(data_rot_crop.astype('float32'), xform)
     # Create nipy object and resample to desired resolution
     nii_nipy = nifti2nipy(nii)
-    nii_nipy_r = resample_nipy(nii_nipy, new_size='x'.join([str(i) for i in pixdim]), new_size_type='mm',
-                               interpolation='linear', dtype=dtype)
+    nii_nipy_r = resample_nipy(nii_nipy, new_size=pixdim, new_size_type='mm', interpolation='linear', dtype=dtype)
     nii_r = nipy2nifti(nii_nipy_r)
     # Create Image object. Default orientation is LPI.
     # For debugging add .save() at the end of the command below

--- a/unit_testing/test_resampling.py
+++ b/unit_testing/test_resampling.py
@@ -66,7 +66,7 @@ def fake_4dimage_nipy():
 # noinspection 801,PyShadowingNames
 def test_nipy_resample_image_3d(fake_3dimage_nipy):
     """Test resampling with 3D nipy image"""
-    img_r = resampling.resample_nipy(fake_3dimage_nipy, new_size='2x2x1', new_size_type='factor', interpolation='nn')
+    img_r = resampling.resample_nipy(fake_3dimage_nipy, new_size=[2, 2, 1], new_size_type='factor', interpolation='nn')
     assert img_r.get_data().shape == (18, 18, 9)
     assert img_r.get_data()[8, 8, 4] == 1.0  # make sure there is no displacement in world coordinate system
     assert nipy2nifti(img_r).header.get_zooms() == (0.5, 0.5, 1.0)
@@ -85,7 +85,7 @@ def test_nipy_resample_image_3d_to_dest(fake_3dimage_nipy, fake_3dimage_nipy_big
 # noinspection 801,PyShadowingNames
 def test_nipy_resample_image_4d(fake_4dimage_nipy):
     """Test resampling with 4D nipy image"""
-    img_r = resampling.resample_nipy(fake_4dimage_nipy, new_size='2x2x1x1', new_size_type='factor', interpolation='nn')
+    img_r = resampling.resample_nipy(fake_4dimage_nipy, new_size=[2, 2, 1, 1], new_size_type='factor', interpolation='nn')
     assert img_r.get_data().shape == (18, 18, 9, 3)
     assert img_r.get_data()[8, 8, 4, 0] == 1.0  # make sure there is no displacement in world coordinate system
     assert img_r.get_data()[8, 8, 4, 1] == 0.0


### PR DESCRIPTION
If axial in-plane resolution is anisotropic, some shape morphometric measures, such as RL/AP diameter and orientation are wrong. 

This PR solves it by resampling the data to isotropic resolution (chooses the smallest pixel size between RL and AP dimension for target resolution) before computing shape morphometrics.

Also see: http://forum.spinalcordmri.org/t/sct-process-segmentation-is-mixing-up-diameter-rl-and-diameter-ap/135/3