### PR TITLE
Remove isolated voxels at the edge of the output segmentation

### DIFF
--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -167,9 +167,10 @@ def main():
 
     im_image = Image(fname_image)
     # note: below we pass im_image.copy() otherwise the field absolutepath becomes None after execution of this function
-    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp, im_labels_viewer, im_ctr = deep_segmentation_spinalcord(
-        im_image.copy(), contrast_type, ctr_algo=ctr_algo, ctr_file=manual_centerline_fname,
-        brain_bool=brain_bool, kernel_size=kernel_size, remove_temp_files=remove_temp_files, verbose=verbose)
+    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp, im_labels_viewer, im_ctr = \
+        deep_segmentation_spinalcord(im_image.copy(), contrast_type, ctr_algo=ctr_algo,
+                                     ctr_file=manual_centerline_fname, brain_bool=brain_bool, kernel_size=kernel_size,
+                                     remove_temp_files=remove_temp_files, verbose=verbose)
 
     # Save segmentation
     fname_seg = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_seg' +

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -220,7 +220,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
                             dim=im_viewer_r_nib.header.get_data_shape()).change_orientation(original_orientation)
 
     else:
-        im_image_res_labels_downsamp = None
+        im_viewer = None
 
     if verbose == 2:
         fname_res_ctr = sct.add_suffix(fname_orient, '_ctr')

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -12,7 +12,8 @@ from scipy.ndimage import distance_transform_edt
 import nibabel as nib
 
 from spinalcordtoolbox import resampling
-from spinalcordtoolbox.deepseg_sc.cnn_models import nn_architecture_seg, nn_architecture_ctr
+from .cnn_models import nn_architecture_seg, nn_architecture_ctr
+from .postprocessing import post_processing_volume_wise
 from spinalcordtoolbox.image import Image, empty_like, change_type, zeros_like
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 
@@ -200,104 +201,6 @@ def crop_image_around_centerline(im_in, ctr_in, crop_size):
 
     im_new.data = data_im_new
     return x_lst, y_lst, z_lst, im_new
