### PR TITLE
sct_utils: Changed default open command for Linux

### DIFF
--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -317,7 +317,7 @@ def display_open(file):
     """Print the syntax to open a file based on the platform."""
     if sys.platform == 'linux':
         printv('\nDone! To view results, type:')
-        printv('xopen ' + file + '\n', verbose=1, type='info')
+        printv('xdg-open ' + file + '\n', verbose=1, type='info')
     elif sys.platform == 'darwin':
         printv('\nDone! To view results, type:')
         printv('open ' + file + '\n', verbose=1, type='info')


### PR DESCRIPTION
The default syntax for opening SCT output file on Linux was `xopen`, which is not widely available. The proposed solution is to replace this command with `xdg-open`, which is [available by default in most distros](https://stackoverflow.com/questions/264395/linux-equivalent-of-the-mac-os-x-open-command). 

Fixes #2574
