### PR TITLE
Better management of CLI syntax in case mandatory arguments are missing

### DIFF
--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -46,10 +46,13 @@ def get_parser():
     mandatory_arguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory_arguments.add_argument(
         "-m",
+        required=True,
         help='Binary mask of lesions (lesions are labeled as "1").',
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+    )
     mandatory_arguments.add_argument(
         "-s",
+        required=True,
         help="Spinal cord centerline or segmentation file, which will be used to correct morphometric measures with "
              "cord angle with respect to slice. (e.g.'t2_seg.nii.gz')",
         metavar=Metavar.file)

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -39,7 +39,7 @@ def get_parser():
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py")
     )
-    
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-i",

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -39,17 +39,21 @@ def get_parser():
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py")
     )
+    
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-i",
-        metavar=Metavar.file,
+        required=True,
         help='Image to analyze. Example: t2.nii.gz',
-        required=False)
+        metavar=Metavar.file,
+    )
     mandatoryArguments.add_argument(
         "-m",
+        required=True,
         metavar=Metavar.file,
         help='Image mask Example: t2_seg.nii.gz',
-        required=False)
+    )
+
     optional = parser.add_argument_group("\nOPTIONALS ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -49,18 +49,24 @@ def get_parser():
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-i",
+        required=True,
         help='Input image. Example: t2.nii.gz',
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+    )
     mandatoryArguments.add_argument(
         "-d",
+        required=True,
         help='Destination image. Example: out.nii.gz',
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+    )
     mandatoryArguments.add_argument(
         "-w",
+        nargs='+',
+        required=True,
         help='Transformation(s), which can be warping fields (nifti image) or affine transformation matrix (text '
              'file). Separate with space. Example: warp1.nii.gz warp2.nii.gz',
-        nargs='+',
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+    )
 
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -81,13 +81,16 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-tr",
         type=float,
+        required=True,
         help='Value of TR (in ms) to get the Ernst Angle. Example: 2000',
         metavar=Metavar.float,
-        required=False)
+    )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -441,12 +441,15 @@ def get_parser():
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py")
     )
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-i",
+        required=True,
         help='First Image on which you want to find the skeleton Example: t2star_manual_gmseg.nii.gz',
         metavar=Metavar.file,
-        required=False)
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_compute_mscc.py
+++ b/scripts/sct_compute_mscc.py
@@ -39,21 +39,24 @@ def get_parser():
     mandatoryArguments.add_argument(
         '-di',
         type=float,
+        required=True,
         help='Anteroposterior cord distance (in mm) at the level of maximum injury. Example: 6.85',
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         '-da',
         type=float,
+        required=True,
         help='Anteroposterior cord distance (in mm) at the nearest normal level above the level of injury.',
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         '-db',
         type=float,
+        required=True,
         help='Anteroposterior cord distance (in mm) at the nearest normal level below the level of injury.',
         metavar=Metavar.float,
-        required=False)
+        )
 
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -29,17 +29,21 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         '-mt0',
+        required=True,
         help='Image without MT pulse (MT0)',
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         '-mt1',
+        required=True,
         help='Image with MT pulse (MT1)',
         metavar=Metavar.float,
-        required=False)
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -38,58 +38,69 @@ def get_parser():
         formatter_class=SmartFormatter,
         prog= os.path.basename(__file__).strip(".py")
     )
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-mt",
+        required=True,
         help="Image with MT_ON",
         metavar=Metavar.file,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-pd",
+        required=True,
         help="Image PD weighted (typically, the MT_OFF)",
         metavar=Metavar.file,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-t1",
+        required=True,
         help="Image T1-weighted",
         metavar=Metavar.file,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-trmt",
+        required=True,
         help="TR [in ms] for mt image.",
         type=float,
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-trpd",
+        required=True,
         help="TR [in ms] for pd image.",
         type=float,
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-trt1",
+        required=True,
         help="TR [in ms] for t1 image.",
         type=float,
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-famt",
+        required=True,
         help="Flip angle [in deg] for mt image.",
         type=float,
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-fapd",
+        required=True,
         help="Flip angle [in deg] for pd image.",
         type=float,
         metavar=Metavar.float,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-fat1",
+        required=True,
         help="Flip angle [in deg] for t1 image.",
         type=float,
         metavar=Metavar.float,
