### PR TITLE
Added an option for keypoints transformation

### DIFF
--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -18,10 +18,7 @@ from __future__ import division, absolute_import
 
 import sys, io, os, time, functools
 import argparse
-import scipy.ndimage.filters as scf
-from skimage.feature import peak_local_max
-import numpy as np
-import math
+
 
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
 from spinalcordtoolbox.image import Image
@@ -140,7 +137,7 @@ class Transform:
         self.list_warpinv = list_warpinv
         self.fname_dest = fname_dest
         self.output_filename = output_filename
-        self.interp = insterp
+        self.interp = interp
         self.crop = crop
         self.verbose = verbose
         self.remove_temp_files = remove_temp_files
@@ -234,9 +231,16 @@ class Transform:
                      '-i', fname_src,
                      '-o', output,
                      '-dilate','2'])
-                fname_src=os.path.join(path_tmp, "dilated_data.nii")
-
-            sct.run(['isct_antsApplyTransforms',
+                tmp_src=os.path.join(path_tmp, "dilated_data.nii")
+                tmp_out=os.path.join(path_tmp, "dilated_data_reg.nii")
+                sct.run(['isct_antsApplyTransforms',
+                     '-d', dim,
+                     '-i', tmp_src,
+                     '-o', tmp_out,
+                     '-t'] + fname_warp_list_invert + ['-r', fname_dest] + interp,
+                    verbose=verbose, is_sct_binary=True)
+            else:
+                sct.run(['isct_antsApplyTransforms',
                      '-d', dim,
                      '-i', fname_src,
                      '-o', fname_out,
@@ -336,7 +340,7 @@ class Transform:
 
         if label==1:
             sct.run(['sct_label_utils',
-                     '-i', fname_out,
+                     '-i', tmp_out,
                      '-o', fname_out,
                      '-cubic-to-point'])
        

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -99,10 +99,11 @@ def get_parser():
         default='')
     optional.add_argument(
         "-x",
-        help="Interpolation method ",
+        help=" Interpolation method. the 'label' interpolation method is designed to improve results on keypoints label file \
+         (e.g., disc label files) by dilating the original label and retrieving key points after the transformation.",
         required=False,
         default='spline',
-        choices=('nn', 'linear', 'spline'))
+        choices=('nn', 'linear', 'spline', 'label'))
     optional.add_argument(
         "-r",
         help="""Remove temporary files.""",
@@ -110,12 +111,6 @@ def get_parser():
         type=int,
         default=1,
         choices=(0, 1))
-    optional.add_argument(
-        "-label",
-        help="specify if the file is an image containing keypoints label",
-        required=False,
-        dest='label',
-        action='store_true')
     optional.add_argument(
         "-v",
         help="Verbose: 0 = nothing, 1 = classic, 2 = expended.",
@@ -140,7 +135,6 @@ class Transform:
         self.verbose = verbose
         self.remove_temp_files = remove_temp_files
         self.debug = debug
-        self.label = label
 
     def apply(self):
         # Initialization
@@ -151,8 +145,8 @@ class Transform:
         verbose = self.verbose
         remove_temp_files = self.remove_temp_files
         crop_reference = self.crop  # if = 1, put 0 everywhere around warping field, if = 2, real crop
-        label = self.label
-        if label == 1:
+        if self.interp == 'label':
+            label = 1
             self.interp = 'nn'
 
         interp = sct.get_interpolation('isct_antsApplyTransforms', self.interp)
@@ -231,7 +225,6 @@ class Transform:
                 fname_src = os.path.join(path_tmp, "dilated_data.nii")
                 tmp_out = os.path.join(path_tmp, "dilated_data_reg.nii")
                 final_out = fname_out
-
 
             sct.run(['isct_antsApplyTransforms',
                          '-d', dim,
@@ -377,7 +370,6 @@ def main(args=None):
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = arguments.v
-    transform.label = arguments.label
 
     sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
 

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -125,7 +125,6 @@ def get_parser():
         default=1,
         choices=(0, 1, 2))
 
-
     return parser
 
 
@@ -144,7 +143,6 @@ class Transform:
         self.debug = debug
         self.label=label
         
-
     def apply(self):
         # Initialization
         fname_src = self.input_filename  # source image (moving)
@@ -157,10 +155,8 @@ class Transform:
         label=self.label
         if label==1:
             self.interp='nn'
-        
 
         interp = sct.get_interpolation('isct_antsApplyTransforms', self.interp)
-
 
         # Parse list of warping fields
         sct.printv('\nParse list of warping fields...', verbose)
@@ -235,7 +231,7 @@ class Transform:
                      '-dilate', '2'])
                 tmp_src=os.path.join(path_tmp, "dilated_data.nii")
                 tmp_out=os.path.join(path_tmp, "dilated_data_reg.nii")
-                
+
                 sct.run(['isct_antsApplyTransforms',
                      '-d', dim,
                      '-i', tmp_src,

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -84,7 +84,7 @@ def get_parser():
         help="Show this help message and exit")
     optional.add_argument(
         "-crop",
-        help="Crop Reference. 0 : no reference. 1 : sets background to 0. 2 : use normal background",
+        help="Crop Reference. 0: no reference, 1: sets background to 0, 2: use normal background.",
         required=False,
         type=int,
         default=0,
@@ -97,10 +97,11 @@ def get_parser():
         default='')
     optional.add_argument(
         "-x",
-        help=""" Interpolation method. the 'label' method is to be used if you would like to apply a transformation on a file that has\
-        single-voxel labels (classical interpolation methods won't work, as resampled labels might disappear or their values be altered).\
-        The function will dilate each label, apply the transformation using nearest neighbour interpolation, \
-        and then take the center-of-mass of each "blob" and output a single voxel per blob.""",
+        help=""" Interpolation method. The 'label' method is to be used if you would like to apply a transformation 
+        on a file that has single-voxel labels (classical interpolation methods won't work, as resampled labels might 
+        disappear or their values be altered). The function will dilate each label, apply the transformation using 
+        nearest neighbour interpolation, and then take the center-of-mass of each "blob" and output a single voxel per 
+        blob.""",
         required=False,
         default='spline',
         choices=('nn', 'linear', 'spline', 'label'))
@@ -113,7 +114,7 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         "-v",
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended.",
+        help="Verbose: 0: nothing, 1: classic, 2: expended.",
         required=False,
         type=int,
         default=1,

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -99,8 +99,10 @@ def get_parser():
         default='')
     optional.add_argument(
         "-x",
-        help=" Interpolation method. the 'label' interpolation method is designed to improve results on keypoints label file \
-         (e.g., disc label files) by dilating the original label and retrieving key points after the transformation.",
+        help=""" Interpolation method. the 'label' method is to be used if you would like to apply a transformation on a file that has\
+        single-voxel labels (classical interpolation methods won't work, as resampled labels might disappear or their values be altered).\
+        The function will dilate each label, apply the transformation using nearest neighbour interpolation, \
+        and then take the center-of-mass of each "blob" and output a single voxel per blob.""",
         required=False,
         default='spline',
         choices=('nn', 'linear', 'spline', 'label'))

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -135,6 +135,7 @@ class Transform:
         self.verbose = verbose
         self.remove_temp_files = remove_temp_files
         self.debug = debug
+        self.label = label
 
     def apply(self):
         # Initialization
@@ -145,6 +146,7 @@ class Transform:
         verbose = self.verbose
         remove_temp_files = self.remove_temp_files
         crop_reference = self.crop  # if = 1, put 0 everywhere around warping field, if = 2, real crop
+        label = self.label
         if self.interp == 'label':
             label = 1
             self.interp = 'nn'
@@ -222,10 +224,9 @@ class Transform:
                          '-i', fname_src,
                          '-o', output,
                          '-dilate', '2'])