-
-
-def _remove_extrem_holes(z_lst, end_z, start_z=0):
-    """Remove extrem holes from the list of holes so that we will not interpolate on the extrem slices."""
-    if start_z in z_lst:
-        while start_z in z_lst:
-            z_lst = z_lst[1:]
-            start_z += 1
-        if len(z_lst):
-            z_lst.pop(0)
-
-    if end_z in z_lst:
-        while end_z in z_lst:
-            z_lst = z_lst[:-1]
-            end_z -= 1
-
-    return z_lst
-
-
-def _list2range(lst):
-    tmplst = lst[:]
-    tmplst.sort()
-    start = tmplst[0]
-
-    currentrange = [start, start + 1]
-
-    for item in tmplst[1:]:
-        if currentrange[1] == item:  # contiguous
-            currentrange[1] += 1
-        else:  # new range start
-            yield list(currentrange)
-            currentrange = [item, item + 1]
-
-    yield list(currentrange)  # last range
-
-
-def _fill_z_holes(zz_lst, data, z_spaccing):
-    data_interpol = np.copy(data)
-
-    for z_hole_start, z_hole_end in list(_list2range(zz_lst)):
-        z_ref_start, z_ref_end = z_hole_start - 1, z_hole_end
-        slice_ref_start, slice_ref_end = data[:, :, z_ref_start], data[:, :, z_ref_end]
-
-        hole_cur_lst = list(range(z_hole_start, z_hole_end))
-        lenght_hole = len(hole_cur_lst) + 1
-        phys_lenght_hole = lenght_hole * z_spaccing
-
-        denom_interpolation = (lenght_hole + 1)
-
-        if phys_lenght_hole < 10:
-            logger.warning('Filling a hole in the segmentation around z_slice #:' + str(z_ref_start))
-
-            for idx_z, z_hole_cur in enumerate(hole_cur_lst):
-                num_interpolation = (lenght_hole - idx_z - 1) * slice_ref_start  # Contribution of the bottom ref slice
-                num_interpolation += (idx_z + 1) * slice_ref_end  # Contribution of the top ref slice
-
-                slice_interpolation = num_interpolation * 1. / denom_interpolation
-                slice_interpolation = (slice_interpolation > 0).astype(np.int)
-
-                data_interpol[:, :, z_hole_cur] = slice_interpolation
-
-    return data_interpol
-
-
-def _remove_blobs(data):
-    """Remove false positive blobs, likely occuring in brain sections."""
-    labeled_obj, num_obj = label(data)
-    if num_obj > 1:  # If there is more than one connected object
-        bigger_obj = (labeled_obj == (np.bincount(labeled_obj.flat)[1:].argmax() + 1))
-
-        data2clean = np.copy(data)
-
-        # remove blobs only above the bigger connected object
-        z_max = np.max(np.where(bigger_obj)[2])
-        data2clean[:, :, :z_max + 1] = 0
-
-        labeled_obj2clean, num_obj2clean = label(data2clean)
-        if num_obj2clean:  # If there is connected object above the biffer connected one
-            for obj_id in range(1, num_obj2clean + 1):
-                # if the blob has a volume < 10% of the bigger connected object, then remove it
-                if np.sum(labeled_obj2clean == obj_id) < 0.1 * np.sum(bigger_obj):
-                    sct.printv('Removing small objects above slice#' + str(z_max))
-                    data[np.where(labeled_obj2clean == obj_id)] = 0
-
-    return data
-
-
-def post_processing_volume_wise(im_in):
-    """Post processing function."""
-    data_in = im_in.data.astype(np.int)
-
-    data_in = _remove_blobs(data_in)
-
-    zz_zeros = [zz for zz in range(im_in.dim[2]) if 1 not in list(np.unique(data_in[:, :, zz]))]
-    zz_holes = _remove_extrem_holes(zz_zeros, im_in.dim[2] - 1, 0)
-    # filling z_holes, i.e. interpolate for z_slice not segmented
-    im_in.data = _fill_z_holes(zz_holes, data_in, im_in.dim[6]) if len(zz_holes) else data_in
-    return im_in
 
 
 def scan_slice(z_slice, model, mean_train, std_train, coord_lst, patch_shape, z_out_dim):

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -591,7 +591,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     im_seg_r.data[np.where(im_seg_r.data < thr)] = 0
 
     # post processing step to z_regularized
