### PR TITLE
Fixed -setorient-data giving wrong results

### DIFF
--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -171,9 +171,6 @@ def main(args=None):
     else:
         fname_out = None
 
-    # Open file(s)
-    # im_in_list = [Image(fn) for fn in fname_in]
-
     # run command
     if arguments.concat is not None:
         dim = arguments.concat
@@ -262,11 +259,11 @@ def main(args=None):
     elif arguments.setorient is not None:
         sct.printv(fname_in[0])
         im_in = Image(fname_in[0])
-        im_out = [msct_image.change_orientation(im_in, arguments.setorient).save(fname_out)]
+        im_out = [msct_image.change_orientation(im_in, arguments.setorient)]
 
     elif arguments.setorient_data is not None:
         im_in = Image(fname_in[0])
-        im_out = [msct_image.change_orientation(im_in, arguments.setorient_data, data_only=True).save(fname_out)]
+        im_out = [msct_image.change_orientation(im_in, arguments.setorient_data, data_only=True)]
 
     elif arguments.split is not None:
         dim = arguments.split

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -266,7 +266,7 @@ def main(args=None):
 
     elif arguments.setorient_data is not None:
         im_in = Image(fname_in[0])
-        im_out = [msct_image.change_orientation(im_in, arguments.setorient_data, inverse=True).save(fname_out)]
+        im_out = [msct_image.change_orientation(im_in, arguments.setorient_data, data_only=True).save(fname_out)]
 
     elif arguments.split is not None:
         dim = arguments.split

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -888,6 +888,7 @@ def change_shape(im_src, shape, im_dst=None):
     im_dst.hdr = pair.header
     return im_dst
 
+
 def change_orientation(im_src, orientation, im_dst=None, inverse=False):
     """
     :return: an image with changed orientation
@@ -895,7 +896,9 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False):
     :param orientation: orientation string (SCT "from" convention)
     :param im_dst: destination image (can be the source image for in-place
                    operation, can be unset to generate one)
-
+    :param inverse: if you think backwards, use this to specify that you actually
+                    want to transform *from* the specified orientation, not *to*
+                    it.
     Notes:
 
     - the resulting image has no path member set

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -889,7 +889,7 @@ def change_shape(im_src, shape, im_dst=None):
     return im_dst
 
 
-def change_orientation(im_src, orientation, im_dst=None, inverse=False):
+def change_orientation(im_src, orientation, im_dst=None, inverse=False, data_only=False):
     """
     :return: an image with changed orientation
     :param im_src: source image
@@ -897,14 +897,16 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False):
     :param im_dst: destination image (can be the source image for in-place
                    operation, can be unset to generate one)
     :param inverse: if you think backwards, use this to specify that you actually
-                    want to transform *from* the specified orientation, not *to*
-                    it.
+                    want to transform *from* the specified orientation, not *to* it.
+    :param data_only: If you want to only permute the data, not the header. Only use if you know there is a problem
+                      with the native orientation of the input data.
     Notes:
 
     - the resulting image has no path member set
     - if the source image is < 3D, it is reshaped to 3D and the destination is 3D
     """
 
+    # TODO: make sure to cover all cases for setorient-data
     if len(im_src.data.shape) < 3:
         pass # Will reshape to 3D
     elif len(im_src.data.shape) == 3:
@@ -956,7 +958,6 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False):
     else:
         raise NotImplementedError()
 
-
     # Update header
 
     im_src_aff = im_src.hdr.get_best_affine()
@@ -965,9 +966,10 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False):
      im_src_data.shape)
     im_dst_aff = np.matmul(im_src_aff, aff)
 
-    im_dst.header.set_qform(im_dst_aff)
-    im_dst.header.set_sform(im_dst_aff)
-    im_dst.header.set_data_shape(data.shape)
+    if not data_only:
+        im_dst.header.set_qform(im_dst_aff)
+        im_dst.header.set_sform(im_dst_aff)
+        im_dst.header.set_data_shape(data.shape)
     im_dst.data = data
 
     return im_dst

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -186,6 +186,7 @@ class SlicerOneAxis(object):
 
        return self.im.data[self._slice(idx)]
 
+
 class SlicerMany(object):
     """
     Image*s* slicer utility class.
@@ -973,6 +974,7 @@ def change_orientation(im_src, orientation, im_dst=None, inverse=False, data_onl
     im_dst.data = data
 
     return im_dst
+
 
 def change_type(im_src, dtype, im_dst=None):
     """


### PR DESCRIPTION
The function `sct_image -setorient-data` was not effectively changing the orientation of the input data as expected. This PR fixes it by **not** changing the header when defining a destination orientation (it is only changing the data).

Fixes #2062