### PR TITLE
New script to concatenate b0 and dwi data

### DIFF
--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -110,6 +110,7 @@ def main(args=None):
     # Concatenate NIFTI files
     im_concat = concat_data(fname_in_list=arguments.i, dim=3, squeeze_data=False)
     im_concat.save(arguments.o)
+    sct.printv("Generated file: {}".format(arguments.o))
 
     # Concatenate bvals and bvecs
     bvals_concat = ''
@@ -132,13 +133,16 @@ def main(args=None):
         for i in (0, 1, 2):
             bvecs_concat[i] += ' '.join(str(v) for v in map(lambda n: '%.16f' % n, bvec[:, i]))
             bvecs_concat[i] += ' '
+    bvecs_concat = '\n'.join(str(v) for v in bvecs_concat)  # transform list into lines of strings
     # Write files
     new_f = open(arguments.obval, 'w')
     new_f.write(bvals_concat)
     new_f.close()
+    sct.printv("Generated file: {}".format(arguments.obval))
     new_f = open(arguments.obvec, 'w')
     new_f.write(bvecs_concat)
     new_f.close()
+    sct.printv("Generated file: {}".format(arguments.obvec))
 
 
 if __name__ == "__main__":

--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -24,8 +24,7 @@ import sct_utils as sct
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Concatenate b=0 scans with DWI time series and update the bvecs and bvals files. Note that you can"
-                    "concatenate more than two files (e.g.: b0 dwi1 dw2 dw3).",
+        description="Concatenate b=0 scans with DWI time series and update the bvecs and bvals files."
         formatter_class=SmartFormatter,
         add_help=None,
         prog=os.path.basename(__file__).strip(".py")
@@ -33,7 +32,7 @@ def get_parser():
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         '-i',
-        help="Input 4d files, separated by space, listed in the right order of concatenation. Example: b0.nii dmri.nii",
+        help="Input 4d files, separated by space, listed in the right order of concatenation. Example: b0.nii dmri1.nii dmri2.nii",
         nargs='+',
         metavar=Metavar.file,
         required=True,
@@ -54,7 +53,7 @@ def get_parser():
     )
     mandatory.add_argument(
         '-order',
-        help="Order of b=0 and DWI files entered in flag '-i', separated by space. Example: b0 dwi",
+        help="Order of b=0 and DWI files entered in flag '-i', separated by space. Example: b0 dwi dwi",
         nargs='+',
         choices=['b0', 'dwi'],
         metavar=Metavar.str,

--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -13,9 +13,13 @@ from __future__ import absolute_import
 import os
 import sys
 import argparse
+import numpy as np
+
+from dipy.data.fetcher import read_bvals_bvecs
+from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.image import Image, concat_data
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
 
 
 def get_parser():
@@ -24,42 +28,63 @@ def get_parser():
                     "concatenate more than two files (e.g.: b0 dwi1 dw2 dw3).",
         formatter_class=SmartFormatter,
         add_help=None,
-        prog=os.path.basename(__file__).strip(".py"))
+        prog=os.path.basename(__file__).strip(".py")
+    )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         '-i',
         help="Input 4d files, separated by space, listed in the right order of concatenation. Example: b0.nii dmri.nii",
         nargs='+',
         metavar=Metavar.file,
-        required=True)
+        required=True,
+    )
     mandatory.add_argument(
         '-bval',
-        help="Bvals file. Example: bvals.txt",
+        help="Bvals file(s). Example: bvals.txt",
+        nargs='+',
         metavar=Metavar.file,
-        required=True)
+        required=True,
+    )
     mandatory.add_argument(
         '-bvec',
-        help="Bvecs file. Example: bvecs.txt",
+        help="Bvecs file(s). Example: bvecs.txt",
+        nargs='+',
         metavar=Metavar.file,
-        required=True)
+        required=True,
+    )
+    mandatory.add_argument(
+        '-order',
+        help="Order of b=0 and DWI files entered in flag '-i', separated by space. Example: b0 dwi",
+        nargs='+',
+        choices=['b0', 'dwi'],
+        metavar=Metavar.str,
+        required=True,
+    )
     mandatory.add_argument(
         '-o',
         help="Output 4d concatenated file. Example: b0_dmri_concat.nii",
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+        required=True,
+    )
     mandatory.add_argument(
         '-obval',
         help="Output concatenated bval file. Example: bval_concat.txt",
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+        required=True,
+    )
     mandatory.add_argument(
         '-obvec',
         help="Output concatenated bvec file. Example: bvec_concat.txt",
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+        required=True,
+    )
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         '-h',
         '--help',
         action='help',
-        help="Show this help message and exit")
+        help="Show this help message and exit",
+    )
 
     return parser
 
@@ -76,8 +101,44 @@ def main(args=None):
     parser = get_parser()
     arguments = parser.parse_args(args=args)
 
