### PR TITLE
QC report: Fixed shift along slice direction between image and overlay

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -255,6 +255,12 @@ class Image(object):
         else:
             raise TypeError('Image constructor takes at least one argument.')
 
+        # TODO: In the future, we might want to check qform_code and enforce its value. Related to #2454
+        # Check qform_code
+        # if not self.hdr['qform_code'] in [0, 1]:
+        #     # Set to 0 (unknown)
+        #     self.hdr.set_qform(self.hdr.get_qform(), code=0)
+        #     self.header.set_qform(self.hdr.get_qform(), code=0)
 
     @property
     def dim(self):

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -55,7 +55,7 @@ class Slice(object):
                 else:
                     # Otherwise it's an image: use spline interpolation
                     type_img = 'im'
-                img_r = self._resample(img, p_resample, type_img=type_img, image_ref=image_ref)
+                img_r = self._resample_slicewise(img, p_resample, type_img=type_img, image_ref=image_ref)
             else:
                 img_r = img.copy()
             self._images.append(img_r)
@@ -291,7 +291,7 @@ class Slice(object):
     def aspect(self):
         return [self.get_aspect(x) for x in self._images]
 
-    def _resample(self, image, p_resample, type_img, image_ref=None):
+    def _resample_slicewise(self, image, p_resample, type_img, image_ref=None):
         """
         Resample at a fixed resolution to make sure the cord always appears with similar scale, regardless of the native
         resolution of the image. Assumes SAL orientation.

--- a/spinalcordtoolbox/resampling.py
+++ b/spinalcordtoolbox/resampling.py
@@ -84,8 +84,9 @@ def resample_nib(img, new_size=None, new_size_type=None, img_dest=None, interpol
         reference = img_dest
 
     if img.ndim == 3:
+        # we use mode 'nearest' to overcome issue #2453
         img_r = resample_from_to(
-            img, to_vox_map=reference, order=dict_interp[interpolation], mode='constant', cval=0.0, out_class=None)
+            img, to_vox_map=reference, order=dict_interp[interpolation], mode='nearest', cval=0.0, out_class=None)
 
     elif img.ndim == 4:
         # TODO: Cover img_dest with 4D volumes


### PR DESCRIPTION
### Description

Sometimes, the QC report shows an overlay which is shifter by one slice compared to the background image, as illustrated below:
![Screen Shot 2019-09-23 at 5 23 47 PM](https://user-images.githubusercontent.com/2482071/65464115-1fcb0380-de27-11e9-965e-e58352352182.png)

To reproduce:
SCT commit 6cd471ae1c153c71d51ad0c8c808082cd4e1e756
Data:  [data_issue2453.zip](https://github.com/neuropoly/spinalcordtoolbox/files/3653640/data_issue2453.zip)

Syntax:
~~~
sct_qc -i PAM50_t1_reg.nii.gz -p sct_register_multimodal -s sub-amu01_acq-T1w_MTS_seg.nii.gz -d sub-amu01_acq-T1w_MTS_crop.nii.gz
~~~

The problem is rooted in the resampling method, which works by applying an affine transformation matrix to an input image (from nibabel's code). What has likely happened in this issue (and similar issues), is that sometimes there are imprecision in the qform matrix, yielding a slight rotation of the image upon interpolation, even though in this case, the slice resolution was not changed (i.e. S-I direction). If that happens, the edge slices are replaced with "zero", as specified by the default mode=constant of the interpolation. This can be fixed by choosing another interpolation mode.

### Proposed solution

The issue was fixed by changing resampling mode from `constant` to `nearest`.

Fixes #2453, Related to #2454 