-    im_seg_r_postproc = post_processing_volume_wise(im_in=im_seg_r)
+    im_seg_r_postproc = post_processing_volume_wise(im_seg_r)
 
     # change data type
     im_seg_r_postproc.change_type(np.uint8)

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -114,9 +114,7 @@ def find_centerline(algo, image_fname, contrast_type, brain_bool, folder_output,
         im_labels = _call_viewer_centerline(Image(image_fname))
         im_centerline, arr_centerline, _, _ = get_centerline(im_labels, param=ParamCenterline())
         centerline_filename = sct.add_suffix(image_fname, "_ctr")
-        labels_filename = sct.add_suffix(image_fname, "_labels-centerline")
         im_centerline.save(centerline_filename)
-        im_labels.save(labels_filename)  # TODO: don't save them, instead, pass the image
 
     elif algo == 'file':
         centerline_filename = sct.add_suffix(image_fname, "_ctr")
@@ -141,7 +139,10 @@ def find_centerline(algo, image_fname, contrast_type, brain_bool, folder_output,
         im_split_lst = split_data(Image(centerline_filename), dim=2)
         im_split_lst[0].save(centerline_filename)
 
-    return fname_res, centerline_filename
+    if algo != 'viewer':
+        im_labels = None
+
+    return fname_res, centerline_filename, im_labels
 
 
 def scale_intensity(data, out_min=0, out_max=255):

--- a/spinalcordtoolbox/deepseg_sc/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_sc/postprocessing.py
@@ -114,11 +114,11 @@ def _remove_isolated_voxels_on_the_edge(im_seg, n_slices=5):
     # ... for the top slice
     if metrics['area'].data[ind_min] < np.median(metrics['area'].data[ind_min:n_slices]):
         im_seg.data[:, :, ind_min] = 0
-        logger.warning('Found isolated voxels on slice %d, Removing them'.format(ind_min))
+        logger.warning('Found isolated voxels on slice {}, Removing them'.format(ind_min))
     # ... for the bottom slice
     if metrics['area'].data[ind_max] < np.median(metrics['area'].data[ind_max-n_slices+1:ind_max+1]):
         im_seg.data[:, :, ind_max] = 0
-        logger.warning('Found isolated voxels on slice %d, Removing them'.format(ind_min))
+        logger.warning('Found isolated voxels on slice {}, Removing them'.format(ind_min))
     return im_seg
 
 

--- a/spinalcordtoolbox/deepseg_sc/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_sc/postprocessing.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# Deals with postprocessing on generated segmentation: remove outliers, fill holes, etc.
+
+
+import logging
+import numpy as np
+from scipy.ndimage.measurements import label
+
+logger = logging.getLogger(__name__)
+
+
+def _fill_z_holes(zz_lst, data, z_spaccing):
+    data_interpol = np.copy(data)
+
+    for z_hole_start, z_hole_end in list(_list2range(zz_lst)):
+        z_ref_start, z_ref_end = z_hole_start - 1, z_hole_end
+        slice_ref_start, slice_ref_end = data[:, :, z_ref_start], data[:, :, z_ref_end]
+
+        hole_cur_lst = list(range(z_hole_start, z_hole_end))
+        lenght_hole = len(hole_cur_lst) + 1
+        phys_lenght_hole = lenght_hole * z_spaccing
+
+        denom_interpolation = (lenght_hole + 1)
+
+        if phys_lenght_hole < 10:
+            logger.warning('Filling a hole in the segmentation around z_slice #:' + str(z_ref_start))
+
+            for idx_z, z_hole_cur in enumerate(hole_cur_lst):
+                num_interpolation = (lenght_hole - idx_z - 1) * slice_ref_start  # Contribution of the bottom ref slice
+                num_interpolation += (idx_z + 1) * slice_ref_end  # Contribution of the top ref slice
+
+                slice_interpolation = num_interpolation * 1. / denom_interpolation
+                slice_interpolation = (slice_interpolation > 0).astype(np.int)
+
+                data_interpol[:, :, z_hole_cur] = slice_interpolation
+
+    return data_interpol
+
+
+def _list2range(lst):
+    tmplst = lst[:]
+    tmplst.sort()
+    start = tmplst[0]
+
+    currentrange = [start, start + 1]
+
+    for item in tmplst[1:]:
+        if currentrange[1] == item:  # contiguous
+            currentrange[1] += 1
+        else:  # new range start
+            yield list(currentrange)
+            currentrange = [item, item + 1]
+
+    yield list(currentrange)  # last range
+
+
+def _remove_blobs(data):
+    """Remove false positive blobs, likely occuring in brain sections."""
+    labeled_obj, num_obj = label(data)
+    if num_obj > 1:  # If there is more than one connected object
+        bigger_obj = (labeled_obj == (np.bincount(labeled_obj.flat)[1:].argmax() + 1))
+
+        data2clean = np.copy(data)
+
+        # remove blobs only above the bigger connected object
+        z_max = np.max(np.where(bigger_obj)[2])
+        data2clean[:, :, :z_max + 1] = 0
+
+        labeled_obj2clean, num_obj2clean = label(data2clean)
+        if num_obj2clean:  # If there is connected object above the biffer connected one
+            for obj_id in range(1, num_obj2clean + 1):
+                # if the blob has a volume < 10% of the bigger connected object, then remove it
+                if np.sum(labeled_obj2clean == obj_id) < 0.1 * np.sum(bigger_obj):
+                    logger.info('Removing small objects above slice#' + str(z_max))
+                    data[np.where(labeled_obj2clean == obj_id)] = 0
+
+    return data
+
+
+def _remove_extrem_holes(z_lst, end_z, start_z=0):
+    """Remove extrem holes from the list of holes so that we will not interpolate on the extrem slices."""
+    if start_z in z_lst:
+        while start_z in z_lst:
+            z_lst = z_lst[1:]
+            start_z += 1
+        if len(z_lst):
+            z_lst.pop(0)
+
+    if end_z in z_lst:
+        while end_z in z_lst:
+            z_lst = z_lst[:-1]
+            end_z -= 1
+
+    return z_lst
+
+
+def post_processing_volume_wise(im_in):
+    """Post processing function."""
+    data_in = im_in.data.astype(np.int)
+
+    data_in = _remove_blobs(data_in)
+
+    zz_zeros = [zz for zz in range(im_in.dim[2]) if 1 not in list(np.unique(data_in[:, :, zz]))]
+    zz_holes = _remove_extrem_holes(zz_zeros, im_in.dim[2] - 1, 0)
+    # filling z_holes, i.e. interpolate for z_slice not segmented
+    im_in.data = _fill_z_holes(zz_holes, data_in, im_in.dim[6]) if len(zz_holes) else data_in
+    return im_in

--- a/spinalcordtoolbox/deepseg_sc/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_sc/postprocessing.py
@@ -76,7 +76,7 @@ def _remove_blobs(data):
             for obj_id in range(1, num_obj2clean + 1):
                 # if the blob has a volume < 10% of the bigger connected object, then remove it
                 if np.sum(labeled_obj2clean == obj_id) < 0.1 * np.sum(bigger_obj):
-                    logger.info('Removing small objects above slice#' + str(z_max))
+                    logger.warning('Removing small objects above slice #' + str(z_max))
                     data[np.where(labeled_obj2clean == obj_id)] = 0
 
     return data

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -30,13 +30,13 @@ def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
     input_resolution = gt.dim[4:7]
     del img, gt
 
-    fname_res, fname_ctr = deepseg_sc.find_centerline(algo='svm',
-                                                        image_fname=fname_t2_RPI,
-                                                        contrast_type=contrast_test,
-                                                        brain_bool=False,
-                                                        folder_output=tmp_folder_path,
-                                                        remove_temp_files=1,
-                                                        centerline_fname=None)
+    fname_res, fname_ctr, _ = deepseg_sc.find_centerline(algo='svm',
+                                                            image_fname=fname_t2_RPI,
+                                                            contrast_type=contrast_test,
+                                                            brain_bool=False,
+                                                            folder_output=tmp_folder_path,
+                                                            remove_temp_files=1,
+                                                            centerline_fname=None)
 
     fname_t2_seg_RPI_res = 'seg_RPI_res.nii.gz'
     new_resolution = 'x'.join(['0.5', '0.5', str(input_resolution[2])])


### PR DESCRIPTION
When using `sct_deepseg_sc`, sometimes the top and/or bottom segmented slice shows incomplete segmentation: only few isolated voxels have the value "1". This could create some issues later on, see for example #2435. 

In this PR, we implement a fix, which consists in computing the CSA across all slices, and checking if the extreme slices have a CSA that is 50% smaller than the median of the CSA on the previous slides. If it is, it will zero the slide.

Specific changes to this PR include:
- Now checking extreme segmented slices and remove isolated voxels (see description above). Fixes #2435
- Refactored `deepseg_sc.core` by creating a new file `deepseg_sc.postprocessing` that includes post-processing code. For clarity.

Note: this issue is similar to #1074 when using `sct_propseg`, for which a fix was also created. In the future, we could merge the two fixes to save lines of code.