-        required=False)
+        )
+
     optional = parser.add_argument_group('\nOPTIONAL ARGUMENTS')
     optional.add_argument(
         "-h",

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -42,12 +42,14 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         '-i',
+        required=True,
         help='4D data to compute the SNR on (along the 4th dimension). Example: b0s.nii.gz',
-        required=False,
         metavar=Metavar.file)
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -138,15 +138,18 @@ def get_parser():
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-d",
+        required=True,
         help='Destination image. (e.g. "mt.nii.gz")',
         metavar=Metavar.file,
-        required=False)
+        )
     mandatoryArguments.add_argument(
         "-w",
+        required=True,
         help='Transformation(s), which can be warping fields (nifti image) or affine transformation matrix (text '
              'file). Separate with space. Example: warp1.nii.gz warp2.nii.gz',
         nargs='+',
         metavar=Metavar.file)
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-winv",

--- a/scripts/sct_convert.py
+++ b/scripts/sct_convert.py
@@ -40,17 +40,21 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-i",
+        required=True,
         help='File input. Example: data.nii.gz',
         metavar=Metavar.file,
-        required=True)
+        )
     mandatoryArguments.add_argument(
         "-o",
+        required=True,
         help='File output (indicate new extension). Example: data.nii',
         metavar=Metavar.str,
-        required=True)
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -50,6 +50,78 @@ class Param:
         self.offset = '0,0'
 
 