-    # Open files and concatenate
-    # Save files
+    # check number of input args
+    if not len(arguments.i) == len(arguments.order):
+        raise Exception("Number of items between flags '-i' and '-order' should be the same.")
+    if not len(arguments.bval) == len(arguments.bvec):
+        raise Exception("Number of files for bval and bvec should be the same.")
+
+    # Concatenate NIFTI files
+    im_concat = concat_data(fname_in_list=arguments.i, dim=3, squeeze_data=False)
+    im_concat.save(arguments.o)
+
+    # Concatenate bvals and bvecs
+    bvals_concat = ''
+    bvecs_concat = ['', '', '']
+    i_dwi = 0  # counter for DWI files, to read in bvec/bval files
+    for i_item in range(len(arguments.order)):
+        if arguments.order[i_item] == 'b0':
+            # count number of b=0
+            n_b0 = Image(arguments.i[i_item]).dim[3]
+            bval = np.array([0.0] * n_b0)
+            bvec = np.array([[0.0, 0.0, 0.0]] * n_b0)
+        elif arguments.order[i_item] == 'dwi':
+            # read bval/bvec files
+            bval, bvec = read_bvals_bvecs(arguments.bval[i_dwi], arguments.bvec[i_dwi])
+            i_dwi += 1
+        # Concatenate bvals
+        bvals_concat += ' '.join(str(v) for v in bval)
+        bvals_concat += ' '
+        # Concatenate bvecs
+        for i in (0, 1, 2):
+            bvecs_concat[i] += ' '.join(str(v) for v in map(lambda n: '%.16f' % n, bvec[:, i]))
+            bvecs_concat[i] += ' '
+    # Write files
+    new_f = open(arguments.obval, 'w')
+    new_f.write(bvals_concat)
+    new_f.close()
+    new_f = open(arguments.obvec, 'w')
+    new_f.write(bvecs_concat)
+    new_f.close()
 
 
 if __name__ == "__main__":

--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Merge b=0 and dMRI data and output appropriate bvecs/bvals files.
+#
+# Copyright (c) 2019 Polytechnique Montreal <www.neuro.polymtl.ca>
+# Author: Julien Cohen-Adad
+#
+# About the license: see the file LICENSE.TXT
+
+
+from __future__ import absolute_import
+
+import os
+import sys
+import argparse
+
+import sct_utils as sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Concatenate b=0 scans with DWI time series and update the bvecs and bvals files. Note that you can"
+                    "concatenate more than two files (e.g.: b0 dwi1 dw2 dw3).",
+        formatter_class=SmartFormatter,
+        add_help=None,
+        prog=os.path.basename(__file__).strip(".py"))
+    mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
+    mandatory.add_argument(
+        '-i',
+        help="Input 4d files, separated by space, listed in the right order of concatenation. Example: b0.nii dmri.nii",
+        nargs='+',
+        metavar=Metavar.file,
+        required=True)
+    mandatory.add_argument(
+        '-bval',
+        help="Bvals file. Example: bvals.txt",
+        metavar=Metavar.file,
+        required=True)
+    mandatory.add_argument(
+        '-bvec',
+        help="Bvecs file. Example: bvecs.txt",
+        metavar=Metavar.file,
+        required=True)
+    mandatory.add_argument(
+        '-o',
+        help="Output 4d concatenated file. Example: b0_dmri_concat.nii",
+        metavar=Metavar.file)
+    mandatory.add_argument(
+        '-obval',
+        help="Output concatenated bval file. Example: bval_concat.txt",
+        metavar=Metavar.file)
+    mandatory.add_argument(
+        '-obvec',
+        help="Output concatenated bvec file. Example: bvec_concat.txt",
+        metavar=Metavar.file)
+    optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
+    optional.add_argument(
+        '-h',
+        '--help',
+        action='help',
+        help="Show this help message and exit")
+
+    return parser
+
+
+def main(args=None):
+    """
+    Main function
+    :param args:
+    :return:
+    """
+    # get parser args
+    if args is None:
+        args = None if sys.argv[1:] else ['--help']
+    parser = get_parser()
+    arguments = parser.parse_args(args=args)
+
+    # Open files and concatenate
+    # Save files
+
+
+if __name__ == "__main__":
+    sct.init_sct()
+    # call main function
+    main()

--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -24,7 +24,7 @@ import sct_utils as sct
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Concatenate b=0 scans with DWI time series and update the bvecs and bvals files."
+        description="Concatenate b=0 scans with DWI time series and update the bvecs and bvals files.",
         formatter_class=SmartFormatter,
         add_help=None,
         prog=os.path.basename(__file__).strip(".py")

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -417,6 +417,7 @@ def get_functions_parallelizable():
         'sct_dice_coefficient',
         'sct_detect_pmj',
         'sct_dmri_compute_dti',
+        'sct_dmri_concat_b0_and_dwi',
         'sct_dmri_concat_bvals',
         'sct_dmri_concat_bvecs',
         'sct_dmri_create_noisemask',

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -789,6 +789,69 @@ def compute_dice(image1, image2, mode='3d', label=1, zboundaries=False):
     return dice
 
 
