### PR TITLE
Fixed cropping of registered image

### DIFF
--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -708,8 +708,8 @@ def main(args=None):
             '-o', 'warp_anat2template.nii.gz'])
 
     # Apply warping fields to anat and template
-    sct.run(['sct_apply_transfo', '-i', 'template.nii', '-o', 'template2anat.nii.gz', '-d', 'data.nii', '-w', 'warp_template2anat.nii.gz', '-crop', '1'], verbose)
-    sct.run(['sct_apply_transfo', '-i', 'data.nii', '-o', 'anat2template.nii.gz', '-d', 'template.nii', '-w', 'warp_anat2template.nii.gz', '-crop', '1'], verbose)
+    sct.run(['sct_apply_transfo', '-i', 'template.nii', '-o', 'template2anat.nii.gz', '-d', 'data.nii', '-w', 'warp_template2anat.nii.gz', '-crop', '0'], verbose)
+    sct.run(['sct_apply_transfo', '-i', 'data.nii', '-o', 'anat2template.nii.gz', '-d', 'template.nii', '-w', 'warp_anat2template.nii.gz', '-crop', '0'], verbose)
 
     # come back
     os.chdir(curdir)


### PR DESCRIPTION
A bug has been introduced in 4.1.0, where the registered template (in subject space) and subject (in template space) are cropped. This PR fixes it.

Fixes #2531
