### PR TITLE
Fixed aberrant mtr values

### DIFF
--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -77,7 +77,7 @@ def main():
     sct.printv('\nCompute MTR...', verbose)
     nii_mtr = compute_mtr(nii_mt1=Image(args.mt1), nii_mt0=Image(args.mt0))
     # save MTR file
-    nii_mtr.save(fname_mtr)
+    nii_mtr.save(fname_mtr, dtype='float64')
 
     sct.display_viewer_syntax([args.mt0, args.mt1, fname_mtr])
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -80,12 +80,11 @@ def main():
     args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     fname_mtr = args.o
     verbose = args.v
-    # Update log level
-    sct.init_sct(log_level=verbose, update=True)
 
     # compute MTR
     sct.printv('\nCompute MTR...', verbose)
     nii_mtr = compute_mtr(nii_mt1=Image(args.mt1), nii_mt0=Image(args.mt0), threshold_mtr=args.thr)
+
     # save MTR file
     nii_mtr.save(fname_mtr, dtype='float32')
 
@@ -93,4 +92,5 @@ def main():
 
 
 if __name__ == "__main__":
+    sct.init_sct()
     main()

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -46,21 +46,31 @@ def get_parser():
 
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
+        "-thr",
+        type=float,
+        help="Threshold to clip MTR output values in case of division by small number. This threshold is applied on the"
+             "absolute value. Default: 100.",
+        default=100
+        )
+    optional.add_argument(
         "-h",
         "--help",
         action="help",
-        help="Show this help message and exit")
+        help="Show this help message and exit"
+        )
     optional.add_argument(
         '-v',
         type=int,
         choices=(0, 1, 2),
         help='Verbose: 0 = nothing, 1 = classic, 2 = expended',
-        default=1)
+        default=1
+        )
     optional.add_argument(
         '-o',
         help='Path to output file.',
         metavar=Metavar.str,
-        default=os.path.join('.','mtr.nii.gz'))
+        default=os.path.join('.', 'mtr.nii.gz')
+        )
     return parser
 
 
@@ -75,7 +85,7 @@ def main():
 
     # compute MTR
     sct.printv('\nCompute MTR...', verbose)
-    nii_mtr = compute_mtr(nii_mt1=Image(args.mt1), nii_mt0=Image(args.mt0))
+    nii_mtr = compute_mtr(nii_mt1=Image(args.mt1), nii_mt0=Image(args.mt0), threshold_mtr=args.thr)
     # save MTR file
     nii_mtr.save(fname_mtr, dtype='float32')
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -77,7 +77,7 @@ def main():
     sct.printv('\nCompute MTR...', verbose)
     nii_mtr = compute_mtr(nii_mt1=Image(args.mt1), nii_mt0=Image(args.mt0))
     # save MTR file
