### PR TITLE
Fixed missing file extension in detect_c2c3()

### DIFF
--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -46,9 +46,9 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     # path to the pmj detector
     path_model = os.path.join(sct.__data_dir__, 'c2c3_disc_models', '{}_model'.format(contrast))
     # check if model exists
-    if not os.path.isfile(path_model):
-        sct.printv('This file does not exist, please download it using sct_download _data: '+path_model+'.yml', 1, 'warning')
-        sys.exit(1)
+    if not os.path.isfile(path_model+'.yml'):
+        raise FileNotFoundError(
+            "The model file {} does not exist. Please download it using sct_download_data".format(path_model+'.yml'))
 
     orientation_init = nii_im.orientation
     z_seg_max = np.max(np.where(nii_seg.change_orientation('PIR').data)[1])


### PR DESCRIPTION
`detect_c2c3()` called by `sct_label_vertebrae` throws a "This file does not exist...", even though the model is properly installed at the cited location. This bug has likely been introduced in #2560.

This PR fixes the issue by adding a missing file extension when checking file existence.

Also replacing `sys.exit(1)` with the more specific `raise FileNotFoundError`.

Fixes #2568 
