### PR TITLE
Fixed q/sform on transformed image

### DIFF
--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -270,15 +270,8 @@ class Transform:
 
         # Copy affine matrix from destination space to make sure qform/sform are the same
         sct.printv("Copy affine matrix from destination space to make sure qform/sform are the same.", verbose)
-        im_dest = Image(fname_dest)
         im_src_reg = Image(fname_out)
-        # Copy q/sform and code
-        im_src_reg.hdr.set_qform(im_dest.hdr.get_qform())
-        im_src_reg.hdr._structarr['qform_code'] = im_dest.hdr._structarr['qform_code']
-        im_src_reg.hdr.set_sform(im_dest.hdr.get_sform())
-        im_src_reg.hdr._structarr['sform_code'] = im_dest.hdr._structarr['sform_code']
-
-        # re-save registered image
+        im_src_reg.copy_qform_from_ref(Image(fname_dest))
         im_src_reg.save(verbose=0)  # set verbose=0 to avoid warning message about rewriting file
 
         # 2. crop the resulting image using dimensions from the warping field

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -174,6 +174,9 @@ def main():
     # Save segmentation
     fname_seg = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_seg' +
                                              sct.extract_fname(fname_image)[2]))
+
+    # copy q/sform from input image to output segmentation
+    im_seg.copy_qform_from_ref(im_image)
     im_seg.save(fname_seg)
 
     if ctr_algo == 'viewer':

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -314,6 +314,18 @@ class Image(object):
         else:
             return deepcopy(self)
 
+    def copy_qform_from_ref(self, im_ref):
+        """
+        Copy qform and sform and associated codes from a reference Image object
+        :param im_ref:
+        :return:
+        """
+        # Copy q/sform and code
+        self.hdr.set_qform(im_ref.hdr.get_qform())
+        self.hdr._structarr['qform_code'] = im_ref.hdr._structarr['qform_code']
+        self.hdr.set_sform(im_ref.hdr.get_sform())
+        self.hdr._structarr['sform_code'] = im_ref.hdr._structarr['sform_code']
+
     def loadFromPath(self, path, verbose):
         """
         This function load an image from an absolute path using nibabel library


### PR DESCRIPTION
When applying `sct_apply_transfo`, the registered image and destination space did not have the same header. This was due to the way ANTs deals with q/sform. 

This PR fixes the problem by copying the q/sform and associated q/sform codes from the destination image to the registered image. Fixes #2398

This PR also copies the q/sform from the input image to the output segmentation in `sct_deepseg_sc`. Fixes #2106.