### PR TITLE
Compute cord length

### DIFF
--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -45,6 +45,7 @@ def get_parser():
 - eccentricity: Eccentricity of the ellipse that has the same second-moments as the spinal cord. The eccentricity is the ratio of the focal distance (distance between focal points) over the major axis length. The value is in the interval [0, 1). When it is 0, the ellipse becomes a circle.
 - orientation: angle (in degrees) between the AP axis of the spinal cord and the AP axis of the image
 - solidity: CSA(spinal_cord) / CSA_convex(spinal_cord). If perfect ellipse, it should be one. This metric is interesting for detecting non-convex shape (e.g., in case of strong compression)
+- length: Length of the segmentation, computed by summing the slice thickness (corrected for the centerline angle at each slice) across the specified superior-inferior region.
 """)
     parser.add_option(name='-i',
                       type_value='image_nifti',

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -38,6 +38,7 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
                      'eccentricity',
                      'orientation',
                      'solidity',
+                     'length'
                      ]
 
     im_seg = Image(segmentation).change_orientation('RPI')
@@ -108,6 +109,7 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
             # Add custom fields
             shape_property['angle_AP'] = angle_AP_rad * 180.0 / math.pi
             shape_property['angle_RL'] = angle_RL_rad * 180.0 / math.pi
+            shape_property['length'] = pz / (np.cos(angle_AP_rad) * np.cos(angle_RL_rad))
             # Loop across properties and assign values for function output
             for property_name in property_list:
                 shape_properties[property_name][iz] = shape_property[property_name]

--- a/unit_testing/test_process_seg.py
+++ b/unit_testing/test_process_seg.py
@@ -28,7 +28,7 @@ DEBUG = False  # Set to True to save images
 im_segs = [
     # test area
     (dummy_segmentation(size_arr=(32, 32, 5), debug=DEBUG),
-     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0, 'length': 5.0},
      {'angle_corr': False}),
     # test anisotropic pixel dim
     (dummy_segmentation(size_arr=(64, 32, 5), pixdim=(0.5, 1, 5), debug=DEBUG),
@@ -51,12 +51,12 @@ im_segs = [
     # test with angled spinal cord (neg angle)
     (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-30.0,
                         debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -30.0, 'angle_AP': 0.0},
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -30.0, 'angle_AP': 0.0, 'length': 23.15},
      {'angle_corr': True}),
     # test with AP angled spinal cord
     (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_AP=20.0,
                         debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 20.0},
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 20.0, 'length': 21.02},
      {'angle_corr': True}),
     # test with RL and AP angled spinal cord
     (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
@@ -98,7 +98,12 @@ def test_compute_shape(im_seg, expected, params):
         if 'slice' in params:
             obtained_value = float(metrics['area'].data[params['slice']])
         else:
-            obtained_value = float(np.mean(metrics[key].data))
+            if key == 'length':
+                # when computing length, sums values across slices
+                obtained_value = metrics[key].data.sum()
+            else:
+                # otherwise, average across slices
+                obtained_value = metrics[key].data.mean()
         # fetch expected_value
         if expected[key] is np.nan:
             assert math.isnan(obtained_value)


### PR DESCRIPTION
With the recent removal of `-p` in `sct_process_segmentation`, it was no more possible to measure cord length. This feature was removed because we (wrongly) thought it was not used, but [some users expressed interest](http://forum.spinalcordmri.org/t/computing-cord-length-in-v4-0-0/105) in having this feature back. 

This PR implements cord length computation as part of `sct_process_segmentation`.

In brief, the algorithm for computing cord length is to sum slice thickness (corrected for cord angle) across a specified number of slices (by default, all slices). A new column with label `SUM(length)` is now present in the output .csv file.

To test it:
~~~
sct_download_data -d sct_testing_data
cd sct_testing_data/t2
sct_process_segmentation -i t2_seg_manual.nii.gz -perslice 0
~~~