### PR TITLE
Fixed segmentation issue that mostly appeared on DWI data

### DIFF
--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -172,7 +172,7 @@ def main():
 
     im_image = Image(fname_image)
     # note: below we pass im_image.copy() otherwise the field absolutepath becomes None after execution of this function
-    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp, im_labels_viewer, im_ctr = \
+    im_seg, im_image_RPI_upsamp, im_seg_RPI_upsamp = \
         deep_segmentation_spinalcord(im_image.copy(), contrast_type, ctr_algo=ctr_algo,
                                      ctr_file=manual_centerline_fname, brain_bool=brain_bool, kernel_size=kernel_size,
                                      remove_temp_files=remove_temp_files, verbose=verbose)
@@ -184,18 +184,6 @@ def main():
     # copy q/sform from input image to output segmentation
     im_seg.copy_qform_from_ref(im_image)
     im_seg.save(fname_seg)
-
-    if ctr_algo == 'viewer':
-        # Save labels
-        fname_labels = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_labels-centerline' +
-                                               sct.extract_fname(fname_image)[2]))
-        im_labels_viewer.save(fname_labels)
-
-    if verbose == 2:
-        # Save ctr
-        fname_ctr = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_centerline' +
-                                               sct.extract_fname(fname_image)[2]))
-        im_ctr.save(fname_ctr)
 
     if path_qc is not None:
         generate_qc(fname_image, fname_seg=fname_seg, args=sys.argv[1:], path_qc=os.path.abspath(path_qc),

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -73,7 +73,7 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         "-kernel",
-        help="Choice of kernel shape for the CNN. Segmentation with 3D kernels is longer than with 2D kernels.",
+        help="Choice of kernel shape for the CNN. Segmentation with 3D kernels is slower than with 2D kernels.",
         choices=('2d', '3d'),
         default="2d")
     optional.add_argument(
@@ -138,7 +138,6 @@ def main():
         kernel_size = '2d'
         sct.printv('3D kernel model for dwi contrast is not available. 2D kernel model is used instead.',
                    type="warning")
-
 
     if ctr_algo == 'file' and args.file_centerline is None:
         sct.printv('Please use the flag -file_centerline to indicate the centerline filename.', 1, 'warning')

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -464,7 +464,6 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     X_CROP_LST, Y_CROP_LST, Z_CROP_LST, im_crop_nii = crop_image_around_centerline(im_in=im_image_res,
                                                                                    ctr_in=im_ctl,
                                                                                    crop_size=crop_size)
-    del im_ctl
 
     # normalize the intensity of the images
     logger.info("Normalizing the intensity...")
@@ -515,12 +514,10 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         im_viewer = None
 
     # TODO: Deal with that later-- ideally this file should be written when debugging, not with verbose=2
-    # if verbose == 2:
-    #     fname_res_ctr = sct.add_suffix(fname_orient, '_ctr')
-    #     resampling.resample_file(fname_res_ctr, fname_res_ctr, initial_resolution, 'mm', 'linear', verbose=0)
-    #     im_image_res_ctr_downsamp = Image(fname_res_ctr).change_orientation(original_orientation)
-    # else:
-    im_image_res_ctr_downsamp = None
+    if verbose == 2:
+        im_ctl_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear')
+    else:
+        im_ctl_r = None
 
     # Binarize the resampled image to remove interpolation effects
     logger.info("Binarizing the resampled segmentation...")
@@ -547,4 +544,4 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
            im_image_res, \
            im_seg.change_orientation('RPI'), \
            im_viewer, \
-           im_image_res_ctr_downsamp
+           im_ctl_r

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -497,17 +497,19 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # seg_uncrop_nii.save(sct.add_suffix(fname_res, '_seg'))  # for debugging
     del seg_crop
 
+    # Change type uint8 --> float32 otherwise resampling will produce binary output (even with linear interpolation)
+    im_seg.change_type(np.float32)
     # resample to initial resolution
     logger.info("Resampling the segmentation to the native image resolution using linear interpolation...")
     im_seg_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear')
-    # TODO: the output is alreay binary! should be linear interp. To check!!
 
     if ctr_algo == 'viewer':  # for debugging
         im_labels_viewer.save(sct.add_suffix(fname_orient, '_labels-viewer'))
 
     # Binarize the resampled image to remove interpolation effects
     logger.info("Binarizing the resampled segmentation...")
-    thr = 0.0001 if contrast_type in ['t1', 'dwi'] else 0.5
+    # thr = 0.0001 if contrast_type in ['t1', 'dwi'] else 0.5
+    thr = 0.5
     # TODO: optimize speed --> np.where is slow
     im_seg_r.data[np.where(im_seg_r.data > thr)] = 1
     im_seg_r.data[np.where(im_seg_r.data <= thr)] = 0

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -469,8 +469,6 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # normalize the intensity of the images
     logger.info("Normalizing the intensity...")
     im_norm_in = apply_intensity_normalization(im_in=im_crop_nii)
-    im_norm_in.save(sct.add_suffix(fname_orient, '_norm'))
-    print(np.mean(im_norm_in.data), np.median(im_norm_in.data), np.max(im_norm_in.data), np.min(im_norm_in.data))
     del im_crop_nii
 
     if kernel_size == '2d':

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -481,9 +481,13 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     logger.info("Reorient the image to RPI, if necessary...")
     original_orientation = im_image.orientation
     fname_orient = 'image_in_RPI.nii'
-    im_image.change_orientation('RPI').save(fname_orient)
+    im_image.change_orientation('RPI').save(fname_orient)  # TODO: only save when physical file is needed
 
     input_resolution = im_image.dim[4:7]
+
+    # Resample image to 0.5mm iso
+    im_image_res = \
+        resampling.resample_nib(im_image, new_size=[0.5, 0.5, im_image.dim[6]], new_size_type='mm', interpolation='linear')
 
     # find the spinal cord centerline - execute OptiC binary
     logger.info("Finding the spinal cord centerline...")

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -503,13 +503,10 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # resample to initial resolution
     logger.info("Resampling the segmentation to the native image resolution using linear interpolation...")
     im_seg_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear')
+    # TODO: the output is alreay binary! should be linear interp. To check!!
 
     if ctr_algo == 'viewer':  # for debugging
         im_labels_viewer.save(sct.add_suffix(fname_orient, '_labels-viewer'))
-
-    # for debugging
-    # TODO: Deal with that later-- ideally this file should be written when debugging, not with verbose=2
-    im_ctl.save(sct.add_suffix(fname_orient, '_centerline'))
 
     # Binarize the resampled image to remove interpolation effects
     logger.info("Binarizing the resampled segmentation...")

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -469,6 +469,8 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # normalize the intensity of the images
     logger.info("Normalizing the intensity...")
     im_norm_in = apply_intensity_normalization(im_in=im_crop_nii)
+    im_norm_in.save(sct.add_suffix(fname_orient, '_norm'))
+    print(np.mean(im_norm_in.data), np.median(im_norm_in.data), np.max(im_norm_in.data), np.min(im_norm_in.data))
     del im_crop_nii
 
     if kernel_size == '2d':

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -505,17 +505,17 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     im_seg_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear')
 
     if ctr_algo == 'viewer':  # resample and reorient the viewer labels
-        im_labels_viewer_nib = nib.nifti1.Nifti1Image(im_labels_viewer.data, im_labels_viewer.hdr.get_best_affine())
-        im_viewer_r_nib = resampling.resample_nib(im_labels_viewer_nib, new_size=input_resolution, new_size_type='mm',
+        im_viewer_r = resampling.resample_nib(im_labels_viewer, new_size=input_resolution, new_size_type='mm',
                                                     interpolation='linear')
-        im_viewer = Image(im_viewer_r_nib.get_data(), hdr=im_viewer_r_nib.header, orientation='RPI',
-                            dim=im_viewer_r_nib.header.get_data_shape()).change_orientation(original_orientation)
+        # TODO: binarize it?
     else:
-        im_viewer = None
+        im_viewer_r = None
 
     # TODO: Deal with that later-- ideally this file should be written when debugging, not with verbose=2
     if verbose == 2:
-        im_ctl_r = resampling.resample_nib(im_seg, image_dest=im_image, interpolation='linear')
+        im_ctl_r = resampling.resample_nib(im_ctl, new_size=input_resolution, new_size_type='mm',
+                                                    interpolation='linear')
+        # TODO: binarize it?
     else:
         im_ctl_r = None
 
@@ -543,5 +543,5 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     return im_seg_r_postproc.change_orientation(original_orientation), \
            im_image_res, \
            im_seg.change_orientation('RPI'), \
-           im_viewer, \
+           im_viewer_r, \
            im_ctl_r

--- a/spinalcordtoolbox/deepseg_sc/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_sc/postprocessing.py
@@ -113,11 +113,11 @@ def _remove_isolated_voxels_on_the_edge(im_seg, n_slices=5):
     ind_min, ind_max = ind_nonnan[0], ind_nonnan[-1]
     # Check if the CSA at the edge is inferior to half of the median across adjacent slices...
     # ... for the top slice
-    if metrics['area'].data[ind_min] < np.median(metrics['area'].data[ind_min:n_slices]):
+    if metrics['area'].data[ind_min] < np.median(metrics['area'].data[ind_min:n_slices])/2:
         im_seg.data[:, :, ind_min] = 0
         logger.warning('Found isolated voxels on slice {}, Removing them'.format(ind_min))
     # ... for the bottom slice
-    if metrics['area'].data[ind_max] < np.median(metrics['area'].data[ind_max-n_slices+1:ind_max+1]):
+    if metrics['area'].data[ind_max] < np.median(metrics['area'].data[ind_max-n_slices+1:ind_max+1])/2:
         im_seg.data[:, :, ind_max] = 0
         logger.warning('Found isolated voxels on slice {}, Removing them'.format(ind_min))
     return im_seg

--- a/spinalcordtoolbox/deepseg_sc/postprocessing.py
+++ b/spinalcordtoolbox/deepseg_sc/postprocessing.py
@@ -142,7 +142,11 @@ def post_processing_volume_wise(im_seg):
 
 
 def post_processing_slice_wise(z_slice, x_cOm, y_cOm):
-    """Keep the largest connected obejct per z_slice and fill little holes."""
+    """
+    Keep the largest connected object per z_slice and fill little holes.
+    Note that this processing will necesseraly binarize the input segmentation. If we want to use soft predictions (as
+    opposed to binary predictions), this function needs to be refactored.
+    """
     labeled_obj, num_obj = label(z_slice)
     if num_obj > 1:
         if x_cOm is None or np.isnan(x_cOm):  # slice 0 or empty slice

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -46,11 +46,7 @@ def compute_shape(segmentation, angle_correction=True, param_centerline=None, ve
     nx, ny, nz, nt, px, py, pz, pt = im_seg.dim
     pr = min([px, py])
     # Resample to isotropic resolution in the axial plane. Use the minimum pixel dimension as target dimension.
-    im_seg_nib = nibabel.nifti1.Nifti1Image(im_seg.data, im_seg.hdr.get_best_affine())
-    im_seg_nibr = resample_nib(im_seg_nib, new_size=[pr, pr, pz], new_size_type='mm', interpolation='linear')
-    # Convert back to Image type
-    im_segr = Image(
-        im_seg_nibr.get_data(), hdr=im_seg_nibr.header, orientation='RPI', dim=im_seg_nibr.header.get_data_shape())
+    im_segr = resample_nib(im_seg, new_size=[pr, pr, pz], new_size_type='mm', interpolation='linear')
 
     # Update dimensions from resampled image.
     nx, ny, nz, nt, px, py, pz, pt = im_segr.dim

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -12,7 +12,7 @@ import sct_utils as sct
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.deepseg_sc import core as deepseg_sc
-from spinalcordtoolbox.resampling import resample_file
+from spinalcordtoolbox import resampling
 from create_test_data import dummy_centerline
 
 
@@ -62,8 +62,8 @@ def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
 
         fname_t2_RPI_res_crop_res = 'img_RPI_res_crop_res.nii.gz'
         fname_t2_seg_RPI_res_crop_res = 'seg_RPI_res_crop_res.nii.gz'
-        resample_file(fname_t2_RPI_res_crop, fname_t2_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
-        resample_file(fname_t2_seg_RPI_res_crop, fname_t2_seg_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
+        resampling.resample_file(fname_t2_RPI_res_crop, fname_t2_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
+        resampling.resample_file(fname_t2_seg_RPI_res_crop, fname_t2_seg_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
         img, gt = Image(fname_t2_RPI_res_crop_res), Image(fname_t2_seg_RPI_res_crop_res)
 
     tmp_folder.chdir_undo()

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -28,7 +28,8 @@ def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
 
     img.change_orientation('RPI')
     gt.change_orientation('RPI')
-
+    new_resolution = 'x'.join(['0.5', '0.5', str(img.dim[6])])
+    
     img_res = \
         resampling.resample_nib(img, new_size=[0.5, 0.5, img.dim[6]], new_size_type='mm', interpolation='linear')
     gt_res = \


### PR DESCRIPTION
For some reasons, some DWI datasets yield empty segmentations (or highly sub-segmented), causing the postprocessing module to crash later on.

This PR fixes:
- The segmentation issue, which was related to a resampling problem.
- Raises a more elegant error during postprocessing if inputing an empty segmentation.

Fixes #2464 

**WARNING: Output segmentation is overall larger (especially on dwi scans), therefore CSA studies should be based on this SCT version (or previous version), but not a mix of both versions.** 