### PR TITLE
Fixed wrong orientation with new version of scikit-image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ before_script:
 script:
   - |
     echo *** UNIT TESTS ***
-    pip install pytest pytest-cov
     pytest
 
   - |

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ nibabel
 pandas
 psutil
 pyqt5
+pytest
+pytest-cov
 raven
 requests
 scipy

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,10 @@ setup(
       'mpich==3.2',
       'mpi4py==3.0.0',
      ],
-     'test': [
-      "pytest-runner",
-      "pytest",
-     ],
+     # 'test': [
+     #  "pytest-runner",
+     #  "pytest",
+     # ],
     },
     entry_points=dict(
      console_scripts=[

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -174,7 +174,7 @@ def _properties2d(image, dim):
     # Compute area with weighted segmentation and adjust area with physical pixel size
     area = np.sum(image_crop_r) * dim[0] * dim[1] / upscale ** 2
     # Compute ellipse orientation, rotated by 90deg because image axis are inverted, modulo pi, in deg, and between [0, 90]
-    orientation = _fix_orientation(region.orientation)
+    orientation = fix_orientation(region.orientation)
     # Find RL and AP diameter based on major/minor axes and cord orientation=
     [diameter_AP, diameter_RL] = \
         _find_AP_and_RL_diameter(region.major_axis_length, region.minor_axis_length, orientation,
@@ -198,7 +198,7 @@ def _properties2d(image, dim):
     return properties
 
 
-def _fix_orientation(orientation):
+def fix_orientation(orientation):
     """Re-map orientation from skimage.regionprops from [-pi/2,pi/2] to [0,90] and rotate by 90deg because image axis
     are inverted"""
     orientation_new = (orientation + math.pi / 2) * 180.0 / math.pi

--- a/spinalcordtoolbox/process_seg.py
+++ b/spinalcordtoolbox/process_seg.py
@@ -173,7 +173,7 @@ def _properties2d(image, dim):
     region = regions[0]
     # Compute area with weighted segmentation and adjust area with physical pixel size
     area = np.sum(image_crop_r) * dim[0] * dim[1] / upscale ** 2
-    # Compute ellipse orientation, rotated by 90deg because image axis are inverted, modulo pi, in deg, and between [0, 90]
+    # Compute ellipse orientation, modulo pi, in deg, and between [0, 90]
     orientation = fix_orientation(region.orientation)
     # Find RL and AP diameter based on major/minor axes and cord orientation=
     [diameter_AP, diameter_RL] = \
@@ -201,7 +201,7 @@ def _properties2d(image, dim):
 def fix_orientation(orientation):
     """Re-map orientation from skimage.regionprops from [-pi/2,pi/2] to [0,90] and rotate by 90deg because image axis
     are inverted"""
-    orientation_new = (orientation + math.pi / 2) * 180.0 / math.pi
+    orientation_new = orientation * 180.0 / math.pi
     if 360 <= abs(orientation_new) <= 540:
         orientation_new = 540 - abs(orientation_new)
     if 180 <= abs(orientation_new) <= 360:

--- a/unit_testing/test_process_seg.py
+++ b/unit_testing/test_process_seg.py
@@ -87,6 +87,28 @@ im_segs = [
 
 
 # noinspection 801,PyShadowingNames
+def test_fix_orientation():
+    dict_test_orientation = [
+        {'input': math.pi, 'expected': 90.0},
+        {'input': -math.pi, 'expected': 90.0},
+        {'input': math.pi / 2, 'expected': 0.0},
+        {'input': -math.pi / 2, 'expected': 0.0},
+        {'input': 0.0, 'expected': 90.0},
+        {'input': 2 * math.pi, 'expected': 90.0},
+        {'input': math.pi / 4, 'expected': 45.0},
+        {'input': -math.pi / 4, 'expected': 45.0},
+        {'input': 3 * math.pi / 4, 'expected': 45.0},
+        {'input': -3 * math.pi / 4, 'expected': 45.0},
+        {'input': math.pi / 8, 'expected': 67.5},
+        {'input': -math.pi / 8, 'expected': 67.5},
+        {'input': 3 * math.pi / 8, 'expected': 22.5},
+        {'input': -3 * math.pi / 8, 'expected': 22.5},
+    ]
+    for test_orient in dict_test_orientation:
+        assert process_seg.fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)
+
+
+# noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('im_seg,expected,params', im_segs)
 def test_compute_shape(im_seg, expected, params):
     metrics, fit_results = process_seg.compute_shape(im_seg,
@@ -111,25 +133,3 @@ def test_compute_shape(im_seg, expected, params):
         else:
             expected_value = pytest.approx(expected[key], rel=0.05)
         assert obtained_value == expected_value
-
-
-# noinspection 801,PyShadowingNames
-def test_fix_orientation():
-    dict_test_orientation = [
-        {'input': math.pi, 'expected': 90.0},
-        {'input': -math.pi, 'expected': 90.0},
-        {'input': math.pi / 2, 'expected': 0.0},
-        {'input': -math.pi / 2, 'expected': 0.0},
-        {'input': 0.0, 'expected': 90.0},
-        {'input': 2 * math.pi, 'expected': 90.0},
-        {'input': math.pi / 4, 'expected': 45.0},
-        {'input': -math.pi / 4, 'expected': 45.0},
-        {'input': 3 * math.pi / 4, 'expected': 45.0},
-        {'input': -3 * math.pi / 4, 'expected': 45.0},
-        {'input': math.pi / 8, 'expected': 67.5},
-        {'input': -math.pi / 8, 'expected': 67.5},
-        {'input': 3 * math.pi / 8, 'expected': 22.5},
-        {'input': -3 * math.pi / 8, 'expected': 22.5},
-    ]
-    for test_orient in dict_test_orientation:
-        assert process_seg._fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)

--- a/unit_testing/test_process_seg.py
+++ b/unit_testing/test_process_seg.py
@@ -24,6 +24,31 @@ from create_test_data import dummy_segmentation
 VERBOSE = 0  # set to 2 to save files
 DEBUG = False  # Set to True to save images
 
+
+dict_test_orientation = [
+    {'input': 0.0, 'expected': 0.0},
+    {'input': math.pi, 'expected': 0.0},
+    {'input': -math.pi, 'expected': 0.0},
+    {'input': math.pi / 2, 'expected': 90.0},
+    {'input': -math.pi / 2, 'expected': 90.0},
+    {'input': 2 * math.pi, 'expected': 0.0},
+    {'input': math.pi / 4, 'expected': 45.0},
+    {'input': -math.pi / 4, 'expected': 45.0},
+    {'input': 3 * math.pi / 4, 'expected': 45.0},
+    {'input': -3 * math.pi / 4, 'expected': 45.0},
+    {'input': math.pi / 8, 'expected': 22.5},
+    {'input': -math.pi / 8, 'expected': 22.5},
+    {'input': 3 * math.pi / 8, 'expected': 67.5},
+    {'input': -3 * math.pi / 8, 'expected': 67.5},
+    ]
+
+
+# noinspection 801,PyShadowingNames
+@pytest.mark.parametrize('test_orient', dict_test_orientation)
+def test_fix_orientation(test_orient):
+    assert process_seg.fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)
+
+
 # Generate a list of fake segmentation for testing: (dummy_segmentation(params), dict of expected results)
 im_segs = [
     # test area
@@ -84,29 +109,6 @@ im_segs = [
      {'area': np.nan},
      {'angle_corr': False, 'slice': 2})
     ]
-
-
-# noinspection 801,PyShadowingNames
-def test_fix_orientation():
-    dict_test_orientation = [
-        {'input': math.pi, 'expected': 90.0},
-        {'input': -math.pi, 'expected': 90.0},
-        {'input': math.pi / 2, 'expected': 0.0},
-        {'input': -math.pi / 2, 'expected': 0.0},
-        {'input': 0.0, 'expected': 90.0},
-        {'input': 2 * math.pi, 'expected': 90.0},
-        {'input': math.pi / 4, 'expected': 45.0},
-        {'input': -math.pi / 4, 'expected': 45.0},
-        {'input': 3 * math.pi / 4, 'expected': 45.0},
-        {'input': -3 * math.pi / 4, 'expected': 45.0},
-        {'input': math.pi / 8, 'expected': 67.5},
-        {'input': -math.pi / 8, 'expected': 67.5},
-        {'input': 3 * math.pi / 8, 'expected': 22.5},
-        {'input': -3 * math.pi / 8, 'expected': 22.5},
-    ]
-    for test_orient in dict_test_orientation:
-        assert process_seg.fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)
-
 
 # noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('im_seg,expected,params', im_segs)


### PR DESCRIPTION
A new version of the library `scikit-image` (16.0.1) changed the way regionprops.orientation() is defined, which made [unit testing crashing](https://travis-ci.org/neuropoly/spinalcordtoolbox/jobs/600352204#L1079). This PR fixes it and brings other minor improvements listed below: 

- Fixed wrong orientation in `process_seg` with `scikit-image==16.0.1`. Fixes #2494 
- Pytest is now installed by default to facilitate running unit tests.
