### PR TITLE
Fix deepseg threshold (again)

### DIFF
--- a/batch_processing.sh
+++ b/batch_processing.sh
@@ -128,7 +128,7 @@ cd ..
 # ===========================================================================================
 cd t1
 # Segment spinal cord
-sct_deepseg_sc -i t1.nii.gz -c t1
+sct_deepseg_sc -i t1.nii.gz -c t1 -qc "$SCT_BP_QC_FOLDER"
 # Smooth spinal cord along superior-inferior axis
 sct_smooth_spinalcord -i t1.nii.gz -s t1_seg.nii.gz
 # Flatten cord in the right-left direction (to make nice figure)

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -25,7 +25,7 @@ BATCH_SIZE = 4
 # Thresholds to apply to binarize segmentations from the output of the 2D CNN. These thresholds were obtained by
 # minimizing the standard deviation of cross-sectional area across contrasts. For more details, see:
 # https://github.com/sct-pipeline/deepseg-threshold
-THR_DEEPSEG = {'t1': 0.74353448, 't2': 0.34353448, 't2s': 0.89008621, 'dwi': 0.01422414}
+THR_DEEPSEG = {'t1': 0.15, 't2': 0.7, 't2s': 0.89, 'dwi': 0.01}
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -548,7 +548,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
     # Binarize the resampled image (except for soft segmentation, defined by threshold_seg=-1)
     if threshold_seg >= 0:
         logger.info("Binarizing the resampled segmentation...")
-        im_seg_r.data = im_seg_r.data.astype(np.uint8)
+        im_seg_r.data = (im_seg_r.data > 0.5).astype(np.uint8)
 
     # post processing step to z_regularized
     im_seg_r_postproc = post_processing_volume_wise(im_seg_r)


### PR DESCRIPTION
The recently-merged PR (https://github.com/neuropoly/spinalcordtoolbox/pull/2479), which consisted in finding the optimal threshold per contrast, by minimizing the STD of CSA across contrasts, was implemented with a flaw: the binarization after resampling was not done properly. This PR fixes it, and updated the optimal threshold per contrast using [this repository](https://github.com/sct-pipeline/deepseg-threshold) (commit a482d205120d76893c4f21c76e4535cc45bbce11).

Fixes #2488 
