### PR TITLE
Fixed problem with parameters xmax, ymax and zmax

### DIFF
--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -109,14 +109,14 @@ def get_parser():
         '-zmin',
         type=int,
         default=0,
-        help="Lower bound for cropping along Z. Follows the same rules as xmax.",
+        help="Lower bound for cropping along Z.",
         metavar=Metavar.int,
         )
     optional.add_argument(
         '-zmax',
         type=int,
         default=-1,
-        help="Higher bound for cropping along Z. Inputting -1 will set it to the maximum dimension.",
+        help="Higher bound for cropping along Z. Follows the same rules as xmax.",
         metavar=Metavar.int,
         )
     optional.add_argument(

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -87,8 +87,8 @@ def get_parser():
         '-xmax',
         type=int,
         default=-1,
-        help="Higher bound for cropping along X. Setting '-1' will crop to the maximum dimension, '-2' will crop to "
-             "the maximum dimension minus 1 slice, etc.",
+        help="Higher bound for cropping along X. Setting '-1' will crop to the maximum dimension (i.e. no change), "
+             "'-2' will crop to the maximum dimension minus 1 slice, etc.",
         metavar=Metavar.int,
         )
     optional.add_argument(

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -38,9 +38,9 @@ class BoundingBox(object):
             # If empty, return dim+1 (corresponds to the maximum of the given dimension, e.g. nx)
             if input is None:
                 return dim + 1
-            # If negative sign, return dim+1 if -1, dim if -2, dim-1 if -3, etc.
+            # If negative sign, return dim if -1, dim-1 if -2, dim-2 if -3, etc.
             elif np.sign(input) == -1:
-                return input + dim + 1
+                return input + dim
             # If user specified a non-negative value, use that
             else:
                 return input

--- a/spinalcordtoolbox/cropping.py
+++ b/spinalcordtoolbox/cropping.py
@@ -35,10 +35,11 @@ class BoundingBox(object):
                 return input
 
         def _get_max_value(input, dim):
-            # If empty, return dim+1 (corresponds to the maximum of the given dimension, e.g. nx)
+            # If empty, return maximum dimension (i.e. no change)
             if input is None:
-                return dim + 1
-            # If negative sign, return dim if -1, dim-1 if -2, dim-2 if -3, etc.
+                return dim
+            # If input is "-1", return maximum dimension (i.e. no change). If input is "-2", returns maximum
+            # dimension minus one, etc.
             elif np.sign(input) == -1:
                 return input + dim
             # If user specified a non-negative value, use that

--- a/testing/test_sct_crop_image.py
+++ b/testing/test_sct_crop_image.py
@@ -45,7 +45,7 @@ def test_integrity(param_test):
 
     # check if cropping was correct depending on the scenario
     if index_args == 0:
-        xyz = (58, 9, 52)
+        xyz = (57, 9, 52)
     elif index_args == 1:
         xyz = (10, 55, 13)
     elif index_args == 2:


### PR DESCRIPTION
I just removed the `+1` in that [line](https://github.com/neuropoly/spinalcordtoolbox/blob/master/spinalcordtoolbox/cropping.py#L43) to get the correct dimension.

Fixes #2603