-                fname_src = os.path.join(path_tmp, "dilated_data.nii")
-                tmp_out = os.path.join(path_tmp, "dilated_data_reg.nii")
-                final_out = fname_out
 
+                fname_src = os.path.join(path_tmp, "dilated_data.nii")
+                final_out = fname_out
             sct.run(['isct_antsApplyTransforms',
                          '-d', dim,
                          '-i', fname_src,
@@ -368,7 +369,6 @@ def main(args=None):
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = arguments.v
-
     sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
 
     transform.apply()

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -343,6 +343,9 @@ class Transform:
                      '-i', tmp_out,
                      '-o', fname_out,
                      '-cubic-to-point'])
+            if int(remove_temp_files):
+                sct.printv('\nRemove temporary files...', verbose)
+                sct.rmtree(path_tmp, verbose=verbose)
        
             
 

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -224,15 +224,18 @@ class Transform:
                 dim = '2'
             else:
                 dim = '3'
+            #if file is a label file
             if label==1:
                 path_tmp = sct.tmp_create(basename="apply_transfo", verbose=verbose)
                 output=os.path.join(path_tmp, "dilated_data.nii")
+                #dilate points
                 sct.run(['sct_maths',
                      '-i', fname_src,
                      '-o', output,
-                     '-dilate','2'])
+                     '-dilate', '2'])
                 tmp_src=os.path.join(path_tmp, "dilated_data.nii")
                 tmp_out=os.path.join(path_tmp, "dilated_data_reg.nii")
