### PR TITLE
Dropped support for El Capitan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
     - os: osx
       name: "OSX 10.12 (Sierra)"
       osx_image: xcode9.2
-    - os: osx
-      name: "OSX 10.11 (El Capitan)"
-      osx_image: xcode8
 
 install:
   - |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ procedures.
 
 The simplest way to install SCT is to do it via a stable release. First, download the [latest release](https://github.com/neuropoly/spinalcordtoolbox/releases). Major changes to each release are listed [here](CHANGES.md).
 
-N.B. We currently cover OS X (10.8+) and Debian/Ubuntu/Fedora/RedHat/CentOS platforms. If you have another OS, please see [Installation with Docker](#installation-with-docker).
+N.B. We currently cover OS X (10.12 and above) and Debian/Ubuntu/Fedora/RedHat/CentOS platforms. If you have another OS, please see [Installation with Docker](#installation-with-docker).
 
 If you have 10.7 or less, the only incompatibility is with ANTs, which you can compile on your station and then copy the binaries under SCT installation as explained [here](https://github.com/neuropoly/spinalcordtoolbox/wiki/binaries).
 


### PR DESCRIPTION
There was likely a change to Keras recently, and El Capitan is no more supported, as suggested by the recent [Travis fail](https://travis-ci.org/neuropoly/spinalcordtoolbox/jobs/586215576#L713).

In this PR we drop support to OSX <10.12 (i.e., El Capitan and older).

Fixes #2445