### PR TITLE
Check if gcc is installed

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -97,7 +97,7 @@ function check_requirements() {
         if [[ ! $(which brew) ]]; then
           yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         fi
-        yes | sudo brew install gcc
+        yes | brew install gcc
         # check if gcc install ran properly
         gcc --version > /dev/null 2>&1  # run silently, then check output status
         if [[ $? ]]; then

--- a/install_sct
+++ b/install_sct
@@ -81,7 +81,7 @@ function fetch_os_type() {
 # Checks if the necessary tools for SCT are installed on the machine
 function check_requirements() {
 
-  echo "Checking requirements..."
+  echo; echo "Checking requirements..."
   # check curl
   if [[ ! $(which curl) && ! $(which wget) ]]; then
     die "ERROR: neither \"curl\" nor \"wget\" is installed. Please install either of them and restart SCT installation."
@@ -91,8 +91,8 @@ function check_requirements() {
   gcc --version > /dev/null 2>&1  # run silently, then check output status
   if [[ $? ]]; then
     if [[ $OS == "osx" ]]; then
-      echo -e "\nWARNING: \"gcc\" is not installed."
-      read -p 'Do you want to install \"gcc\" now? (accepting to install gcc will also install \"brew\" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
+      echo -e "WARNING: \"gcc\" is not installed."
+      read -p 'Do you want to install "gcc" now? (accepting to install "gcc" will also install "brew" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(which brew) ]]; then
           yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

--- a/install_sct
+++ b/install_sct
@@ -89,7 +89,7 @@ function check_requirements() {
 
   # check gcc
   gcc --version > /dev/null 2>&1  # run silently, then check output status
-  if [[ ! $? ]]; then
+  if [[ $? ]]; then
     if [[ $OS == "osx" ]]; then
       echo -e "\nWARNING: \"gcc\" is not installed."
       read -p 'Do you want to install \"gcc\" now? (accepting to install gcc will also install \"brew\" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL

--- a/install_sct
+++ b/install_sct
@@ -45,6 +45,38 @@ function die() {
   exit 1
 }
 
+function fetch_os_type() {
+  # Fetch OS type
+  if uname -a | grep -i darwin >/dev/null 2>&1; then
+    # OSX
+
+    # Fix for non-English Unicode systems on MAC
+    if [[ -z $LC_ALL ]]; then
+      export LC_ALL=en_US.UTF-8
+    fi
+
+    if [[ -z $LANG ]]; then
+      export LANG=en_US.UTF-8
+    fi
+
+    OS=osx
+    force_bashrc_loading
+  elif uname -a | grep -i linux >/dev/null 2>&1; then
+    if cat /etc/issue | grep -i centos | grep 6. 2>&1; then
+      # CentOS 6.X
+      OS=linux_centos6
+    elif cat /etc/issue | grep -i Red | grep 6. 2>&1; then
+      # RedHat 6.X
+      OS=linux_centos6
+    else
+      # Other Linux
+      OS=linux
+    fi
+  else
+    die "Sorry, the installer only supports Linux and OSX, quitting installer"
+  fi
+}
+
 function check_requirements() {
 
   if [[ ! $(which curl) && ! $(which wget) ]]; then
@@ -55,6 +87,20 @@ function check_requirements() {
     die "You need to install \"git\" before you can install the SPINALCORDTOOLBOX \n
 for installation instructions check: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 "
+  fi
+
+  if [[ ! $(which gcc) ]]; then
+    echo "Your OS: $OS"
+    if [[ $OS == "osx" ]]; then
+      read -p 'You need to install gcc before you can use the SPINALCORDTOOLBOX. Do you want to install gcc now? [y]es/[n]o: ' -r GCC_INSTALL
+      if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
+        brew install gcc
+      else
+        die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
+      fi
+    else 
+      die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
+    fi
   fi
 
 }
@@ -174,6 +220,7 @@ function usage() {
 # ========================================================================
 echo -e "\nWelcome to the SCT installer!"
 
+fetch_os_type
 check_requirements
 
 # Transform  long option "--long" into short option  "-l"
@@ -225,36 +272,6 @@ if [[ "x$SCT_INSTALL_TYPE" == "x" ]]; then
   else
     SCT_INSTALL_TYPE="package"
   fi
-fi
-
-# Fetch OS type
-if uname -a | grep -i darwin >/dev/null 2>&1; then
-  # OSX
-
-  # Fix for non-English Unicode systems on MAC
-  if [[ -z $LC_ALL ]]; then
-    export LC_ALL=en_US.UTF-8
-  fi
-
-  if [[ -z $LANG ]]; then
-    export LANG=en_US.UTF-8
-  fi
-
-  OS=osx
-  force_bashrc_loading
-elif uname -a | grep -i linux >/dev/null 2>&1; then
-  if cat /etc/issue | grep -i centos | grep 6. 2>&1; then
-    # CentOS 6.X
-    OS=linux_centos6
-  elif cat /etc/issue | grep -i Red | grep 6. 2>&1; then
-    # RedHat 6.X
-    OS=linux_centos6
-  else
-    # Other Linux
-    OS=linux
-  fi
-else
-  die "Sorry, the installer only supports Linux and OSX, quitting installer"
 fi
 
 # Define sh files, by default it will use unix shell

--- a/install_sct
+++ b/install_sct
@@ -81,33 +81,37 @@ function fetch_os_type() {
 # Checks if the necessary tools for SCT are installed on the machine
 function check_requirements() {
 
+  echo "Checking requirements..."
+  # check curl
   if [[ ! $(which curl) && ! $(which wget) ]]; then
-    die "Install \"curl\" OR \"wget\" before you can install the SPINALCORDTOOLBOX"
+    die "ERROR: neither \"curl\" nor \"wget\" is installed. Please install either of them and restart SCT installation."
   fi
 
+  # check git
   if [[ ! $(which git) ]]; then
-    die "You need to install \"git\" before you can install the SPINALCORDTOOLBOX \n
+    die "ERROR: \"git\" is not installed. Please install it and restart SCT installation.\n
 for installation instructions check: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 "
   fi
 
-  if [[ ! $(which gcc) ]]; then
+  # check gcc
+  gcc --version > /dev/null 2>&1  # run silently, then check output status
+  if [[ ! $? ]]; then
     if [[ $OS == "osx" ]]; then
-      echo -e "\nYou need to install gcc before you can use the SPINALCORDTOOLBOX."
-      read -p 'Do you want to install gcc now (accepting to install gcc will also install brew in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
+      echo -e "\nWARNING: \"gcc\" is not installed."
+      read -p 'Do you want to install \"gcc\" now? (accepting to install gcc will also install \"brew\" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(which brew) ]]; then
           yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         fi
         yes | brew install gcc
       else
-        die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
+        die "Please install \"gcc\" and restart SCT installation."
       fi
     else
-      die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
+      die "Please install \"gcc\" and restart SCT installation."
     fi
   fi
-
 }
 
 # Gets the shell rc file path

--- a/install_sct
+++ b/install_sct
@@ -90,7 +90,6 @@ for installation instructions check: https://git-scm.com/book/en/v2/Getting-Star
   fi
 
   if [[ ! $(which gcc) ]]; then
-    echo "Your OS: $OS"
     if [[ $OS == "osx" ]]; then
       read -p 'You need to install gcc before you can use the SPINALCORDTOOLBOX. Do you want to install gcc now? [y]es/[n]o: ' -r GCC_INSTALL
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then

--- a/install_sct
+++ b/install_sct
@@ -92,12 +92,17 @@ function check_requirements() {
   if [[ $? ]]; then
     if [[ $OS == "osx" ]]; then
       echo -e "WARNING: \"gcc\" is not installed."
-      read -p 'Do you want to install "gcc" now? (accepting to install "gcc" will also install "brew" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
+      read -p 'Do you want to install it now? (accepting to install "gcc" will also install "brew" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(which brew) ]]; then
           yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         fi
-        yes | brew install gcc
+        yes | sudo brew install gcc
+        # check if gcc install ran properly
+        gcc --version > /dev/null 2>&1  # run silently, then check output status
+        if [[ $? ]]; then
+          die "ERROR: Installation of \"gcc\" failed. Please contact SCT team for assistance."
+        fi
       else
         die "Please install \"gcc\" and restart SCT installation."
       fi

--- a/install_sct
+++ b/install_sct
@@ -89,7 +89,7 @@ function check_requirements() {
 
   # check gcc
   gcc --version > /dev/null 2>&1  # run silently, then check output status
-  if [[ $? ]]; then
+  if [[ $? -ne 0 ]]; then
     if [[ $OS == "osx" ]]; then
       echo -e "WARNING: \"gcc\" is not installed."
       read -p 'Do you want to install it now? (accepting to install "gcc" will also install "brew" in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
@@ -100,7 +100,7 @@ function check_requirements() {
         yes | brew install gcc
         # check if gcc install ran properly
         gcc --version > /dev/null 2>&1  # run silently, then check output status
-        if [[ $? ]]; then
+        if [[ $? -ne 0 ]]; then
           die "ERROR: Installation of \"gcc\" failed. Please contact SCT team for assistance."
         fi
       else

--- a/install_sct
+++ b/install_sct
@@ -87,13 +87,6 @@ function check_requirements() {
     die "ERROR: neither \"curl\" nor \"wget\" is installed. Please install either of them and restart SCT installation."
   fi
 
-  # check git
-  if [[ ! $(which git) ]]; then
-    die "ERROR: \"git\" is not installed. Please install it and restart SCT installation.\n
-for installation instructions check: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
-"
-  fi
-
   # check gcc
   gcc --version > /dev/null 2>&1  # run silently, then check output status
   if [[ ! $? ]]; then

--- a/install_sct
+++ b/install_sct
@@ -293,12 +293,6 @@ echo -e "\nSCT version ......... "$SCT_VERSION
 echo -e "Installation type ... "$SCT_INSTALL_TYPE
 echo -e "Operating system .... "$OS
 echo -e "Shell ............... "$THE_RC
-# Check if sudo
-if [[ $UID == 0 ]]; then
-  echo -e "sudo mode ........... 1"
-else
-  echo -e "sudo mode ........... 0"
-fi
 
 # If you do not want the crash reports question to be ask,
 # set ASK_REPORT_QUESTION at installation time like this:

--- a/install_sct
+++ b/install_sct
@@ -97,13 +97,13 @@ for installation instructions check: https://git-scm.com/book/en/v2/Getting-Star
       read -p 'Do you want to install gcc now (accepting to install gcc will also install brew in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(which brew) ]]; then
-          /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+          yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         fi
-        brew install gcc
+        yes | brew install gcc
       else
         die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
       fi
-    else 
+    else
       die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
     fi
   fi

--- a/install_sct
+++ b/install_sct
@@ -45,8 +45,9 @@ function die() {
   exit 1
 }
 
+# Fetches the OS type
+# @output: OS var is modified with the appropiate OS
 function fetch_os_type() {
-  # Fetch OS type
   if uname -a | grep -i darwin >/dev/null 2>&1; then
     # OSX
 
@@ -77,6 +78,7 @@ function fetch_os_type() {
   fi
 }
 
+# Checks if the necessary tools for SCT are installed on the machine
 function check_requirements() {
 
   if [[ ! $(which curl) && ! $(which wget) ]]; then
@@ -91,8 +93,12 @@ for installation instructions check: https://git-scm.com/book/en/v2/Getting-Star
 
   if [[ ! $(which gcc) ]]; then
     if [[ $OS == "osx" ]]; then
-      read -p 'You need to install gcc before you can use the SPINALCORDTOOLBOX. Do you want to install gcc now? [y]es/[n]o: ' -r GCC_INSTALL
+      echo -e "\nYou need to install gcc before you can use the SPINALCORDTOOLBOX."
+      read -p 'Do you want to install gcc now (accepting to install gcc will also install brew in case it is not installed already)? [y]es/[n]o: ' -r GCC_INSTALL
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
+        if [[ ! $(which brew) ]]; then
+          /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        fi
         brew install gcc
       else
         die "Install \"gcc\" before you can install the SPINALCORDTOOLBOX"
@@ -104,6 +110,7 @@ for installation instructions check: https://git-scm.com/book/en/v2/Getting-Star
 
 }
 
+# Gets the shell rc file path
 function get_shell_rc_path () {
     local RC_FILE_PATH=$HOME/.bashrc
     if [[ $(which zsh) ]]; then


### PR DESCRIPTION
Fixes: #2404 

## Change list

- Fetching the OS was refactored to be a function and is now called at the beginning of the script. Nice to check from the beginning on the requirements.

- Checks if `gcc` installed and ask the `osx` users if they want to install it right away. 
