### PR TITLE
README: Added link to Youtube tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,17 +127,7 @@ We organize **free** SCT courses, each year after the ISMRM conference. If you'd
 
 ## Video tutorials
 
-#### Manual vertebral labeling
-
-<a href="http://www.youtube.com/watch?feature=player_embedded&v=Q3DhKOCEl5s
-" target="_blank"><img src="http://img.youtube.com/vi/Q3DhKOCEl5s/0.jpg"
-alt="Manual vertebral labeling" width="240" height="180" border="10" /></a>
-
-#### Fsleyes integration
-
-<a href="http://www.youtube.com/watch?feature=player_embedded&v=XC0vu0brEB0
-" target="_blank"><img src="http://img.youtube.com/vi/XC0vu0brEB0/0.jpg"
-alt="Fsleyes integration" width="240" height="180" border="10" /></a>
+Please visit our video tutorials [here](https://www.youtube.com/channel/UC3o_1ar-yenIlKfuNHitLqw).
 
 
 ## References


### PR DESCRIPTION
I suggest we redirect to the Youtube page instead of populating the README with embedded videos (more maintenance)