### PR TITLE
Added button to toggle overlay and removed automatic fading

### DIFF
--- a/spinalcordtoolbox/reports/assets/_assets/css/style.css
+++ b/spinalcordtoolbox/reports/assets/_assets/css/style.css
@@ -46,14 +46,17 @@
     left: 0px;
 }
 
+/* -- UNCOMMENT THESE LINES TO HAVE FADING EFFECT OF THE OVERLAY
 @keyframes phase-in-out {
     from { opacity: 1; }
     to { opacity: 0; }
 }
 
+
 #overlay-img {
     animation: phase-in-out .5s infinite alternate ease-in-out;
 }
+*/
 
 .Sagittal, .Axial{
     max-width: 100%;

--- a/spinalcordtoolbox/reports/assets/_assets/js/main.js
+++ b/spinalcordtoolbox/reports/assets/_assets/js/main.js
@@ -34,21 +34,24 @@ $(document).ready(function(){
 
   $('html').keydown( function(evt) {
     var obj = $('#table tr.active');
+    // Arrow down: next subject
     if (evt.which == 40) {
       if (obj.length == 0 || obj.text() === "DateDatasetSubjectPathFileContrastFunctionFunction+Args") {
         $('#table tr:first-child').click();
-      } else {
+      }
+      else {
         obj.next().click();
       }
     }
+    // Arrow up: previous subject
     if (evt.which == 38) {
       if (obj.length == 0) {
         $('#table tr:last-child').click();
-      } else {
+      }
+      else {
         obj.prev().click();
       }
     }
-//    evt.preventDefault();
   });
 
   $("#table").bootstrapTable({

--- a/spinalcordtoolbox/reports/assets/index.html
+++ b/spinalcordtoolbox/reports/assets/index.html
@@ -110,6 +110,7 @@
                   <img id="sprite-img" onload="fetch_image_height()"/>
                   <img id="overlay-img"/>
               </div>
+              <button onclick="toggleOverlay()">Toggle overlay</button>
               <div id="cmdLine"></div>
               <div id="sctVer"></div>
           </div>
@@ -215,7 +216,7 @@
         dropdown.classList.toggle('open');
     });
 
-    thead.addEventListener('click', function(e){
+    thead.addEventListener('click', function(e) {
         /*
         This function hides the columns that are not supposed to be displayed when sorting the columns.
         */
@@ -233,7 +234,7 @@
         }, 4);
     });
 
-    setTimeout(function(){
+    setTimeout(function() {
          /*
          This function removes the columns we do not want to display at
          the beginning after a certain delay of time and adds the message
@@ -248,7 +249,7 @@
      },4);
 
 
-     function hideColumns(){
+     function hideColumns() {
             var columns = document.getElementsByTagName("th");
             var iHead;
             for (iHead = 0; iHead < columns.length; iHead++){
@@ -260,6 +261,16 @@
                 }
             }
         }
+
+    function toggleOverlay() {
+        var x = document.getElementById("overlay-img");
+        if (x.style.display === "none") {
+            x.style.display = "inline";
+        }
+        else {
+            x.style.display = "none";
+        }
+    }
 
         
 </script>

--- a/spinalcordtoolbox/reports/assets/index.html
+++ b/spinalcordtoolbox/reports/assets/index.html
@@ -110,7 +110,7 @@
                   <img id="sprite-img" onload="fetch_image_height()"/>
                   <img id="overlay-img"/>
               </div>
-              <button onclick="toggleOverlay()">Toggle overlay</button>
+              <button onclick="toggleOverlay()">Toggle overlay (right arrow)</button>
               <div id="cmdLine"></div>
               <div id="sctVer"></div>
           </div>
@@ -249,19 +249,20 @@
      },4);
 
 
-     function hideColumns() {
-            var columns = document.getElementsByTagName("th");
-            var iHead;
-            for (iHead = 0; iHead < columns.length; iHead++){
-                if (columns[iHead].style.display == "none"){
-                    var iTD;
-                    for (iTD = iHead; iTD < document.getElementsByTagName("td").length; iTD = iTD + columns.length){
-                        document.getElementsByTagName("td")[iTD].style.display = "none";
-                    }
+    function hideColumns() {
+        var columns = document.getElementsByTagName("th");
+        var iHead;
+        for (iHead = 0; iHead < columns.length; iHead++){
+            if (columns[iHead].style.display == "none"){
+                var iTD;
+                for (iTD = iHead; iTD < document.getElementsByTagName("td").length; iTD = iTD + columns.length){
+                    document.getElementsByTagName("td")[iTD].style.display = "none";
                 }
             }
         }
+    }
 
+    <!-- Toggle overlay -->
     function toggleOverlay() {
         var x = document.getElementById("overlay-img");
         if (x.style.display === "none") {
@@ -272,6 +273,13 @@
         }
     }
 
-        
+    <!-- Press right arrow key to toggle overlay -->
+    document.addEventListener('keydown', function (evt) {
+    if (evt.which == 39) {
+        toggleOverlay()
+    }
+});
+
+
 </script>
 </html>


### PR DESCRIPTION
Some users requested to adjust the frequency of the fading (too fast/slow) for toggling the overlay (e.g. segmentation), while other users preferred to have more control on the toggling. 

This PR removes the automatic toggling of the overlay and implements a new button (with shortkey "right arrow") to toggle the overlay. See below the added button.

<img width="1577" alt="Screen Shot 2019-10-27 at 9 43 04 PM" src="https://user-images.githubusercontent.com/2482071/67646100-d3318700-f902-11e9-9fd3-01cf0a5ab510.png">

Fixes #2511 