### PR TITLE
Replaced sct.mv with shutil.copyfile for tmp space issue

### DIFF
--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -223,7 +223,7 @@ def main(args=None):
     sct.generate_output_file(os.path.join(path_tmp, "fmri" + param.suffix + '_params_X.nii'), os.path.join(path_out, file_data + param.suffix + '_params_X' + ext_data), squeeze_data=False, verbose=param.verbose)
     sct.generate_output_file(os.path.join(path_tmp, "fmri" + param.suffix + '_params_Y.nii'), os.path.join(path_out, file_data + param.suffix + '_params_Y' + ext_data), squeeze_data=False, verbose=param.verbose)
     shutil.copyfile(os.path.join(path_tmp, 'fmri_moco_params.tsv'), os.path.join(path_out + file_data + param.suffix + '_params.tsv'))
-    
+
     # Delete temporary files
     if param.remove_temp_files == 1:
         sct.printv('\nDelete temporary files...', param.verbose)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -222,8 +222,8 @@ def main(args=None):
     sct.generate_output_file(os.path.join(path_tmp, "fmri" + param.suffix + '_mean.nii'), os.path.join(path_out, file_data + param.suffix + '_mean' + ext_data), param.verbose)
     sct.generate_output_file(os.path.join(path_tmp, "fmri" + param.suffix + '_params_X.nii'), os.path.join(path_out, file_data + param.suffix + '_params_X' + ext_data), squeeze_data=False, verbose=param.verbose)
     sct.generate_output_file(os.path.join(path_tmp, "fmri" + param.suffix + '_params_Y.nii'), os.path.join(path_out, file_data + param.suffix + '_params_Y' + ext_data), squeeze_data=False, verbose=param.verbose)
-    sct.mv(os.path.join(path_tmp, 'fmri_moco_params.tsv'), os.path.join(path_out + file_data + param.suffix + '_params.tsv'))
-
+    shutil.copyfile(os.path.join(path_tmp, 'fmri_moco_params.tsv'), os.path.join(path_out + file_data + param.suffix + '_params.tsv'))
+    
     # Delete temporary files
     if param.remove_temp_files == 1:
         sct.printv('\nDelete temporary files...', param.verbose)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division
 
 import sys
 import os
+import shutil
 import time
 import math
 from tqdm import tqdm


### PR DESCRIPTION
Use copy instead of move for fmri_moco_params.tsv in sct_fmri_moco.py to avoid the below error when running in a Singularity container.

    Traceback (most recent call last):
      File "/opt/sct/scripts/sct_fmri_moco.py", line 452, in <module>
        main()
      File "/opt/sct/scripts/sct_fmri_moco.py", line 225, in main
        sct.mv(os.path.join(path_tmp, 'fmri_moco_params.tsv'), os.path.join(path_out + file_data + param.suffix + '_params.tsv'))
      File "/opt/sct/scripts/sct_utils.py", line 421, in mv
        os.rename(src, dst)
    OSError: [Errno 18] Invalid cross-device link: '/tmp/sct-20190821183953.774530-fmri_moco-kvn3v5rh/fmri_moco_params.tsv' -> './fmri_moco_params.tsv'

Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/2419

Tested and working for me.

