### PR TITLE
Fixed shape mismatch during straightening

### DIFF
--- a/spinalcordtoolbox/centerline/nurbs.py
+++ b/spinalcordtoolbox/centerline/nurbs.py
@@ -945,7 +945,7 @@ class NURBS:
         param = np.linspace(x[0], x[-1], prec)
         P_x, P_y, P_z, P_x_d, P_y_d, P_z_d = self.compute_curve_from_parametrization(P, k, x, Nik, Nikp, param)
         centerline = Centerline(P_x, P_y, P_z, P_x_d, P_y_d, P_z_d)
-        distances_between_points = centerline.progressive_length
+        distances_between_points = centerline.progressive_length[1:]
         range_points = np.linspace(0.0, 1.0, prec)
         dist_curved = np.zeros(prec)
         for i in range(1, prec):


### PR DESCRIPTION
The function crashes during straightening. It only happens in isolated cases. The segmentation (see "steps to reproduce" below) looks OK: some irregularities on the derivatives, but no discontinuities.

This PR fixes #2443 by changing some indexing, as detailed [here](https://github.com/neuropoly/spinalcordtoolbox/issues/2443#issuecomment-532359342).

Other notable issues addressed in this PR:
TODO:
- the usage does not specify "nurbs" in -param algo_fitting, even though it seems to always use this algorithm regardless the input param. 
- When using -v 2, the straightening command does not pass the verbose info. The sct.run() should be replaced with python call.
- The [linear interpolation before running nurbs](https://github.com/neuropoly/spinalcordtoolbox/blob/master/spinalcordtoolbox/centerline/core.py#L135) is dysfunctional, because given that the smoothing window is null, it will [return the intput](https://github.com/neuropoly/spinalcordtoolbox/blob/master/spinalcordtoolbox/centerline/curve_fitting.py#L126) without interpolation. Instead, the function `numpy.interp` could be used if smooth=0.

### Steps to Reproduce

SCT version: 4.0.2
Download these data:
[T2_seg.nii.gz](https://github.com/neuropoly/spinalcordtoolbox/files/3616531/T2_seg.nii.gz)

Run:
~~~
sct_smooth_spinalcord -i T2_seg.nii.gz -s T2_seg.nii.gz -smooth 0 0 8 -r 0 -v 2
~~~