-    nii_mtr.save(fname_mtr, dtype='float64')
+    nii_mtr.save(fname_mtr, dtype='float32')
 
     sct.display_viewer_syntax([args.mt0, args.mt1, fname_mtr])
 

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -48,8 +48,8 @@ def get_parser():
     optional.add_argument(
         "-thr",
         type=float,
-        help="Threshold to clip MTR output values in case of division by small number. This threshold is applied on the"
-             "absolute value. Default: 100.",
+        help="Threshold to clip MTR output values in case of division by small number. This implies that the output image" 
+             "range will be [-thr, +thr]. Default: 100.",
         default=100
         )
     optional.add_argument(

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -467,6 +467,9 @@ class Image(object):
         if hdr:
             hdr.set_data_shape(data.shape)
 
+        if dtype is not None:
+            hdr.set_data_dtype(dtype)
+
         # nb. that copy() is important because if it were a memory map, save()
         # would corrupt it
         img = Nifti1Image(data.copy(), None, hdr)

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -466,9 +466,9 @@ class Image(object):
         hdr = self.hdr.copy() if self.hdr else None
         if hdr:
             hdr.set_data_shape(data.shape)
-
-        if dtype is not None:
-            hdr.set_data_dtype(dtype)
+            # Update dtype if provided (but not if based on SCT-specific values: 'minimize')
+            if (dtype is not None) and (dtype not in ['minimize', 'minimize_int']):
+                hdr.set_data_dtype(dtype)
 
         # nb. that copy() is important because if it were a memory map, save()
         # would corrupt it

--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -13,16 +13,37 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-def compute_mtr(nii_mt1, nii_mt0):
+def divide_after_removing_zero(dividend, divisor, threshold, replacement=np.nan):
+    """
+    Mask zero, divide, look for numbers larger than 'threshold', and replace masked elements.
+    :param dividend:
+    :param divisor:
+    :param threshold:
+    :param replacement: value to replace masked value with.
+    :return:
+    """
+    ind_nonzero = np.where(divisor)
+    # divide without zero element in divisor
+    result = np.true_divide(dividend[ind_nonzero], divisor[ind_nonzero])
+    # find aberrant values above threshold
+    np.clip(result, -threshold, threshold, out=result)
+    # initiate resulting array with replacement values
+    result_full = np.full_like(dividend, fill_value=replacement)
+    result_full[ind_nonzero] = result
+    return result_full
+
+
+def compute_mtr(nii_mt1, nii_mt0, threshold_mtr=100):
     """
     Compute Magnetization Transfer Ratio in percentage.
     :param nii_mt1: Image object
     :param nii_mt0: Image object
+    :param threshold_mtr: float: value above which number will be clipped
     :return: nii_mtr
     """
     # Initialize Image object
     nii_mtr = nii_mt1.copy()
-    nii_mtr.data = 100 * np.true_divide((nii_mt0.data - nii_mt1.data), nii_mt0.data)
+    nii_mtr.data = 100 * divide_after_removing_zero((nii_mt0.data - nii_mt1.data), nii_mt0.data, threshold_mtr / 100)
     return nii_mtr
 
 

--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 def divide_after_removing_zero(dividend, divisor, threshold, replacement=np.nan):
     """
     Mask zero, divide, look for numbers larger than 'threshold', and replace masked elements.
-    :param dividend:
-    :param divisor:
-    :param threshold:
-    :param replacement: value to replace masked value with.
+    :param dividend: np.array
+    :param divisor: np.array
+    :param threshold: float
+    :param replacement: float: value to replace masked value with.
     :return:
     """
     ind_nonzero = np.where(divisor)
@@ -28,7 +28,7 @@ def divide_after_removing_zero(dividend, divisor, threshold, replacement=np.nan)
     # find aberrant values above threshold
     np.clip(result, -threshold, threshold, out=result)
     # initiate resulting array with replacement values
-    result_full = np.full_like(dividend, fill_value=replacement)
+    result_full = np.full_like(dividend, fill_value=replacement, dtype='float32')
     result_full[ind_nonzero] = result
     return result_full
 

--- a/spinalcordtoolbox/qmri/mt.py
+++ b/spinalcordtoolbox/qmri/mt.py
@@ -23,9 +23,12 @@ def divide_after_removing_zero(dividend, divisor, threshold, replacement=np.nan)
     :return:
     """
     ind_nonzero = np.where(divisor)
+    n_zero = divisor.size - len(ind_nonzero[0])
+    logger.info("Found {} voxels with value=0. These will be replaced by {}.".format(n_zero, replacement))
     # divide without zero element in divisor
     result = np.true_divide(dividend[ind_nonzero], divisor[ind_nonzero])
     # find aberrant values above threshold
+    logger.info("Threshold to clip values: +/- {}".format(threshold))
     np.clip(result, -threshold, threshold, out=result)
     # initiate resulting array with replacement values
     result_full = np.full_like(dividend, fill_value=replacement, dtype='float32')
@@ -43,7 +46,8 @@ def compute_mtr(nii_mt1, nii_mt0, threshold_mtr=100):
     """
     # Initialize Image object
     nii_mtr = nii_mt1.copy()
-    nii_mtr.data = 100 * divide_after_removing_zero((nii_mt0.data - nii_mt1.data), nii_mt0.data, threshold_mtr / 100)
+    # Compute MTR
+    nii_mtr.data = divide_after_removing_zero(100 * (nii_mt0.data - nii_mt1.data), nii_mt0.data, threshold_mtr)
     return nii_mtr
 
 

--- a/unit_testing/test_qmri.py
+++ b/unit_testing/test_qmri.py
@@ -24,7 +24,7 @@ def make_sct_image(data):
     data: scalar
     """
     affine = np.eye(4)
-    nii = nibabel.nifti1.Nifti1Image(np.array(data), affine)
+    nii = nibabel.nifti1.Nifti1Image(np.array([data, data]), affine)
     img = Image(nii.get_data(), hdr=nii.header, orientation="LPI", dim=nii.header.get_data_shape())
     return img
 
@@ -33,7 +33,7 @@ def test_compute_mtr():
     img_mtr = mt.compute_mtr(nii_mt1=make_sct_image(10),
                              nii_mt0=make_sct_image(20)
                              )
-    assert img_mtr.data == 0.5 * 100  # output is in percent
+    assert img_mtr.data[0] == 0.5 * 100  # output is in percent
 
 
 def test_compute_mtsat():
@@ -47,4 +47,4 @@ def test_compute_mtsat():
                                             fa_pd=9,
                                             fa_t1=15
                                             )
-    assert img_mtsat.data == pytest.approx(1.5327, 0.0001)
+    assert img_mtsat.data[0] == pytest.approx(1.5327, 0.0001)


### PR DESCRIPTION
A combination of issues yielded aberrant MTR values as the output of `sct_compute_mtr`:
- The output dtype was based on the input mt1 image. If it was int, it created ugly precision.
- Division by very small numbers yielded aberrant values (highly dependent on output dtype).

This PR fixes it by:
- Forcing float32 as the output of mtr
- Create a "smart" divider, where zeros are removed before division and output values can be clipped given application-specific priors (e.g., MTR should not be higher than 100). The advantage of aggressive clipping is that the output NIFTI file has a "human-friendly" range (e.g. -100/+100), so people don't have to adjust the dynamics when opening the image in a viewer, as [can happen sometimes](http://forum.spinalcordmri.org/t/computed-mtr-resulting-in-dark-image/46).
- Added CLI param to change default threshold: `-thr`
- SCT version now appears when running the function.

Fixes #2501 