### PR TITLE
.travis.yml: Removed coveralls check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,9 @@ script:
 #  - python create_package.py -s ${TRAVIS_OS_NAME}  # test package creation
 #  - cd ../spinalcordtoolbox_v*
 #  - yes | ./install_sct  # test installation of package
-  - |
-    pip install coveralls
-    echo "This is the end, thanks for reading up to here."
+#   - |
+#     pip install coveralls
+#     echo "This is the end, thanks for reading up to here."
 
-after_success:
-  - CI=true TRAVIS=true coveralls
+# after_success:
+#   - CI=true TRAVIS=true coveralls


### PR DESCRIPTION
To temporarily address the following Travis crash: 
https://travis-ci.org/neuropoly/spinalcordtoolbox/jobs/625017450#L3098

Note: This is not a sensitive change given that coveralls has not been thoroughly used so far (we are still building unit tests).
