### PR TITLE
Fixed flag -b crops instead of masking

### DIFF
--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -123,8 +123,9 @@ def get_parser():
         '-b',
         type=int,
         default=None,
-        help="If this flag is declared, the image will not be cropped. Instead, voxels outside the bounding box will "
-             "be set to the value specified by this flag.",
+        help="If this flag is declared, the image will not be cropped (i.e. the dimension will not change). Instead, "
+             "voxels outside the bounding box will be set to the value specified by this flag. For example, to have "
+             "zeros outside the bounding box, use: '-b 0'",
         metavar=Metavar.int,
         )
     optional.add_argument(

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -170,7 +170,7 @@ def main(args=None):
         )
 
     # Crop image
-    img_crop = cropper.crop()
+    img_crop = cropper.crop(background=arguments.b)
 
     # Write cropped image to file
     if arguments.o is None:


### PR DESCRIPTION
The flag `-b 1` is expected to not crop the image (i.e. reduce dimension), but instead mask the image outside of the bounding box defined by xmin, xmax, etc. with zeros. However, in the current implementation (commit 576ddeb), it does crop the image. This PR fixes the problem (an argument was missing in the crop() function).

The usage for `-b` was also clarified.

Fixes #2605 