### PR TITLE
Fix index error and display fsleyes command

### DIFF
--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -132,7 +132,7 @@ def main(file_to_denoise, param, output_file_name) :
     sct.printv("total time: %s" % (time() - t))
     sct.printv("vol size", den.shape)
 
-    axial_middle = data.shape[2] / 2
+    axial_middle = int(data.shape[2] / 2)
 
     before = data[:, :, axial_middle].T
     after = den[:, :, axial_middle].T

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -81,7 +81,7 @@ def get_parser():
         "-v",
         help="Verbose. 0: nothing. 1: basic. 2: extended.",
         type=int,
-        default=0,
+        default=1,
         choices=(0, 1, 2))
 
     return parser

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -166,6 +166,9 @@ def main(file_to_denoise, param, output_file_name) :
     nib.save(img_denoise, output_file_name)
     nib.save(img_diff, file + '_difference' + ext)
 
+    sct.printv('\nDone! To view results, type:', param.verbose)
+    sct.printv('fsleyes ' + file_to_denoise + ' ' + output_file_name + ' & \n', param.verbose, 'info')
+
 
 # =======================================================================================================================
 # Start program


### PR DESCRIPTION
### Done:
- IndexError bug reported #2430. Now fixed.
- Display `fsleyes` command in terminal output:
```
Done! To view results, type:
fsleyes t2.nii.gz t2_denoised.nii.gz &
```
- Change the default value of `verbose`: set to 1 instead of 0.

Fixes #2430.

NB: We will be able to answer this issue: http://forum.spinalcordmri.org/t/sct-denoising-onlm-error-sct-version-4-0-2/157