+def concat_data(fname_in_list, dim, pixdim=None, squeeze_data=False):
+    """
+    Concatenate data
+    :param im_in_list: list of Images or image filenames
+    :param dim: dimension: 0, 1, 2, 3.
+    :param pixdim: pixel resolution to join to image header
+    :param squeeze_data: bool: if True, remove the last dim if it is a singleton.
+    :return im_out: concatenated image
+    """
+    # WARNING: calling concat_data in python instead of in command line causes a non-understood issue (results are
+    # different with both options) from numpy import concatenate, expand_dims
+
+    dat_list = []
+    data_concat_list = []
+
+    for i, fname in enumerate(fname_in_list):
+        # if there is more than 100 images to concatenate, then it does it iteratively to avoid memory issue.
+        if i != 0 and i % 100 == 0:
+            data_concat_list.append(np.concatenate(dat_list, axis=dim))
+            im = Image(fname)
+            dat = im.data
+            # if image shape is smaller than asked dim, then expand dim
+            if len(dat.shape) <= dim:
+                dat = np.expand_dims(dat, dim)
+            dat_list = [dat]
+            del im
+            del dat
+        else:
+            im = Image(fname)
+            dat = im.data
+            # if image shape is smaller than asked dim, then expand dim
+            if len(dat.shape) <= dim:
+                dat = np.expand_dims(dat, dim)
+            dat_list.append(dat)
+            del im
+            del dat
+    if data_concat_list:
+        data_concat_list.append(np.concatenate(dat_list, axis=dim))
+        data_concat = np.concatenate(data_concat_list, axis=dim)
+    else:
+        data_concat = np.concatenate(dat_list, axis=dim)
+    # write file
+    im_out = empty_like(Image(fname_in_list[0]))
+    im_out.data = data_concat
+    if isinstance(fname_in_list[0], str):
+        im_out.absolutepath = sct.add_suffix(fname_in_list[0], '_concat')
+    else:
+        if fname_in_list[0].absolutepath:
+            im_out.absolutepath = sct.add_suffix(fname_in_list[0].absolutepath, '_concat')
+
+    if pixdim is not None:
+        im_out.hdr['pixdim'] = pixdim
+
+    if squeeze_data and data_concat.shape[dim] == 1:
+        # remove the last dim if it is a singleton.
+        im_out.data = data_concat.reshape(
+            tuple([x for (idx_shape, x) in enumerate(data_concat.shape) if idx_shape != dim]))
+    else:
+        im_out.data = data_concat
+
+    return im_out
+
+
 def find_zmin_zmax(im, threshold=0.1):
     """
     Find the min (and max) z-slice index below which (and above which) slices only have voxels below a given threshold.

--- a/testing/test_sct_dmri_concat_b0_and_dwi.py
+++ b/testing/test_sct_dmri_concat_b0_and_dwi.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Test function for sct_dmri_concat_b0_and_dwi
+#
+# Copyright (c) 2019 Polytechnique Montreal <www.neuro.polymtl.ca>
+# Author: Julien Cohen-Adad
+#
+# About the license: see the file LICENSE.TXT
+
+
+def init(param_test):
+    """
+    Initialize class: param_test
+    """
+    # initialization
+    default_args = ['-i dmri_T0000.nii.gz dmri.nii.gz -bvec bvecs.txt -bval bvals.txt -order b0 dwi '
+                    '-o b0_dwi_concat.nii -obval bvals_concat.txt -obvec bvecs_concat.txt']
+    # assign default params
+    if not param_test.args:
+        param_test.args = default_args
+    return param_test
+
+
+def test_integrity(param_test):
+    """
+    Test integrity of function
+    """
+    param_test.output += '\nNot implemented.'
+    return param_test

--- a/testing/test_sct_dmri_concat_b0_and_dwi.py
+++ b/testing/test_sct_dmri_concat_b0_and_dwi.py
@@ -13,8 +13,8 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i dmri_T0000.nii.gz dmri.nii.gz -bvec bvecs.txt -bval bvals.txt -order b0 dwi '
-                    '-o b0_dwi_concat.nii -obval bvals_concat.txt -obvec bvecs_concat.txt']
+    default_args = ['-i dmri/dmri_T0000.nii.gz dmri/dmri.nii.gz -bvec dmri/bvecs.txt -bval dmri/bvals.txt '
+                    '-order b0 dwi -o b0_dwi_concat.nii -obval bvals_concat.txt -obvec bvecs_concat.txt']
     # assign default params
     if not param_test.args:
         param_test.args = default_args


### PR DESCRIPTION
As of now, if users have separate b=0 scans, they have to concatenate them manually, then update bvals/bvecs files manually. This PR introduces the new function `sct_dmri_concat_b0_and_dwi`, which does the following:
- Input: FILE(s): b0, dwi, FILE: bvecs, FILE: bvals
- Output: FILE: b0_dwi, FILE: bvecs_concat, FILE: bvals_concat

Other changes:
- Refactoring: moved `sct_image.concat_data()` --> `spinalcordtoolbox/image.concat_data()`
- Added test for this new function

Fixes #2451 