### PR TITLE
Fixed issue when passing absolute path to script

### DIFF
--- a/shell/sct_run_batch.sh
+++ b/shell/sct_run_batch.sh
@@ -24,11 +24,20 @@ On_Black='\033[40m'  # Black
 
 # Functions
 # =============================================================================
+
+check_file_exist() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    printf "\n${Red}${On_Black}ERROR: File does not exist: $path ${Color_Off}\n\n"
+    exit 1
+  fi
+}
+
 create_folder() {
   local folder="$1"
   mkdir -p $folder  # "-p" creates parent folders if needed
   if [ ! -d "$folder" ]; then
-    printf "\n${Red}${On_Black}ERROR: Cannot create folder: $folder. Exit.${Color_Off}\n\n"
+    printf "\n${Red}${On_Black}ERROR: Cannot create folder: $folder ${Color_Off}\n\n"
     exit 1
   fi
 }
@@ -59,6 +68,10 @@ PATH_SCRIPT="$( cd "$(dirname "$0")" ; pwd -P )"
 time_start=$(date +%x_%r)
 
 source $1
+
+# Check existence of input files
+check_file_exist $1
+check_file_exist $2
 
 # Get absolute paths
 fileparam="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"

--- a/shell/sct_run_batch.sh
+++ b/shell/sct_run_batch.sh
@@ -59,11 +59,30 @@ PATH_SCRIPT="$( cd "$(dirname "$0")" ; pwd -P )"
 time_start=$(date +%x_%r)
 
 # Load config file
-source $1
-fileparam="`pwd`/$1"
+if [ -f $PATH_SCRIPT/$(echo ${1##*/}) ];then	# ${1##*/} - get everything after last slash (/) from variable $1
+	# Config file is in same folder as this script
+	fileparam=$PATH_SCRIPT/$(echo ${1##*/})
+elif [ -f $1 ];then
+	# Config file is in any another folder
+	fileparam=$1
+else
+	echo "Path to config file is wrong."
+	exit 1
+fi
 
-# build syntax for process execution
-task="`pwd`/$2"
+source $fileparam
+
+# Build syntax for process execution
+if [ -f $PATH_SCRIPT/$(echo ${2##*/}) ];then	# ${2##*/} - get everything after last slash (/) from variable $2
+	# Script is in same folder as this script
+	task=$PATH_SCRIPT/$(echo ${2##*/})
+elif [ -f $2 ];then
+	# Script is in any another folder
+	task=$2
+else
+	echo "Path to script is wrong."
+	exit 1
+fi
 
 # Create folders
 create_folder $PATH_LOG

--- a/shell/sct_run_batch.sh
+++ b/shell/sct_run_batch.sh
@@ -58,31 +58,11 @@ fi
 PATH_SCRIPT="$( cd "$(dirname "$0")" ; pwd -P )"
 time_start=$(date +%x_%r)
 
-# Load config file
-if [ -f $PATH_SCRIPT/$(echo ${1##*/}) ];then	# ${1##*/} - get everything after last slash (/) from variable $1
-	# Config file is in same folder as this script
-	fileparam=$PATH_SCRIPT/$(echo ${1##*/})
-elif [ -f $1 ];then
-	# Config file is in any another folder
-	fileparam=$1
-else
-	echo "Path to config file is wrong."
-	exit 1
-fi
+source $1
 
-source $fileparam
-
-# Build syntax for process execution
-if [ -f $PATH_SCRIPT/$(echo ${2##*/}) ];then	# ${2##*/} - get everything after last slash (/) from variable $2
-	# Script is in same folder as this script
-	task=$PATH_SCRIPT/$(echo ${2##*/})
-elif [ -f $2 ];then
-	# Script is in any another folder
-	task=$2
-else
-	echo "Path to script is wrong."
-	exit 1
-fi
+# Get absolute paths
+fileparam="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+task="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
 
 # Create folders
 create_folder $PATH_LOG


### PR DESCRIPTION
I fixed building of path for input arguments/files for `sct_run_batch.sh ` script. Script failed when input files were not in same directory as the script or when input files were entered with absolute path (script expected only file names).

Fixes #2517