### PR TITLE
Fixed missing type when using erode feature

### DIFF
--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -417,9 +417,13 @@ def main(args=None):
         printv('\nDone! File created: ' + fname_out, verbose, 'info')
 
 
-def convert_list_str(string_list, type):
+def convert_list_str(string_list, type='int'):
     """
-    Receive a string and then converts it into a list of selected type
+    Receive a string and then converts it into a list of selected type.
+    Example: "2,2,3" --> [2, 2, 3]
+    :param string_list: List of comma-separated string
+    :param type: string: int, float
+    :return:
     """
     new_type_list = (string_list).split(",")
     for inew_type_list, ele in enumerate(new_type_list):

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -339,7 +339,7 @@ def main(args=None):
         data_out = dilate(data, convert_list_str(arguments.dilate, "int"))
 
     elif arguments.erode is not None:
-        data_out = erode(data, convert_list_str(arguments.erode))
+        data_out = erode(data, convert_list_str(arguments.erode, "int"))
 
     elif arguments.denoise is not None:
         # parse denoising arguments


### PR DESCRIPTION
A bug related to a missing input argument in `convert_list_str()` made `sct_maths -erode` crash. This has now been fixed, and the doc has been clarified.

Fixes #2612