+def get_parser():
+    # Initialize default parameters
+    param_default = Param()
+    # Initialize the parser
+
+    parser = argparse.ArgumentParser(
+        description='Create mask along z direction.',
+        add_help=None,
+        prog=os.path.basename(__file__).strip(".py"),
+        formatter_class= SmartFormatter)
+
+    mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
+    mandatoryArguments.add_argument(
+        '-i',
+        required=True,
+        help='Image to create mask on. Only used to get header. Must be 3D. Example: data.nii.gz',
+        metavar=Metavar.file,
+        )
+    mandatoryArguments.add_argument(
+        '-p',
+        default=param_default.process
+        required=True,
+        help='R|Process to generate mask.\n'
+             '  <coord,XxY>: Center mask at the X,Y coordinates. (e.g. "coord,20x15")\n'
+             '  <point,FILE>: Center mask at the X,Y coordinates of the label defined in input volume FILE. (e.g. "point,label.nii.gz")\n'
+             '  <center>: Center mask in the middle of the FOV (nx/2, ny/2).\n'
+             '  <centerline,FILE>: At each slice, the mask is centered at the spinal cord centerline, defined by the input segmentation FILE. (e.g. "centerline,t2_seg.nii.gz")',
+        metavar=Metavar.str,
+    )
+
+    optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
+    optional.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        help="Show this help message and exit")
+    optional.add_argument(
+        '-size',
+        help='Size of the mask in the axial plane, given in pixel (Example: 35) or in millimeter (Example: 35mm). '
+             'If shape=gaussian, size corresponds to "sigma" (Example: 45).',
+        metavar=Metavar.str,
+        required = False,
+        default = param_default.size)
+    optional.add_argument(
+        '-f',
+        help='Shape of the mask',
+        required = False,
+        default = param_default.shape,
+        choices=('cylinder', 'box', 'gaussian'))
+    optional.add_argument(
+        '-o',
+        metavar=Metavar.str,
+        help='Name of output mask, Example: data.nii',
+        required = False)
+    optional.add_argument(
+        "-r",
+        type=int,
+        help='Remove temporary files',
+        required = False,
+        default = 1,
+        choices = (0, 1))
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended ",
+        required=False,
+        choices=(0, 1, 2),
+        default = 1)
+
+    return parser
+
+
 def main(args=None):
     """
     Main function
@@ -281,74 +353,6 @@ def create_mask2d(param, center, shape, size, im_data):
         mask2d = np.exp(-(((xx + offset[0] - xc)**2) / (2 * (sigma**2)) + ((yy + offset[1] - yc)**2) / (2 * (sigma**2))))
 
     return mask2d
-
-
-def get_parser():
-    # Initialize default parameters
-    param_default = Param()
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
-        description='Create mask along z direction.',
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"),
-        formatter_class= SmartFormatter)
-    mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
-    mandatoryArguments.add_argument(
-        '-i',
-        help='Image to create mask on. Only used to get header. Must be 3D. Example: data.nii.gz',
-        metavar=Metavar.file,
-        required = False)
-    mandatoryArguments.add_argument(
-        '-p',
-        help='R|Process to generate mask.\n'
-             '  <coord,XxY>: Center mask at the X,Y coordinates. (e.g. "coord,20x15")\n'
-             '  <point,FILE>: Center mask at the X,Y coordinates of the label defined in input volume FILE. (e.g. "point,label.nii.gz")\n'
-             '  <center>: Center mask in the middle of the FOV (nx/2, ny/2).\n'
-             '  <centerline,FILE>: At each slice, the mask is centered at the spinal cord centerline, defined by the input segmentation FILE. (e.g. "centerline,t2_seg.nii.gz")',
-        metavar=Metavar.str,
-        required = False,
-        default = param_default.process)
-    optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
-    optional.add_argument(
-        "-h",
-        "--help",
-        action="help",
-        help="Show this help message and exit")
-    optional.add_argument(
-        '-size',
-        help='Size of the mask in the axial plane, given in pixel (Example: 35) or in millimeter (Example: 35mm). '
-             'If shape=gaussian, size corresponds to "sigma" (Example: 45).',
-        metavar=Metavar.str,
-        required = False,
-        default = param_default.size)
-    optional.add_argument(
-        '-f',
-        help='Shape of the mask',
-        required = False,
-        default = param_default.shape,
-        choices=('cylinder', 'box', 'gaussian'))
-    optional.add_argument(
-        '-o',
-        metavar=Metavar.str,
-        help='Name of output mask, Example: data.nii',
-        required = False)
-    optional.add_argument(
-        "-r",
-        type=int,
-        help='Remove temporary files',
-        required = False,
-        default = 1,
-        choices = (0, 1))
-    optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended ",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
-
-    return parser
 
 
 if __name__ == "__main__":

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -70,7 +70,7 @@ def get_parser():
         )
     mandatoryArguments.add_argument(
         '-p',
-        default=param_default.process
+        default=param_default.process,
         required=True,
         help='R|Process to generate mask.\n'
              '  <coord,XxY>: Center mask at the X,Y coordinates. (e.g. "coord,20x15")\n'

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -276,27 +276,32 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
         "-i",
+        required=True,
         help='Input image. Example: t2.nii.gz',
         metavar=Metavar.file,
-        required = False)
+        )
     mandatoryArguments.add_argument(
         "-g",
         type=int,
+        required=True,
         help="1: use the GUI to crop, 0: use the command line to crop.",
-        required=False,
         choices=(0, 1),
-        default = 0)
+        default = 0
+    )
 
-    # Command line mandatory arguments
+    # Command line mandatory arguments only for CLI execution
     requiredCommandArguments = parser.add_argument_group("\nCOMMAND LINE RELATED MANDATORY ARGUMENTS")
     requiredCommandArguments.add_argument(
         "-o",
         help='Output image. This option is REQUIRED for the command line execution Example: t1.nii.gz',
         metavar=Metavar.str,
-        required=False)
+        required=False
+    )
+
     # Optional arguments section
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -284,14 +284,6 @@ def get_parser():
         help='Input image. Example: t2.nii.gz',
         metavar=Metavar.file,
         )
-    mandatoryArguments.add_argument(
-        "-g",
-        type=int,
-        required=True,
-        help="1: use the GUI to crop, 0: use the command line to crop.",
-        choices=(0, 1),
-        default = 0
-    )
 
     # Command line mandatory arguments only for CLI execution
     requiredCommandArguments = parser.add_argument_group("\nCOMMAND LINE RELATED MANDATORY ARGUMENTS")
@@ -302,13 +294,19 @@ def get_parser():
         required=False
     )
 
-    # Optional arguments section
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",
         "--help",
         action="help",
         help="Show this help message and exit")
+    optional.add_argument(
+        "-g",
+        type=int,
+        help="0: Cropping via command line | 1: Cropping via GUI",
+        choices=(0, 1),
+        default=0,
+    )
     optional.add_argument(
         "-v",
         type=int,
@@ -421,22 +419,18 @@ def main(args=None):
 
     # assigning variables to arguments
     input_filename = arguments.i
-    exec_choice = 0
-    if arguments.g is not None:
-        exec_choice = bool(arguments.g)
+    cropping_with_gui = arguments.g
 
-    # cropping with GUI
+    # initialize ImageCropper
     cropper = ImageCropper(input_filename)
     cropper.verbose = arguments.v
     sct.init_sct(log_level=cropper.verbose, update=True)  # Update log level
 
-    if exec_choice:
-        fname_data = arguments.i
+    if cropping_with_gui:
         if arguments.r is not None:
             cropper.rm_tmp_files = arguments.r
         cropper.crop_with_gui()
 
-    # cropping with specified command-line arguments
     else:
         if arguments.o is not None:
             cropper.output_filename = arguments.o
@@ -464,6 +458,7 @@ def main(args=None):
             cropper.mesh = arguments.mesh
 
         cropper.crop()
+
 
 if __name__ == "__main__":
     sct.init_sct()

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -29,11 +29,15 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
+        required=True,
         help="Image filename to segment (3D volume). Example: t2s.nii.gz.",
-        metavar=Metavar.file)
+        metavar=Metavar.file
+    )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -33,24 +33,31 @@ def get_parser():
         formatter_class=SmartFormatter,
         add_help=None,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
+        required=True,
         help='Input image. Example: t1.nii.gz',
-        metavar=Metavar.file)
+        metavar=Metavar.file,
+    )
     mandatory.add_argument(
         "-c",
+        required=True,
         help='R|Type of image contrast.\n'
              ' t2: T2w scan with isotropic or anisotropic resolution.\n'
              ' t2_ax: T2w scan with axial orientation and thick slices.\n'
              ' t2s: T2*w scan with axial orientation and thick slices.',
-        choices=('t2', 't2_ax', 't2s'))
+        choices=('t2', 't2_ax', 't2s'),
+    )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",
         "--help",
         action="help",
-        help="Show this help message and exit")
+        help="Show this help message and exit",
+    )
     optional.add_argument(
         "-centerline",
         help="R|Method used for extracting the centerline:\n"

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -35,11 +35,15 @@ def get_parser():
     mandatory.add_argument(
         "-i",
         metavar=Metavar.file,
-        help='Input image. Example: t1.nii.gz')
+        help='Input image. Example: t1.nii.gz',
+        required=True
+    )
     mandatory.add_argument(
         "-c",
         help="Type of image contrast.",
-        choices=('t1', 't2', 't2s', 'dwi'))
+        choices=('t1', 't2', 't2s', 'dwi'),
+        required=True
+    )
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -34,16 +34,17 @@ def get_parser():
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
+        required=True,
         metavar=Metavar.file,
         help='Input image. Example: t1.nii.gz',
-        required=True
     )
     mandatory.add_argument(
         "-c",
+        required=True,
         help="Type of image contrast.",
         choices=('t1', 't2', 't2s', 'dwi'),
-        required=True
     )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -32,12 +32,16 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
+        default=None,
+        required=True,
         help="Input NIFTI image to be denoised. Example: image_input.nii.gz",
         metavar=Metavar.file,
-        default=None)
+    )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -39,18 +39,22 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
+        required=True,
         metavar=Metavar.file,
         help='Input image. Example: t2.nii.gz',
-        required=True)
+        )
     mandatory.add_argument(
         "-c",
+        choices=("t1", "t2"),
+        required=True,
         help="Type of image contrast, if your contrast is not in the available options (t1, t2), "
              "use t1 (cord bright/ CSF dark) or t2 (cord dark / CSF bright)",
-        required=True,
-        choices=("t1", "t2"))
+    )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -28,17 +28,21 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         '-i',
+        required=True,
         metavar=Metavar.file,
         help='First input image. Example: t2_seg.nii.gz',
-        required=True)
+        )
     mandatory.add_argument(
         '-d',
-        metavar=Metavar.file,
+        required=True,
         help='Second input image. Example: t2_manual_seg.nii.gz',
-        required=True)
+        metavar=Metavar.file,
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_dmri_compute_bvalue.py
+++ b/scripts/sct_dmri_compute_bvalue.py
@@ -59,25 +59,30 @@ def get_parser():
         add_help=None,
         formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-g",
         type=float,
-        metavar=Metavar.float,
+        required=True,
         help="Amplitude of diffusion gradients (in mT/m). Example: 40",
-        required=True)
+        metavar=Metavar.float,
+        )
     mandatory.add_argument(
         "-b",
-        metavar=Metavar.float,
         type=float,
+        required=True,
         help="Big delta: time between both diffusion gradients (in ms). Example: 40",
-        required=True)
+        metavar=Metavar.float,
+        )
     mandatory.add_argument(
         "-d",
         type=float,
-        metavar=Metavar.float,
+        required=True,
         help="Small delta: duration of each diffusion gradient (in ms). Example: 30",
-        required=True)
+        metavar=Metavar.float,
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -35,22 +35,27 @@ def get_parser():
         formatter_class=SmartFormatter,
         add_help=None,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("MANDATORY ARGMENTS")
     mandatory.add_argument(
         "-i",
+        required=True,
         help='Input 4d file. Example: dmri.nii.gz',
         metavar=Metavar.file,
-        required=True)
+        )
     mandatory.add_argument(
         "-bval",
+        required=True,
         help='Bvals file. Example: bvals.txt',
         metavar=Metavar.file,
-        required=True)
+        )
     mandatory.add_argument(
         "-bvec",
+        required=True,
         help='Bvecs file. Example: bvecs.txt',
         metavar=Metavar.file,
-        required=True)
+        )
+
     optional = parser.add_argument_group("OPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -32,51 +32,52 @@ def get_parser():
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         '-i',
-        help="Input 4d files, separated by space, listed in the right order of concatenation. Example: b0.nii dmri1.nii dmri2.nii",
         nargs='+',
-        metavar=Metavar.file,
         required=True,
+        help="Input 4d files, separated by space, listed in the right order of concatenation. Example: b0.nii dmri1.nii dmri2.nii",
+        metavar=Metavar.file,
     )
     mandatory.add_argument(
         '-bval',
-        help="Bvals file(s). Example: bvals.txt",
         nargs='+',
-        metavar=Metavar.file,
         required=True,
+        help="Bvals file(s). Example: bvals.txt",
+        metavar=Metavar.file,
     )
     mandatory.add_argument(
         '-bvec',
-        help="Bvecs file(s). Example: bvecs.txt",
         nargs='+',
-        metavar=Metavar.file,
         required=True,
+        help="Bvecs file(s). Example: bvecs.txt",
+        metavar=Metavar.file,
     )
     mandatory.add_argument(
         '-order',
-        help="Order of b=0 and DWI files entered in flag '-i', separated by space. Example: b0 dwi dwi",
         nargs='+',
+        required=True,
+        help="Order of b=0 and DWI files entered in flag '-i', separated by space. Example: b0 dwi dwi",
         choices=['b0', 'dwi'],
         metavar=Metavar.str,
-        required=True,
     )
     mandatory.add_argument(
         '-o',
+        required=True,
         help="Output 4d concatenated file. Example: b0_dmri_concat.nii",
         metavar=Metavar.file,
-        required=True,
     )
     mandatory.add_argument(
         '-obval',
+        required=True,
         help="Output concatenated bval file. Example: bval_concat.txt",
         metavar=Metavar.file,
-        required=True,
     )
     mandatory.add_argument(
         '-obvec',
+        required=True,
         help="Output concatenated bvec file. Example: bvec_concat.txt",
         metavar=Metavar.file,
-        required=True,
     )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         '-h',

--- a/scripts/sct_dmri_concat_bvals.py
+++ b/scripts/sct_dmri_concat_bvals.py
@@ -32,10 +32,12 @@ def get_parser():
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
-        help='List of the bval files to concatenate. Example: dmri_b700.bval dmri_b2000.bval',
         nargs='+',
+        required=True,
+        help='List of the bval files to concatenate. Example: dmri_b700.bval dmri_b2000.bval',
         metavar=Metavar.file,
-        required=True)
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",

--- a/scripts/sct_dmri_concat_bvecs.py
+++ b/scripts/sct_dmri_concat_bvecs.py
@@ -32,13 +32,16 @@ def get_parser():
         formatter_class=SmartFormatter,
         add_help=None,
         prog=os.path.basename(__file__).strip(".py"))
+
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
-        help='List of the bvec files to concatenate. Example: dmri_b700.bvec dmri_b2000.bvec',
         nargs='+',
+        required=True,
+        help='List of the bvec files to concatenate. Example: dmri_b700.bvec dmri_b2000.bvec',
         metavar=Metavar.file,
-        required=True)
+        )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",


### PR DESCRIPTION
When mandatory arguments are missing in CLI, the function crashes and gives an error which is difficult to interpret. The parser should take care of providing a human friendlier verbose. 

This is fixed by adding `required=True` in functions where Python's argparse is used.

The Wiki has also been updated [here](https://github.com/neuropoly/spinalcordtoolbox/wiki/example_script) to document how the parser should be used.

Fixes #2456 