### PR TITLE
Corrected wrong slice information on QC output

### DIFF
--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -183,10 +183,20 @@ def _make_figure(metric, fit_results):
 
         ax = fig.add_subplot(313)
         ax.grid(True)
-        ax.plot(fit_results.data.zmean, fit_results.data.xmean, 'b.', label='_nolegend_')
-        ax.plot(fit_results.data.zref, fit_results.data.xfit, 'b')
-        ax.plot(fit_results.data.zmean, fit_results.data.ymean, 'r.', label='_nolegend_')
-        ax.plot(fit_results.data.zref, fit_results.data.yfit, 'r')
+        #find a way to condense the following lines
+        zmean_list, xmean_list, xfit_list, ymean_list, yfit_list, zref_list = [], [], [], [], [], []
+        for i, value in enumerate(fit_results.data.zref):
+            if value in z:
+                zmean_list.append(fit_results.data.zmean[i])
+                xmean_list.append(fit_results.data.xmean[i])
+                xfit_list.append(fit_results.data.xfit[i])
+                ymean_list.append(fit_results.data.ymean[i])
+                yfit_list.append(fit_results.data.yfit[i])
+                zref_list.append(fit_results.data.zref[i])
+        ax.plot(zmean_list, xmean_list, 'b.', label='_nolegend_')
+        ax.plot(zref_list, xfit_list, 'b')
+        ax.plot(zmean_list, ymean_list, 'r.', label='_nolegend_')
+        ax.plot(zref_list, yfit_list, 'r')
         ax.legend(['Fitted (RL)', 'Fitted (AP)'])
         ax.set_ylabel('Centerline [$vox$]')
     else:

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import, division
 
 import sys, os
+from matplotlib.ticker import MaxNLocator
 
 import sct_utils as sct
 from msct_parser import Parser
@@ -170,6 +171,7 @@ def _make_figure(metric, fit_results):
         ax.grid(True)
         ax.set_ylabel('CSA [$mm^2$]')
         ax.set_xticklabels([])
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
 
         ax = fig.add_subplot(312)
         ax.grid(True)
@@ -180,6 +182,7 @@ def _make_figure(metric, fit_results):
         ax.legend(['Rotation about AP axis', 'Rotation about RL axis'])
         ax.set_ylabel('Angle [$deg$]')
         ax.set_xticklabels([])
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
 
         ax = fig.add_subplot(313)
         ax.grid(True)
@@ -199,6 +202,7 @@ def _make_figure(metric, fit_results):
         ax.plot(zref_list, yfit_list, 'r')
         ax.legend(['Fitted (RL)', 'Fitted (AP)'])
         ax.set_ylabel('Centerline [$vox$]')
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
     else:
         ax = fig.add_subplot(111)
         ax.plot(z, csa, 'k')


### PR DESCRIPTION
At the moment, when outputting the QC report with script `sct_process_segmentation` and specifying a value for argument `-z`, the last graph always displays all slices rather than displaying the slices specified by argument `-z`. 

This PR corrects the slice information on the last (bottom) graph to only display the information related to the wanted slices. (fixes #2391 )

If the following commands are executed:
```
sct_download_data -d sct_testing_data
cd sct_testing_data/data/t2
sct_process_segmentation -i t2_seg_manual.nii.gz -z 2:5 -perslice 1 -qc qc-test
```
The following QC report is outputted:
![Screen Shot 2019-08-13 at 10 07 15 AM](https://user-images.githubusercontent.com/50307272/62948347-30ad4180-bdb2-11e9-8edd-2113d8cd2b06.png)

