### PR TITLE
PyQt5 version downgrade to fix GUI on Debian 8.11 distros

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ matplotlib
 nibabel
 pandas
 psutil
-pyqt5
+pyqt5==5.11.3
 pytest
 pytest-cov
 raven


### PR DESCRIPTION
Linked to the issue signalled here: http://forum.spinalcordmri.org/t/spinal-cord-dki-processing/185/19?u=alexandrufoias
~~~
(venv_sct) osboxes@osboxes:~/Downloads$ sct_deepseg_sc -i kurtosis_dwi_mean.nii -c dwi -centerline viewer
 
--
Spinal Cord Toolbox (4.1.0)
 
Config deepseg_sc:
  Centerline algorithm: viewer
  Brain in image: False
  Kernel dimension: 2d
  Contrast: dwi
  Threshold: 0.01
 
Create temporary folder (/tmp/sct-20191113150318.717328-u564u8q2)...
Reorient the image to RPI, if necessary...
Finding the spinal cord centerline...
/home/osboxes/sct_4.1.0/python/envs/venv_sct/bin/python: relocation error: /home/osboxes/sct_4.1.0/python/envs/venv_sct/lib/python3.6/site-packages/PyQt5/Qt/plugins/platforms/../../lib/libQt5DBus.so.5: symbol dbus_message_get_allow_interactive_authorization, version LIBDBUS_1_3 not defined in file libdbus-1.so.3 with link time reference
~~~

The issue was reproduced using virtual box debian 8.11 from osboxes.org

Forcing pyqt5==5.11.3 seems to fix the issue. 

Tested with 5.13.1, 5.13.0,5.12.3,5.12.2, 5.12 without success.

To check if this proposed version will impact other functions in SCT.