### PR TITLE
Fixed generation of QC report

### DIFF
--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -220,22 +220,30 @@ def main(args=None):
 
     # Deal with QC report
     if path_qc is not None:
-        fname_wm = os.path.join(
-            w.folder_out, w.folder_template, spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4))  # label = 'white matter mask (probabilistic)'
-        generate_qc(
-            fname_src, fname_seg=fname_wm, args=sys.argv[1:], path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
-            subject=qc_subject, process='sct_warp_template')
+        try:
+            fname_wm = os.path.join(
+                w.folder_out, w.folder_template, spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4))  # label = 'white matter mask (probabilistic)'
+            generate_qc(
+                fname_src, fname_seg=fname_wm, args=sys.argv[1:], path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
+                subject=qc_subject, process='sct_warp_template')
+        # If label is missing, get_file_label() throws a RuntimeError
+        except RuntimeError:
+            sct.printv("QC not generated since expected labels are missing from template", type="warning")
 
     # Deal with verbose
-    sct.display_viewer_syntax(
-        [fname_src,
-         spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
-         spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
-         spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")],  # label = 'white matter mask (probabilistic)'
-        colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
-        opacities=['1', '1', '0.5', '0.5'],
-        minmax=['', '0,4000', '0.4,1', '0.4,1'],
-        verbose=verbose)
+    try:
+        sct.display_viewer_syntax(
+            [fname_src,
+             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
+             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
+             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")],  # label = 'white matter mask (probabilistic)'
+            colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
+            opacities=['1', '1', '0.5', '0.5'],
+            minmax=['', '0,4000', '0.4,1', '0.4,1'],
+            verbose=verbose)
+    # If label is missing, continue silently
+    except RuntimeError:
+        pass
 
 
 if __name__ == "__main__":

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -218,29 +218,24 @@ def main(args=None):
 
     path_template = os.path.join(w.folder_out, w.folder_template)
 
-    # Only deal with QC and verbose if white matter was warped (meaning, everything under template/)
-    if "white matter" in spinalcordtoolbox.metadata.get_indiv_label_info(path_template)['name']:
-        # Deal with QC report
-        if path_qc is not None:
-            fname_wm = os.path.join(
-                w.folder_out, w.folder_template, spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4))  # label = 'white matter mask (probabilistic)'
-            generate_qc(
-                fname_src, fname_seg=fname_wm, args=sys.argv[1:], path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
-                subject=qc_subject, process='sct_warp_template')
+    # Deal with QC report
+    if path_qc is not None:
+        fname_wm = os.path.join(
+            w.folder_out, w.folder_template, spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4))  # label = 'white matter mask (probabilistic)'
+        generate_qc(
+            fname_src, fname_seg=fname_wm, args=sys.argv[1:], path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
+            subject=qc_subject, process='sct_warp_template')
 
-        # Deal with verbose
-        sct.display_viewer_syntax(
-            [fname_src,
-             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
-             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
-             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")],  # label = 'white matter mask (probabilistic)'
-            colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
-            opacities=['1', '1', '0.5', '0.5'],
-            minmax=['', '0,4000', '0.4,1', '0.4,1'],
-            verbose=verbose)
-    else:
-        if path_qc is not None:
-            sct.printv("QC not generated since expected labels are missing from template", type="warning" )
+    # Deal with verbose
+    sct.display_viewer_syntax(
+        [fname_src,
+         spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
+         spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
+         spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")],  # label = 'white matter mask (probabilistic)'
+        colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
+        opacities=['1', '1', '0.5', '0.5'],
+        minmax=['', '0,4000', '0.4,1', '0.4,1'],
+        verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -222,24 +222,22 @@ def main(args=None):
     if "white matter" in spinalcordtoolbox.metadata.get_indiv_label_info(path_template)['name']:
         # Deal with QC report
         if path_qc is not None:
-            fname_wm = os.path.join(w.folder_out, w.folder_template,
-                                    spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4))  # label = 'white matter mask (probabilistic)'
-            generate_qc(fname_src, fname_seg=fname_wm, args=sys.argv[1:], path_qc=os.path.abspath(path_qc),
-                        dataset=qc_dataset, subject=qc_subject, process='sct_warp_template')
+            fname_wm = os.path.join(
+                w.folder_out, w.folder_template, spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4))  # label = 'white matter mask (probabilistic)'
+            generate_qc(
+                fname_src, fname_seg=fname_wm, args=sys.argv[1:], path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
+                subject=qc_subject, process='sct_warp_template')
 
         # Deal with verbose
         sct.display_viewer_syntax(
-         [
-          fname_src,
-          spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
-          spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
-          spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")  # label = 'white matter mask (probabilistic)'
-         ],
-         colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
-         opacities=['1', '1', '0.5', '0.5'],
-         minmax=['', '0,4000', '0.4,1', '0.4,1'],
-         verbose=verbose,
-        )
+            [fname_src,
+             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=1, output="filewithpath"),  # label = 'T2-weighted template'
+             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=5, output="filewithpath"),  # label = 'gray matter mask (probabilistic)'
+             spinalcordtoolbox.metadata.get_file_label(path_template, id_label=4, output="filewithpath")],  # label = 'white matter mask (probabilistic)'
+            colormaps=['gray', 'gray', 'red-yellow', 'blue-lightblue'],
+            opacities=['1', '1', '0.5', '0.5'],
+            minmax=['', '0,4000', '0.4,1', '0.4,1'],
+            verbose=verbose)
     else:
         if path_qc is not None:
             sct.printv("QC not generated since expected labels are missing from template", type="warning" )

--- a/spinalcordtoolbox/metadata.py
+++ b/spinalcordtoolbox/metadata.py
@@ -211,6 +211,7 @@ def get_file_label(path_label='', id_label=0, output='file'):
 
     raise RuntimeError("Label ID {} not found in {}".format(id_label, fname_label))
 
+
 def get_indiv_label_info(directory):
     """
     Get all individual label info (id, name, filename) in a folder


### PR DESCRIPTION
A bug related to the new definition of `spinalcordtoolbox.metadata.get_file_label()` prevented the generation of the QC report, because the label "white matter" was recently renamed in "mask white matter (probabilistic)". This PR fixes the problem by simply removing the useless if statement.

Fixes #2564 