+                
                 sct.run(['isct_antsApplyTransforms',
                      '-d', dim,
                      '-i', tmp_src,
@@ -347,9 +350,6 @@ class Transform:
                 sct.printv('\nRemove temporary files...', verbose)
                 sct.rmtree(path_tmp, verbose=verbose)
        
-            
-
-
 # MAIN
 # ==========================================================================================
 def main(args=None):

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -36,8 +36,6 @@ class Param:
 
 # PARSER
 # ==========================================================================================
-
-
 def get_parser():
     # parser initialisation
 
@@ -337,8 +335,6 @@ class Transform:
 
 # MAIN
 # ==========================================================================================
-
-
 def main(args=None):
     """
     Entry point for sct_apply_transfo

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -140,7 +140,7 @@ class Transform:
         self.list_warpinv = list_warpinv
         self.fname_dest = fname_dest
         self.output_filename = output_filename
-        self.interp = interp
+        self.interp = insterp
         self.crop = crop
         self.verbose = verbose
         self.remove_temp_files = remove_temp_files
@@ -158,9 +158,12 @@ class Transform:
         remove_temp_files = self.remove_temp_files
         crop_reference = self.crop  # if = 1, put 0 everywhere around warping field, if = 2, real crop
         label=self.label
+        if label==1:
+            self.interp='nn'
         
 
         interp = sct.get_interpolation('isct_antsApplyTransforms', self.interp)
+
 
         # Parse list of warping fields
         sct.printv('\nParse list of warping fields...', verbose)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -232,7 +232,6 @@ class Transform:
                     list_value.append(coordinates_origin_space[i].value)
                 mask=[[[1,1]for i in range (2)]for j in range (2)]
                 img_src.data=scf.convolve(img_src.data,mask)
-             
                 img_src.save(os.path.join(path_tmp, "dilated_data.nii"))
                 fnams_src=os.path.join(path_tmp, "dilated_data.nii")
 
@@ -344,7 +343,7 @@ class Transform:
             coordinates.reverse()
             groups_out=[]
        
-            while len(coordinates)>2:
+            while len(coordinates)>0:
                 g,coordinates=group_position_by_proximity(coordinates)
                 groups_out.append(g)
             center_coord=[]

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -112,11 +112,10 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         "-label",
-        help="""specify if the file is an image containing keypoints label""",
+        help="""specify  if the file is an image containing keypoints label""",
         required=False,
-        type=int,
-        default=0,
-        choices=(0, 1))
+        dest='label',
+        action='store_true')
     optional.add_argument(
         "-v",
         help="Verbose: 0 = nothing, 1 = classic, 2 = expended.",

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -228,17 +228,12 @@ class Transform:
                          '-i', fname_src,
                          '-o', output,
                          '-dilate', '2'])
-                tmp_src = os.path.join(path_tmp, "dilated_data.nii")
+                fname_src = os.path.join(path_tmp, "dilated_data.nii")
                 tmp_out = os.path.join(path_tmp, "dilated_data_reg.nii")
+                final_out = fname_out
 
-                sct.run(['isct_antsApplyTransforms',
-                         '-d', dim,
-                         '-i', tmp_src,
-                         '-o', tmp_out,
-                         '-t'] + fname_warp_list_invert + ['-r', fname_dest] + interp,
-                        verbose=verbose, is_sct_binary=True)
-            else:
-                sct.run(['isct_antsApplyTransforms',
+
+            sct.run(['isct_antsApplyTransforms',
                          '-d', dim,
                          '-i', fname_src,
                          '-o', fname_out,
@@ -338,8 +333,8 @@ class Transform:
 
         if label == 1:
             sct.run(['sct_label_utils',
-                     '-i', tmp_out,
-                     '-o', fname_out,
+                     '-i', fname_out,
+                     '-o', final_out,
                      '-cubic-to-point'])
             if int(remove_temp_files):
                 sct.printv('\nRemove temporary files...', verbose)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -19,11 +19,9 @@ from __future__ import division, absolute_import
 import sys, io, os, time, functools
 import argparse
 
-
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.cropping import ImageCropper
-
 
 import sct_utils as sct
 import sct_convert
@@ -38,6 +36,8 @@ class Param:
 
 # PARSER
 # ==========================================================================================
+
+
 def get_parser():
     # parser initialisation
 
@@ -112,7 +112,7 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         "-label",
-        help="""specify  if the file is an image containing keypoints label""",
+        help="specify if the file is an image containing keypoints label",
         required=False,
         dest='label',
         action='store_true')
@@ -128,7 +128,7 @@ def get_parser():
 
 
 class Transform:
-    def __init__(self, input_filename, fname_dest, list_warp, list_warpinv=[], output_filename='', verbose=0, crop=0,label=0,
+    def __init__(self, input_filename, fname_dest, list_warp, list_warpinv=[], output_filename='', verbose=0, crop=0, label=0,
                  interp='spline', remove_temp_files=1, debug=0):
         self.input_filename = input_filename
         self.list_warp = list_warp
@@ -140,8 +140,8 @@ class Transform:
         self.verbose = verbose
         self.remove_temp_files = remove_temp_files
         self.debug = debug
-        self.label=label
-        
+        self.label = label
+
     def apply(self):
         # Initialization
         fname_src = self.input_filename  # source image (moving)
@@ -151,9 +151,9 @@ class Transform:
         verbose = self.verbose
         remove_temp_files = self.remove_temp_files
         crop_reference = self.crop  # if = 1, put 0 everywhere around warping field, if = 2, real crop
-        label=self.label
-        if label==1:
-            self.interp='nn'
+        label = self.label
+        if label == 1:
+            self.interp = 'nn'
 
         interp = sct.get_interpolation('isct_antsApplyTransforms', self.interp)
 
@@ -191,7 +191,7 @@ class Transform:
 
         # N.B. Here we take the inverse of the warp list, because sct_WarpImageMultiTransform concatenates in the reverse order
         fname_warp_list_invert.reverse()
-        fname_warp_list_invert = functools.reduce(lambda x,y: x+y, fname_warp_list_invert)
+        fname_warp_list_invert = functools.reduce(lambda x, y: x + y, fname_warp_list_invert)
 
         # Extract path, file and extension
         path_src, file_src, ext_src = sct.extract_fname(fname_src)
@@ -219,31 +219,31 @@ class Transform:
                 dim = '2'
             else:
                 dim = '3'
-            #if file is a label file
-            if label==1:
+            # if file is a label file
+            if label == 1:
                 path_tmp = sct.tmp_create(basename="apply_transfo", verbose=verbose)
-                output=os.path.join(path_tmp, "dilated_data.nii")
-                #dilate points
+                output = os.path.join(path_tmp, "dilated_data.nii")
+                # dilate points
                 sct.run(['sct_maths',
-                     '-i', fname_src,
-                     '-o', output,
-                     '-dilate', '2'])
-                tmp_src=os.path.join(path_tmp, "dilated_data.nii")
-                tmp_out=os.path.join(path_tmp, "dilated_data_reg.nii")
+                         '-i', fname_src,
+                         '-o', output,
+                         '-dilate', '2'])
+                tmp_src = os.path.join(path_tmp, "dilated_data.nii")
+                tmp_out = os.path.join(path_tmp, "dilated_data_reg.nii")
 
                 sct.run(['isct_antsApplyTransforms',
-                     '-d', dim,
-                     '-i', tmp_src,
-                     '-o', tmp_out,
-                     '-t'] + fname_warp_list_invert + ['-r', fname_dest] + interp,
-                    verbose=verbose, is_sct_binary=True)
+                         '-d', dim,
+                         '-i', tmp_src,
+                         '-o', tmp_out,
+                         '-t'] + fname_warp_list_invert + ['-r', fname_dest] + interp,
+                        verbose=verbose, is_sct_binary=True)
             else:
                 sct.run(['isct_antsApplyTransforms',
-                     '-d', dim,
-                     '-i', fname_src,
-                     '-o', fname_out,
-                     '-t'] + fname_warp_list_invert + ['-r', fname_dest] + interp,
-                    verbose=verbose, is_sct_binary=True)
+                         '-d', dim,
+                         '-i', fname_src,
+                         '-o', fname_out,
+                         '-t'] + fname_warp_list_invert + ['-r', fname_dest] + interp,
+                        verbose=verbose, is_sct_binary=True)
 
         # if 4d, loop across the T dimension
         else:
@@ -280,13 +280,13 @@ class Transform:
                 file_data_split_reg = 'data_reg_T' + str(it).zfill(4) + '.nii'
 
                 status, output = sct.run(['isct_antsApplyTransforms',
-                  '-d', '3',
-                  '-i', file_data_split,
-                  '-o', file_data_split_reg,
-                  '-t',
-                 ] + fname_warp_list_invert_tmp + [
-                  '-r', file_dest + ext_dest,
-                 ] + interp, verbose, is_sct_binary=True)
+                                          '-d', '3',
+                                          '-i', file_data_split,
+                                          '-o', file_data_split_reg,
+                                          '-t',
+                                          ] + fname_warp_list_invert_tmp + [
+                    '-r', file_dest + ext_dest,
+                ] + interp, verbose, is_sct_binary=True)
 
             # Merge files back
             sct.printv('\nMerge file back...', verbose)
@@ -336,7 +336,7 @@ class Transform:
 
         sct.display_viewer_syntax([fname_dest, fname_out], verbose=verbose)
 
-        if label==1:
+        if label == 1:
             sct.run(['sct_label_utils',
                      '-i', tmp_out,
                      '-o', fname_out,
@@ -344,9 +344,11 @@ class Transform:
             if int(remove_temp_files):
                 sct.printv('\nRemove temporary files...', verbose)
                 sct.rmtree(path_tmp, verbose=verbose)
-       
+
 # MAIN
 # ==========================================================================================
+
+
 def main(args=None):
     """
     Entry point for sct_apply_transfo
@@ -380,7 +382,7 @@ def main(args=None):
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = arguments.v
-    transform.label=arguments.label
+    transform.label = arguments.label
 
     sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
 


### PR DESCRIPTION
This PR aims to add the -label flag to the sct_apply_transfo script. This flag can be used when applying a warping field to images containing point-like labels (e.g., discs label).
It performs the following :

* Change interpolation to 'nearest neighbor'
* Dilate labels on the image 
* Apply the warping field to the dilated image
* Apply cubic_to_point function to retrieve point-like labels on the transformed image.


Fixes #2519 
