### PR TITLE
Fixed issue that appeared when trying to remove temporary folder from different file systems

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -485,9 +485,9 @@ fi
 
 ## Create launchers for Python scripts
 echo -e "\nCreating launchers for Python scripts..."
-mkdir -p $SCT_DIR/bin
+mkdir -p $SCT_DIR/$BIN_DIR
 for file in $SCT_DIR/python/envs/venv_sct/bin/*sct*; do
-  cp "$file" "$SCT_DIR/bin/"
+  cp "$file" "$SCT_DIR/$BIN_DIR/"
   res=$?
   if [[ $res != 0 ]]; then
     echo "\nProblem creating launchers!"
@@ -503,8 +503,8 @@ done
 
 ## Create symbolic links for Shell scripts (-f: overwrite if exists)
 echo -e "\nCreating symbolic links for Shell scripts..."
-ln -s -f $SCT_DIR/shell/sct_run_batch.sh $SCT_DIR/bin/sct_run_batch
-ln -s -f $SCT_DIR/shell/_run_with_log.sh $SCT_DIR/bin/_run_with_log.sh
+ln -s -f $SCT_DIR/shell/sct_run_batch.sh $SCT_DIR/$BIN_DIR/sct_run_batch
+ln -s -f $SCT_DIR/shell/_run_with_log.sh $SCT_DIR/$BIN_DIR/_run_with_log.sh
 res=$?
 if [[ $res != 0 ]]; then
   echo "\nProblem creating symlinks!"

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -18,7 +18,8 @@ import sys
 import tarfile
 import tempfile
 import zipfile
-from shutil import rmtree, move, copytree
+from shutil import rmtree
+from distutils.dir_util import copy_tree
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -155,13 +156,16 @@ def main(args=None):
             os.remove(fullpath_dest)
 
     # Destination path
-    for source_path in extracted_files_paths:
-        # Move the content of source to destination
-        move(source_path, dest_folder, copy_function=copytree)
+    # for source_path in extracted_files_paths:
+        # Copy the content of source to destination (and create destination folder)
+    copy_tree(dest_tmp_folder, dest_folder)
 
-    sct.printv('\nRemove temporary files...', verbose)
-    os.remove(tmp_file)
-    rmtree(dest_tmp_folder)
+    sct.printv("\nRemove temporary folders...", verbose)
+    try:
+        rmtree(os.path.split(tmp_file)[0])
+        rmtree(dest_tmp_folder)
+    except Exception as error:
+        print("Cannot remove temp folder: " + repr(error))
 
     sct.printv('Done!\n', verbose)
     return 0

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -145,15 +145,12 @@ def main(args=None):
         extracted_files_paths.append(os.path.join(os.path.abspath(dest_tmp_folder), extracted_file))
 
     # Check if files and folder already exists
-    sct.printv('\nCheck if files or folder already exists on the destination path...', verbose)
+    sct.printv('\nCheck if folder already exists on the destination path...', verbose)
     for data_extracted_name in extracted_files:
         fullpath_dest = os.path.join(dest_folder, data_extracted_name)
         if os.path.isdir(fullpath_dest):
             sct.printv("Folder {} already exists. Removing it...".format(data_extracted_name), 1, 'warning')
             rmtree(fullpath_dest)
-        elif os.path.isfile(fullpath_dest):
-            sct.printv("File {} already exists. Removing it...".format(data_extracted_name), 1, 'warning')
-            os.remove(fullpath_dest)
 
     # Destination path
     # for source_path in extracted_files_paths:


### PR DESCRIPTION
This PR accommodates fixes an issue that appeared when installing SCT under Singulary container, where a folder located in another file system could not be moved.

The implemented solution is to copy the files (instead of moving them). This PR also includes a few minor improvements, notably by replacing shutil by distutils for copying files to existing directories (not possible with shutil.copytree).

Fixes #2472 