### PR TITLE
Enable 2D kernel for morpho math operations and various improvements

### DIFF
--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -22,6 +22,7 @@ import argparse
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.cropping import ImageCropper
+from spinalcordtoolbox.math import dilate
 
 import sct_utils as sct
 import sct_image
@@ -214,10 +215,7 @@ class Transform:
                 path_tmp = sct.tmp_create(basename="apply_transfo", verbose=verbose)
                 fname_dilated_labels = os.path.join(path_tmp, "dilated_data.nii")
                 # dilate points
-                sct.run(['sct_maths',
-                         '-i', fname_src,
-                         '-o', fname_dilated_labels,
-                         '-dilate', '2'])
+                dilate(Image(fname_src), 2, 'ball').save(fname_dilated_labels)
                 fname_src = fname_dilated_labels
 
             sct.printv("\nApply transformation and resample to destination space...", verbose)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -14,17 +14,18 @@
 from __future__ import division, absolute_import
 
 import sys, os
-
 import numpy as np
-import sct_maths
-from sct_label_utils import ProcessLabels
-from msct_parser import Parser
+
 from spinalcordtoolbox.image import Image
-import sct_utils as sct
 from spinalcordtoolbox.vertebrae.core import create_label_z, get_z_and_disc_values_from_label, vertebral_detection, \
     clean_labeled_segmentation, label_discs, label_vert
 from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
+from spinalcordtoolbox.math import dilate
+
+from sct_label_utils import ProcessLabels
+from msct_parser import Parser
+import sct_utils as sct
 import sct_straighten_spinalcord
 
 
@@ -310,7 +311,7 @@ def main(args=None):
             label = ProcessLabels('segmentation.nii', fname_output='tmp.labelz.nii.gz',
                                       coordinates=['{},{}'.format(initz[0], initz[1])])
             im_label = label.process('create-seg')
-            im_label.data = sct_maths.dilate(im_label.data, [3])  # TODO: create a dilation method specific to labels,
+            im_label.data = dilate(im_label.data, 3, 'ball')  # TODO: create a dilation method specific to labels,
             # which does not apply a convolution across all voxels (highly inneficient)
             im_label.save(fname_labelz)
         elif fname_initlabel:
@@ -339,7 +340,7 @@ def main(args=None):
             im_label_c2c3.save(fname_labelz)
 
         # dilate label so it is not lost when applying warping
-        sct_maths.main(['-i', fname_labelz, '-dilate', '3', '-o', fname_labelz])
+        dilate(Image(fname_labelz), 3, 'ball').save(fname_labelz)
 
         # Apply straightening to z-label
         sct.printv('\nAnd apply straightening to label...', verbose)

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -352,12 +352,10 @@ def main(args=None):
         data_out = smooth(data, sigmas)
 
     elif arguments.dilate is not None:
-        data_out = sctmath.morphomath(data, filter='dilation', size=arguments.dilate, shape=arguments.shape,
-                                      dim=arguments.dim)
+        data_out = sctmath.dilate(data, size=arguments.dilate, shape=arguments.shape, dim=arguments.dim)
 
     elif arguments.erode is not None:
-        data_out = sctmath.morphomath(data, filter='erosion', size=arguments.erode, shape=arguments.shape,
-                                      dim=arguments.dim)
+        data_out = sctmath.erode(data, size=arguments.erode, shape=arguments.shape, dim=arguments.dim)
 
     elif arguments.denoise is not None:
         # parse denoising arguments

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -19,6 +19,7 @@ import argparse
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
+import spinalcordtoolbox.math as sctmath
 
 from sct_utils import printv, extract_fname
 import sct_utils as sct
@@ -336,10 +337,10 @@ def main(args=None):
         data_out = smooth(data, sigmas)
 
     elif arguments.dilate is not None:
-        data_out = dilate(data, convert_list_str(arguments.dilate, "int"))
+        data_out = sctmath.dilate(data, convert_list_str(arguments.dilate, "int"))
 
     elif arguments.erode is not None:
-        data_out = erode(data, convert_list_str(arguments.erode, "int"))
+        data_out = sctmath.erode(data, convert_list_str(arguments.erode, "int"))
 
     elif arguments.denoise is not None:
         # parse denoising arguments
@@ -469,40 +470,6 @@ def perc(data, perc_value):
 
 def binarise(data, bin_thr=0):
     return data > bin_thr
-
-
-def dilate(data, radius):
-    """
-    Dilate data using ball structuring element
-    :param data: 2d or 3d array
-    :param radius: radius of structuring element OR comma-separated int.
-    :return: data dilated
-    """
-    from skimage.morphology import dilation, ball
-    if len(radius) == 1:
-        # define structured element as a ball
-        selem = ball(radius[0])
-    else:
-        # define structured element as a box with input dimensions
-        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
-    return dilation(data, selem=selem, out=None)
-
-
-def erode(data, radius):
-    """
-    Erode data using ball structuring element
-    :param data: 2d or 3d array
-    :param radius: radius of structuring element
-    :return: data eroded
-    """
-    from skimage.morphology import erosion, ball
-    if len(radius) == 1:
-        # define structured element as a ball
-        selem = ball(radius[0])
-    else:
-        # define structured element as a box with input dimensions
-        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
-    return erosion(data, selem=selem, out=None)
 
 
 def get_data(list_fname):

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -140,18 +140,33 @@ def get_parser():
     mathematical = parser.add_argument_group("MATHEMATICAL MORPHOLOGY")
     mathematical.add_argument(
         '-dilate',
-        metavar='',
-        help='Dilate binary image. If only one input is given, structured element is a ball with input radius (in '
-             'voxel). If comma-separated inputs are given (Example: 2,4,5 ), structured element is a box with input '
-             'dimensions.',
+        type=int,
+        metavar=Metavar.int,
+        help="Dilate binary image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
+             "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
+             "the center element (size=0 has no effect).",
         required=False)
     mathematical.add_argument(
         '-erode',
-        metavar='',
-        help='Erode binary image. If only one input is given, structured element is a ball with input radius (in '
-             'voxel). If comma-separated inputs are given (Example: 2,4,5), structured element is a box with input '
-             'dimensions.',
+        type=int,
+        metavar=Metavar.int,
+        help="Erode binary image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
+             "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
+             "the center element (size=0 has no effect).",
         required=False)
+    mathematical.add_argument(
+        '-shape',
+        help="Shape of the structuring element for the mathematical morphology operation.",
+        required=False,
+        choices=('square', 'cube', 'disk', 'ball'))
+    mathematical.add_argument(
+        '-dim',
+        type=int,
+        metavar=Metavar.int,
+        help="Dimension of the array which 2D structural element will be orthogonal to. For example, if you wish to "
+             "apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.",
+        required=False,
+        choices=(0, 1, 2))
 
     filtering = parser.add_argument_group("FILTERING METHODS")
     filtering.add_argument(

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -356,7 +356,7 @@ def main(args=None):
                                       dim=arguments.dim)
 
     elif arguments.erode is not None:
-        data_out = sctmath.morphomath(data, filter='erosion', size=arguments.dilate, shape=arguments.shape,
+        data_out = sctmath.morphomath(data, filter='erosion', size=arguments.erode, shape=arguments.shape,
                                       dim=arguments.dim)
 
     elif arguments.denoise is not None:

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -17,12 +17,12 @@ import sys
 import numpy as np
 import argparse
 
+import spinalcordtoolbox as sct
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
-import spinalcordtoolbox.math as sctmath
+import spinalcordtoolbox.math
 
-from sct_utils import printv, extract_fname
-import sct_utils as sct
+from sct_utils import printv, extract_fname, display_viewer_syntax, init_sct
 
 
 ALMOST_ZERO = 0.000000001
@@ -251,7 +251,7 @@ def main(args=None):
     fname_in = arguments.i
     fname_out = arguments.o
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     if '-type' in arguments:
         output_type = arguments.type
     else:
@@ -352,10 +352,10 @@ def main(args=None):
         data_out = smooth(data, sigmas)
 
     elif arguments.dilate is not None:
-        data_out = sctmath.dilate(data, size=arguments.dilate, shape=arguments.shape, dim=arguments.dim)
+        data_out = sct.math.dilate(data, size=arguments.dilate, shape=arguments.shape, dim=arguments.dim)
 
     elif arguments.erode is not None:
-        data_out = sctmath.erode(data, size=arguments.erode, shape=arguments.shape, dim=arguments.dim)
+        data_out = sct.math.erode(data, size=arguments.erode, shape=arguments.shape, dim=arguments.dim)
 
     elif arguments.denoise is not None:
         # parse denoising arguments
@@ -428,7 +428,7 @@ def main(args=None):
 
     # display message
     if data_out is not None:
-        sct.display_viewer_syntax([fname_out], verbose=verbose)
+        display_viewer_syntax([fname_out], verbose=verbose)
     else:
         printv('\nDone! File created: ' + fname_out, verbose, 'info')
 
@@ -496,7 +496,7 @@ def get_data(list_fname):
     try:
         nii = [Image(f_in) for f_in in list_fname]
     except Exception as e:
-        sct.printv(str(e), 1, 'error')  # file does not exist, exit program
+        printv(str(e), 1, 'error')  # file does not exist, exit program
     data0 = nii[0].data
     data = nii[0].data
     # check that every images have same shape
@@ -756,5 +756,5 @@ def correlation(x, y, type='pearson'):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -337,10 +337,12 @@ def main(args=None):
         data_out = smooth(data, sigmas)
 
     elif arguments.dilate is not None:
-        data_out = sctmath.dilate(data, convert_list_str(arguments.dilate, "int"))
+        data_out = sctmath.morphomath(data, filter='dilation', size=arguments.dilate, shape=arguments.shape,
+                                      dim=arguments.dim)
 
     elif arguments.erode is not None:
-        data_out = sctmath.erode(data, convert_list_str(arguments.erode, "int"))
+        data_out = sctmath.morphomath(data, filter='erosion', size=arguments.dilate, shape=arguments.shape,
+                                      dim=arguments.dim)
 
     elif arguments.denoise is not None:
         # parse denoising arguments

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -142,7 +142,7 @@ def get_parser():
         '-dilate',
         type=int,
         metavar=Metavar.int,
-        help="Dilate binary image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
+        help="Dilate binary or greyscale image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
              "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
              "the center element (size=0 has no effect).",
         required=False)
@@ -150,7 +150,7 @@ def get_parser():
         '-erode',
         type=int,
         metavar=Metavar.int,
-        help="Erode binary image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
+        help="Erode binary or greyscale image with specified size. If shape={'square', 'cube'}: size corresponds to the length of "
              "an edge (size=1 has no effect). If shape={'disk', 'ball'}: size corresponds to the radius, not including "
              "the center element (size=0 has no effect).",
         required=False)

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -156,9 +156,10 @@ def get_parser():
         required=False)
     mathematical.add_argument(
         '-shape',
-        help="Shape of the structuring element for the mathematical morphology operation.",
+        help="Shape of the structuring element for the mathematical morphology operation. Default: ball.",
         required=False,
-        choices=('square', 'cube', 'disk', 'ball'))
+        choices=('square', 'cube', 'disk', 'ball'),
+        default='ball')
     mathematical.add_argument(
         '-dim',
         type=int,

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -25,6 +25,7 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.resampling import resample_file
+from spinalcordtoolbox.math import dilate
 
 import sct_utils as sct
 import sct_maths
@@ -474,9 +475,7 @@ def main(args=None):
 
             # Dilating the input label so they can be straighten without losing them
             sct.printv('\nDilating input labels using 3vox ball radius')
-            sct_maths.main(['-i', ftmp_label,
-                            '-dilate', '3',
-                            '-o', add_suffix(ftmp_label, '_dilate')])
+            dilate(Image(ftmp_label), 3, 'ball').save(add_suffix(ftmp_label, '_dilate'))
             ftmp_label = add_suffix(ftmp_label, '_dilate')
 
             # Apply straightening to labels

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8
 # Functions that perform mathematical operations on an image.
 
-from __future__ import absolute_import
 
 import logging
 import numpy as np

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -29,6 +29,19 @@ def dilate(data, size, shape, dim=None):
     # Create structuring element of desired shape and radius
     # Note: the trick here is to use the variable shape as the skimage.morphology function itself
     selem = globals()[shape](size)
+    # If 2d kernel, replicate it along the specified dimension
+    if len(selem.shape) == 2:
+        selem3d = np.zeros([selem.shape[0]]*3)  # Note: selem.shape[0] and selem.shape[1] are supposed to be the same
+        imid = np.floor(selem.shape[0] / 2).astype(int)
+        if dim == 0:
+            selem3d[:, imid, imid] = selem
+        elif dim == 1:
+            selem3d[imid, :, imid] = selem
+        elif dim == 2:
+            selem3d[:, :, imid] = selem
+        else:
+            raise ValueError("dim can only take values: {0, 1, 2}")
+        selem = selem3d
     # else:
     #     # define structured element as a box with input dimensions
     #     selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -13,10 +13,11 @@ from skimage.morphology import erosion, dilation, disk, ball, square, cube
 logger = logging.getLogger(__name__)
 
 
-def dilate(data, size, shape, dim=None):
+def morphomath(data, filter, size, shape, dim=None):
     """
     Dilate data using ball structuring element
     :param data: numpy array: 2d or 3d array
+    :param filter: {'dilation', 'erosion'}: Type of filter to apply
     :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
     If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
     :param shape: {'square', 'cube', 'disk', 'ball'}
@@ -42,23 +43,5 @@ def dilate(data, size, shape, dim=None):
         else:
             raise ValueError("dim can only take values: {0, 1, 2}")
         selem = selem3d
-    # else:
-    #     # define structured element as a box with input dimensions
-    #     selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
-    return dilation(data, selem=selem, out=None)
-
-
-def erode(data, radius):
-    """
-    Erode data using ball structuring element
-    :param data: 2d or 3d array
-    :param radius: radius of structuring element
-    :return: data eroded
-    """
-    if len(radius) == 1:
-        # define structured element as a ball
-        selem = ball(radius[0])
-    else:
-        # define structured element as a box with input dimensions
-        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
-    return erosion(data, selem=selem, out=None)
+    # Applies the specified filter by running skimage.morphology command
+    return globals()[filter](data, selem=selem, out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -5,6 +5,42 @@
 from __future__ import absolute_import
 
 import logging
+import numpy as np
+
+from skimage.morphology import erosion, ball
+
 
 logger = logging.getLogger(__name__)
 
+
+def dilate(data, radius):
+    """
+    Dilate data using ball structuring element
+    :param data: 2d or 3d array
+    :param radius: radius of structuring element OR comma-separated int.
+    :return: data dilated
+    """
+    from skimage.morphology import dilation, ball
+    if len(radius) == 1:
+        # define structured element as a ball
+        selem = ball(radius[0])
+    else:
+        # define structured element as a box with input dimensions
+        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
+    return dilation(data, selem=selem, out=None)
+
+
+def erode(data, radius):
+    """
+    Erode data using ball structuring element
+    :param data: 2d or 3d array
+    :param radius: radius of structuring element
+    :return: data eroded
+    """
+    if len(radius) == 1:
+        # define structured element as a ball
+        selem = ball(radius[0])
+    else:
+        # define structured element as a box with input dimensions
+        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
+    return erosion(data, selem=selem, out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -13,11 +13,12 @@ from skimage.morphology import erosion, dilation, disk, ball, square, cube
 logger = logging.getLogger(__name__)
 
 
-def dilate(data, radius, shape, dim=None):
+def dilate(data, size, shape, dim=None):
     """
     Dilate data using ball structuring element
     :param data: numpy array: 2d or 3d array
-    :param radius: int: Radius of the structuring element. If 0, the convolution has no effect.
+    :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
+    If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
     :param shape: {'square', 'cube', 'disk', 'ball'}
     :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
@@ -25,10 +26,9 @@ def dilate(data, radius, shape, dim=None):
     """
     # TODO: make a build_selem(radius, shape) function called here
     # TODO: enable custom selem
-    shape = 'ball'
     # Create structuring element of desired shape and radius
     # Note: the trick here is to use the variable shape as the skimage.morphology function itself
-    selem = globals()[shape](radius)
+    selem = globals()[shape](size)
     # else:
     #     # define structured element as a box with input dimensions
     #     selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from skimage.morphology import erosion, dilation, disk, ball, square, cube
 
+from spinalcordtoolbox.image import Image
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +57,7 @@ def _get_selem(shape, size, dim):
 def dilate(data, size, shape, dim=None):
     """
     Dilate data using ball structuring element
-    :param data: numpy array: 2d or 3d array
+    :param data: Image or numpy array: 2d or 3d array
     :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
     If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
     :param shape: {'square', 'cube', 'disk', 'ball'}
@@ -63,13 +65,18 @@ def dilate(data, size, shape, dim=None):
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
     :return: numpy array: data dilated
     """
-    return dilation(data, selem=_get_selem(shape, size, dim), out=None)
+    if isinstance(data, Image):
+        im_out = data.copy()
+        im_out.data = dilation(data.data, selem=_get_selem(shape, size, dim), out=None)
+        return im_out
+    else:
+        return dilation(data, selem=_get_selem(shape, size, dim), out=None)
 
 
 def erode(data, size, shape, dim=None):
     """
     Dilate data using ball structuring element
-    :param data: numpy array: 2d or 3d array
+    :param data: Image or numpy array: 2d or 3d array
     :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
     If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
     :param shape: {'square', 'cube', 'disk', 'ball'}
@@ -77,4 +84,9 @@ def erode(data, size, shape, dim=None):
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
     :return: numpy array: data dilated
     """
-    return erosion(data, selem=_get_selem(shape, size, dim), out=None)
+    if isinstance(data, Image):
+        im_out = data.copy()
+        im_out.data = erosion(data.data, selem=_get_selem(shape, size, dim), out=None)
+        return im_out
+    else:
+        return erosion(data, selem=_get_selem(shape, size, dim), out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -12,23 +12,27 @@ from skimage.morphology import erosion, dilation, disk, ball, square, cube
 logger = logging.getLogger(__name__)
 
 
-def morphomath(data, filter, size, shape, dim=None):
+def _get_selem(shape, size, dim):
     """
-    Dilate data using ball structuring element
-    :param data: numpy array: 2d or 3d array
-    :param filter: {'dilation', 'erosion'}: Type of filter to apply
-    :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
-    If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
-    :param shape: {'square', 'cube', 'disk', 'ball'}
+    Create structuring element of desired shape and radius
+    :param shape: str: Shape of the structuring element. See available options below in the code
+    :param size: int: size of the element.
     :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if
     you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
-    :return: numpy array: data dilated
+    :return: numpy array: structuring element
     """
-    # TODO: make a build_selem(radius, shape) function called here
     # TODO: enable custom selem
-    # Create structuring element of desired shape and radius
-    # Note: the trick here is to use the variable shape as the skimage.morphology function itself
-    selem = globals()[shape](size)
+    if shape == 'square':
+        selem = square(size)
+    elif shape == 'cube':
+        selem = cube(size)
+    elif shape == 'disk':
+        selem = disk(size)
+    elif shape == 'ball':
+        selem = ball(size)
+    else:
+        ValueError("This shape is not a valid entry: {}".format(shape))
+
     # If 2d kernel, replicate it along the specified dimension
     if len(selem.shape) == 2:
         selem3d = np.zeros([selem.shape[0]]*3)  # Note: selem.shape[0] and selem.shape[1] are supposed to be the same
@@ -42,5 +46,32 @@ def morphomath(data, filter, size, shape, dim=None):
         else:
             raise ValueError("dim can only take values: {0, 1, 2}")
         selem = selem3d
-    # Applies the specified filter by running skimage.morphology command
-    return globals()[filter](data, selem=selem, out=None)
+    return selem
+
+
+def dilate(data, size, shape, dim=None):
+    """
+    Dilate data using ball structuring element
+    :param data: numpy array: 2d or 3d array
+    :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
+    If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
+    :param shape: {'square', 'cube', 'disk', 'ball'}
+    :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if
+    you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
+    :return: numpy array: data dilated
+    """
+    return dilation(data, selem=_get_selem(shape, size, dim), out=None)
+
+
+def erode(data, size, shape, dim=None):
+    """
+    Dilate data using ball structuring element
+    :param data: numpy array: 2d or 3d array
+    :param size: int: If shape={'square', 'cube'}: Corresponds to the length of an edge (size=1 has no effect).
+    If shape={'disk', 'ball'}: Corresponds to the radius, not including the center element (size=0 has no effect).
+    :param shape: {'square', 'cube', 'disk', 'ball'}
+    :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if
+    you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
+    :return: numpy array: data dilated
+    """
+    return erosion(data, selem=_get_selem(shape, size, dim), out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# Functions that perform mathematical operations on an image.
+
+from __future__ import absolute_import
+
+import logging
+
+logger = logging.getLogger(__name__)
+

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -6,6 +6,8 @@
 import logging
 import numpy as np
 
+from skimage.morphology import erosion, dilation, disk, ball, square, cube
+
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -67,7 +67,7 @@ def dilate(data, size, shape, dim=None):
     """
     if isinstance(data, Image):
         im_out = data.copy()
-        im_out.data = dilation(data.data, selem=_get_selem(shape, size, dim), out=None)
+        im_out.data = dilate(data.data, size, shape, dim)
         return im_out
     else:
         return dilation(data, selem=_get_selem(shape, size, dim), out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -33,9 +33,12 @@ def _get_selem(shape, size, dim):
     else:
         ValueError("This shape is not a valid entry: {}".format(shape))
 
+    if not (len(selem.shape) in [2, 3] and selem.shape[0] == selem.shape[1]):
+        raise ValueError("Invalid shape")
+
     # If 2d kernel, replicate it along the specified dimension
     if len(selem.shape) == 2:
-        selem3d = np.zeros([selem.shape[0]]*3)  # Note: selem.shape[0] and selem.shape[1] are supposed to be the same
+        selem3d = np.zeros([selem.shape[0]]*3)
         imid = np.floor(selem.shape[0] / 2).astype(int)
         if dim == 0:
             selem3d[imid, :, :] = selem

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -86,7 +86,7 @@ def erode(data, size, shape, dim=None):
     """
     if isinstance(data, Image):
         im_out = data.copy()
-        im_out.data = erosion(data.data, selem=_get_selem(shape, size, dim), out=None)
+        im_out.data = erode(data.data, size, shape, dim)
         return im_out
     else:
         return erosion(data, selem=_get_selem(shape, size, dim), out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -6,8 +6,6 @@
 import logging
 import numpy as np
 
-from skimage.morphology import erosion, dilation, disk, ball, square, cube
-
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -35,9 +35,9 @@ def morphomath(data, filter, size, shape, dim=None):
         selem3d = np.zeros([selem.shape[0]]*3)  # Note: selem.shape[0] and selem.shape[1] are supposed to be the same
         imid = np.floor(selem.shape[0] / 2).astype(int)
         if dim == 0:
-            selem3d[:, imid, imid] = selem
+            selem3d[imid, :, :] = selem
         elif dim == 1:
-            selem3d[imid, :, imid] = selem
+            selem3d[:, imid, :] = selem
         elif dim == 2:
             selem3d[:, :, imid] = selem
         else:

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -7,26 +7,31 @@ from __future__ import absolute_import
 import logging
 import numpy as np
 
-from skimage.morphology import erosion, ball
+from skimage.morphology import erosion, dilation, disk, ball, square, cube
 
 
 logger = logging.getLogger(__name__)
 
 
-def dilate(data, radius):
+def dilate(data, radius, shape, dim=None):
     """
     Dilate data using ball structuring element
-    :param data: 2d or 3d array
-    :param radius: radius of structuring element OR comma-separated int.
-    :return: data dilated
+    :param data: numpy array: 2d or 3d array
+    :param radius: int: Radius of the structuring element. If 0, the convolution has no effect.
+    :param shape: {'square', 'cube', 'disk', 'ball'}
+    :param dim: {0, 1, 2}: Dimension of the array which 2D structural element will be orthogonal to. For example, if
+    you wish to apply a 2D disk kernel in the X-Y plane, leaving Z unaffected, parameters will be: shape=disk, dim=2.
+    :return: numpy array: data dilated
     """
-    from skimage.morphology import dilation, ball
-    if len(radius) == 1:
-        # define structured element as a ball
-        selem = ball(radius[0])
-    else:
-        # define structured element as a box with input dimensions
-        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
+    # TODO: make a build_selem(radius, shape) function called here
+    # TODO: enable custom selem
+    shape = 'ball'
+    # Create structuring element of desired shape and radius
+    # Note: the trick here is to use the variable shape as the skimage.morphology function itself
+    selem = globals()[shape](radius)
+    # else:
+    #     # define structured element as a box with input dimensions
+    #     selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
     return dilation(data, selem=selem, out=None)
 
 

--- a/spinalcordtoolbox/testing/create_test_data.py
+++ b/spinalcordtoolbox/testing/create_test_data.py
@@ -16,7 +16,7 @@ DEBUG = False  # Save img_sub
 
 def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None, debug=False):
     # nx, ny, nz = size_arr
-    data = np.zeros(size_arr)
+    data = np.zeros(size_arr, dtype=np.uint8)
     # if not specified, voxel coordinate is set at the middle of the volume
     if coordvox is None:
         coordvox = tuple([round(i / 2) for i in size_arr])

--- a/spinalcordtoolbox/testing/create_test_data.py
+++ b/spinalcordtoolbox/testing/create_test_data.py
@@ -14,6 +14,24 @@ from spinalcordtoolbox.resampling import resample_nib
 DEBUG = False  # Save img_sub
 
 
+def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), debug=False):
+    # nx, ny, nz = size_arr
+    data = np.zeros(size_arr)
+    # Add point in the middle
+    data[[round(i / 2) for i in size_arr]] = 1
+    # Create image with default orientation LPI
+    affine = np.eye(4)
+    affine[0:3, 0:3] = affine[0:3, 0:3] * pixdim
+    nii = nib.nifti1.Nifti1Image(data, affine)
+    img = Image(data, hdr=nii.header, dim=nii.header.get_data_shape())
+    # Update orientation
+    img.change_orientation(orientation)
+    img_sub.change_orientation(orientation)
+    if debug:
+        img_sub.save('tmp_dummy_seg_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
+    return img, img_sub, arr_ctl
+
+
 def dummy_centerline(size_arr=(9, 9, 9), pixdim=(1, 1, 1), subsampling=1, dilate_ctl=0, hasnan=False, zeroslice=[],
                      outlier=[], orientation='RPI', debug=False):
     """

--- a/spinalcordtoolbox/testing/create_test_data.py
+++ b/spinalcordtoolbox/testing/create_test_data.py
@@ -15,13 +15,27 @@ DEBUG = False  # Save img_sub
 
 
 def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None):
+    """
+    Create an image with a non-null voxels at coordinates specified by coordvox.
+    :param size_arr:
+    :param pixdim:
+    :param coordvox: If None: will create a single voxel in the middle of the FOV.
+      If tuple: (x,y,z): Create single voxel at specified coordinate
+      If list of tuples: [(x1,y1,z1), (x2,y2,z2)]: Create multiple voxels.
+    :return: Image object
+    """
     # nx, ny, nz = size_arr
     data = np.zeros(size_arr)
     # if not specified, voxel coordinate is set at the middle of the volume
     if coordvox is None:
         coordvox = tuple([round(i / 2) for i in size_arr])
-    # Add non-null voxel at specified coordinates
-    data[coordvox] = 1
+    elif isinstance(coordvox, list):
+        for icoord in coordvox:
+            data[icoord] = 1
+    elif isinstance(coordvox, tuple):
+        data[coordvox] = 1
+    else:
+        ValueError("Wrong type for coordvox")
     # Create image with default orientation LPI
     affine = np.eye(4)
     affine[0:3, 0:3] = affine[0:3, 0:3] * pixdim

--- a/spinalcordtoolbox/testing/create_test_data.py
+++ b/spinalcordtoolbox/testing/create_test_data.py
@@ -16,7 +16,7 @@ DEBUG = False  # Save img_sub
 
 def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None):
     # nx, ny, nz = size_arr
-    data = np.zeros(size_arr, dtype=np.uint8)
+    data = np.zeros(size_arr)
     # if not specified, voxel coordinate is set at the middle of the volume
     if coordvox is None:
         coordvox = tuple([round(i / 2) for i in size_arr])

--- a/spinalcordtoolbox/testing/create_test_data.py
+++ b/spinalcordtoolbox/testing/create_test_data.py
@@ -14,22 +14,22 @@ from spinalcordtoolbox.resampling import resample_nib
 DEBUG = False  # Save img_sub
 
 
-def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), debug=False):
+def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None, debug=False):
     # nx, ny, nz = size_arr
     data = np.zeros(size_arr)
-    # Add point in the middle
-    data[[round(i / 2) for i in size_arr]] = 1
+    # if not specified, voxel coordinate is set at the middle of the volume
+    if coordvox is None:
+        coordvox = tuple([round(i / 2) for i in size_arr])
+    # Add non-null voxel at specified coordinates
+    data[coordvox] = 1
     # Create image with default orientation LPI
     affine = np.eye(4)
     affine[0:3, 0:3] = affine[0:3, 0:3] * pixdim
     nii = nib.nifti1.Nifti1Image(data, affine)
     img = Image(data, hdr=nii.header, dim=nii.header.get_data_shape())
-    # Update orientation
-    img.change_orientation(orientation)
-    img_sub.change_orientation(orientation)
     if debug:
-        img_sub.save('tmp_dummy_seg_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
-    return img, img_sub, arr_ctl
+        img.save('tmp_dummy_im_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
+    return img
 
 
 def dummy_centerline(size_arr=(9, 9, 9), pixdim=(1, 1, 1), subsampling=1, dilate_ctl=0, hasnan=False, zeroslice=[],

--- a/spinalcordtoolbox/testing/create_test_data.py
+++ b/spinalcordtoolbox/testing/create_test_data.py
@@ -14,7 +14,7 @@ from spinalcordtoolbox.resampling import resample_nib
 DEBUG = False  # Save img_sub
 
 
-def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None, debug=False):
+def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None):
     # nx, ny, nz = size_arr
     data = np.zeros(size_arr, dtype=np.uint8)
     # if not specified, voxel coordinate is set at the middle of the volume
@@ -27,8 +27,6 @@ def dummy_blob(size_arr=(9, 9, 9), pixdim=(1, 1, 1), coordvox=None, debug=False)
     affine[0:3, 0:3] = affine[0:3, 0:3] * pixdim
     nii = nib.nifti1.Nifti1Image(data, affine)
     img = Image(data, hdr=nii.header, dim=nii.header.get_data_shape())
-    if debug:
-        img.save('tmp_dummy_im_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
     return img
 
 

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -11,10 +11,11 @@ import scipy.ndimage.measurements
 from scipy.ndimage.filters import gaussian_filter
 
 import sct_utils as sct
-from sct_maths import mutual_information, dilate
+from sct_maths import mutual_information
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.metadata import get_file_label
+from spinalcordtoolbox.math import dilate
 
 
 def label_vert(fname_seg, fname_label, verbose=1):
@@ -273,8 +274,7 @@ def create_label_z(fname_seg, z, value, fname_labelz='labelz.nii.gz'):
     nii.data[:, :, :] = 0
     nii.data[x, y, z] = value
     # dilate label to prevent it from disappearing due to nearestneighbor interpolation
-    from sct_maths import dilate
-    nii.data = dilate(nii.data, [3])
+    nii.data = dilate(nii.data, 3, 'ball')
     nii.change_orientation(orientation_origin)  # put back in original orientation
     nii.save(fname_labelz)
     return fname_labelz
@@ -310,7 +310,7 @@ def clean_labeled_segmentation(fname_labeled_seg, fname_seg, fname_labeled_seg_n
     img_seg = Image(fname_seg)
     data_labeled_seg_mul = img_labeled_seg.data * img_seg.data
     # dilate to add voxels in segmentation that are not in segmentation_labeled
-    data_labeled_seg_dil = dilate(img_labeled_seg.data, [2])
+    data_labeled_seg_dil = dilate(img_labeled_seg.data, 2, 'ball')
     data_labeled_seg_mul_bin = data_labeled_seg_mul > 0
     data_diff = img_seg.data - data_labeled_seg_mul_bin
     ind_nonzero = np.where(data_diff)

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -48,6 +48,5 @@ def test_dilate(im):
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
 
     # square in xy plane
-    # data_dil = math.dilate(im.data, size=1, shape='disk', dim=0)
-
-    # assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
+    data_dil = math.dilate(im.data, size=1, shape='disk', dim=2)
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -12,7 +12,7 @@ import datetime
 
 from spinalcordtoolbox.utils import __sct_dir__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-import spinalcordtoolbox as sct
+import spinalcordtoolbox.math as sctmath
 
 from create_test_data import dummy_blob
 
@@ -34,25 +34,25 @@ def test_morphomath(im):
         im.save('tmp_dummy_im_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='cube')
+    data_dil = sctmath.dilate(im.data, size=1, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=2, shape='cube')
+    data_dil = sctmath.dilate(im.data, size=2, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 0, 0]))
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=3, shape='cube')
+    data_dil = sctmath.dilate(im.data, size=3, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=0, shape='ball')
+    data_dil = sctmath.dilate(im.data, size=0, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='ball')
+    data_dil = sctmath.dilate(im.data, size=1, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=2, shape='ball')
+    data_dil = sctmath.dilate(im.data, size=2, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
 
     # square in xy plane
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=1)
+    data_dil = sctmath.dilate(im.data, size=1, shape='disk', dim=1)
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[4, 4, 2:7], np.array([0, 1, 1, 1, 0]))
-    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=2)
+    data_dil = sctmath.dilate(im.data, size=1, shape='disk', dim=2)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
-# pytest unit tests for spinalcordtoolbox.process_seg
+# pytest unit tests for spinalcordtoolbox.math
 
-# TODO: add test with known angle (i.e. not found with fitting)
-# TODO: test empty slices and slices with two objects
 
 from __future__ import absolute_import
 import sys
@@ -14,124 +12,23 @@ import numpy as np
 
 from spinalcordtoolbox.utils import __sct_dir__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-from spinalcordtoolbox import process_seg
-from spinalcordtoolbox.centerline.core import ParamCenterline
+from spinalcordtoolbox import math
 
-from create_test_data import dummy_segmentation
+from create_test_data import dummy_blob
 
 
 # Define global variables
 VERBOSE = 0  # set to 2 to save files
 DEBUG = False  # Set to True to save images
 
-
-dict_test_orientation = [
-    {'input': 0.0, 'expected': 0.0},
-    {'input': math.pi, 'expected': 0.0},
-    {'input': -math.pi, 'expected': 0.0},
-    {'input': math.pi / 2, 'expected': 90.0},
-    {'input': -math.pi / 2, 'expected': 90.0},
-    {'input': 2 * math.pi, 'expected': 0.0},
-    {'input': math.pi / 4, 'expected': 45.0},
-    {'input': -math.pi / 4, 'expected': 45.0},
-    {'input': 3 * math.pi / 4, 'expected': 45.0},
-    {'input': -3 * math.pi / 4, 'expected': 45.0},
-    {'input': math.pi / 8, 'expected': 22.5},
-    {'input': -math.pi / 8, 'expected': 22.5},
-    {'input': 3 * math.pi / 8, 'expected': 67.5},
-    {'input': -3 * math.pi / 8, 'expected': 67.5},
-    ]
-
-
-# noinspection 801,PyShadowingNames
-@pytest.mark.parametrize('test_orient', dict_test_orientation)
-def test_fix_orientation(test_orient):
-    assert process_seg.fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)
-
-
-# Generate a list of fake segmentation for testing: (dummy_segmentation(params), dict of expected results)
-im_segs = [
+# Generate a list of dummy images with single pixel in the middle
+list_im = [
     # test area
-    (dummy_segmentation(size_arr=(32, 32, 5), debug=DEBUG),
-     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0, 'length': 5.0},
-     {'angle_corr': False}),
-    # test anisotropic pixel dim
-    (dummy_segmentation(size_arr=(64, 32, 5), pixdim=(0.5, 1, 5), debug=DEBUG),
-     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
-     {'angle_corr': False}),
-    # test with angle IS
-    (dummy_segmentation(size_arr=(32, 32, 5), pixdim=(1, 1, 5), angle_IS=15, debug=DEBUG),
-     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
-     {'angle_corr': False}),
-    # test with ellipse shape
-    (dummy_segmentation(size_arr=(64, 64, 5), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0,
-                        debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 0.0},
-     {'angle_corr': False}),
-    # test with int16. Different bit ordering, which can cause issue when applying transform.warp()
-    (dummy_segmentation(size_arr=(64, 320, 5), pixdim=(1, 1, 1), dtype=np.int16, orientation='RPI',
-                        shape='rectangle', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0, debug=DEBUG),
-     {'area': 297.0, 'angle_RL': 0.0, 'angle_AP': 0.0},
-     {'angle_corr': False}),
-    # test with angled spinal cord (neg angle)
-    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-30.0,
-                        debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -30.0, 'angle_AP': 0.0, 'length': 23.15},
-     {'angle_corr': True}),
-    # test with AP angled spinal cord
-    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_AP=20.0,
-                        debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 20.0, 'length': 21.02},
-     {'angle_corr': True}),
-    # test with RL and AP angled spinal cord
-    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
-                        angle_RL=-10.0, angle_AP=15.0, debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -10.0, 'angle_AP': 15.0},
-     {'angle_corr': True}),
-    # Reproduce issue: "LinAlgError: SVD did not converge". Note: due to the cropping, the estimated angle_RL is wrong,
-    # so it had to be made wrong in the expected values
-    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
-                        angle_RL=-10.0, angle_AP=30.0, debug=DEBUG),
-     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -11.5, 'angle_AP': 30.0},
-     {'angle_corr': True}),
-    # test uint8 input
-    (dummy_segmentation(size_arr=(32, 32, 50), dtype=np.uint8, angle_RL=15, debug=DEBUG),
-     {'area': 77, 'angle_RL': 15.0, 'angle_AP': 0.0},
-     {'angle_corr': True}),
-    # test all output params
-    (dummy_segmentation(size_arr=(128, 128, 5), pixdim=(1, 1, 1), shape='ellipse', radius_RL=50.0, radius_AP=30.0,
-                        debug=DEBUG),
-     {'area': 4701, 'angle_AP': 0.0, 'angle_RL': 0.0, 'diameter_AP': 60.0, 'diameter_RL': 100.0, 'eccentricity': 0.8,
-      'orientation': 0.0},
-     {'angle_corr': False}),
-    # test with one empty slice
-    (dummy_segmentation(size_arr=(32, 32, 5), zeroslice=[2], debug=DEBUG),
-     {'area': np.nan},
-     {'angle_corr': False, 'slice': 2})
+    (dummy_blob(size_arr=(9, 9, 9), debug=DEBUG)),
     ]
 
 # noinspection 801,PyShadowingNames
-@pytest.mark.parametrize('im_seg,expected,params', im_segs)
-def test_compute_shape(im_seg, expected, params):
-    metrics, fit_results = process_seg.compute_shape(im_seg,
-                                                     angle_correction=params['angle_corr'],
-                                                     param_centerline=ParamCenterline(),
-                                                     verbose=VERBOSE)
-    for key in expected.keys():
-        # fetch obtained_value
-        if 'slice' in params:
-            obtained_value = float(metrics['area'].data[params['slice']])
-        else:
-            if key == 'length':
-                # when computing length, sums values across slices
-                obtained_value = metrics[key].data.sum()
-            else:
-                # otherwise, average across slices
-                obtained_value = metrics[key].data.mean()
-        # fetch expected_value
-        if expected[key] is np.nan:
-            assert math.isnan(obtained_value)
-            break
-        else:
-            expected_value = pytest.approx(expected[key], rel=0.05)
-        assert obtained_value == expected_value
+@pytest.mark.parametrize('im', list_im)
+def test_dilate(im):
+    data_dil = math.dilate(im.data, radius=3, shape='disk', dim=0)
+    a=1

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -18,9 +18,8 @@ from spinalcordtoolbox import math
 from create_test_data import dummy_blob
 
 
-# Define global variables
-VERBOSE = 0  # set to 2 to save files
-DEBUG = False  # Set to True to save images
+VERBOSE = int(os.getenv('SCT_VERBOSE', 0))
+DUMP_IMAGES = bool(os.getenv('SCT_DEBUG_IMAGES', False))
 
 # Generate a list of dummy images with single pixel in the middle
 list_im = [

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -49,6 +49,8 @@ def test_morphomath(im):
 
     # square in xy plane
     data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=1)
-    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
+    assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
+    assert np.array_equal(data_dil[4, 4, 2:7], np.array([0, 1, 1, 1, 0]))
     data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=2)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
+    assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -7,12 +7,12 @@ from __future__ import absolute_import
 import sys
 import os
 import pytest
-import math
 import numpy as np
+import datetime
 
 from spinalcordtoolbox.utils import __sct_dir__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-from spinalcordtoolbox import math
+import spinalcordtoolbox as sct
 
 from create_test_data import dummy_blob
 
@@ -23,32 +23,36 @@ DUMP_IMAGES = bool(os.getenv('SCT_DEBUG_IMAGES', False))
 # Generate a list of dummy images with single pixel in the middle
 list_im = [
     # test area
-    (dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4), debug=DEBUG)),
+    (dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4))),
     ]
 
 # noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('im', list_im)
 def test_morphomath(im):
+
+    if DUMP_IMAGES:
+        im.save('tmp_dummy_im_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
+
     # cube (only asserting along one dimension for convenience)
-    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='cube')
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = math.morphomath(im.data, filter='dilation', size=2, shape='cube')
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=2, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 0, 0]))
-    data_dil = math.morphomath(im.data, filter='dilation', size=3, shape='cube')
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=3, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = math.morphomath(im.data, filter='dilation', size=0, shape='ball')
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=0, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='ball')
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
-    data_dil = math.morphomath(im.data, filter='dilation', size=2, shape='ball')
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=2, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
 
     # square in xy plane
-    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=1)
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=1)
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[4, 4, 2:7], np.array([0, 1, 1, 1, 0]))
-    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=2)
+    data_dil = sct.math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=2)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -30,23 +30,25 @@ list_im = [
 
 # noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('im', list_im)
-def test_dilate(im):
+def test_morphomath(im):
     # cube (only asserting along one dimension for convenience)
-    data_dil = math.dilate(im.data, size=1, shape='cube')
+    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = math.dilate(im.data, size=2, shape='cube')
+    data_dil = math.morphomath(im.data, filter='dilation', size=2, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 0, 0]))
-    data_dil = math.dilate(im.data, size=3, shape='cube')
+    data_dil = math.morphomath(im.data, filter='dilation', size=3, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = math.dilate(im.data, size=0, shape='ball')
+    data_dil = math.morphomath(im.data, filter='dilation', size=0, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = math.dilate(im.data, size=1, shape='ball')
+    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
-    data_dil = math.dilate(im.data, size=2, shape='ball')
+    data_dil = math.morphomath(im.data, filter='dilation', size=2, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
 
     # square in xy plane
-    data_dil = math.dilate(im.data, size=1, shape='disk', dim=2)
+    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=1)
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
+    data_dil = math.morphomath(im.data, filter='dilation', size=1, shape='disk', dim=2)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -9,7 +9,6 @@ import os
 import pytest
 import math
 import numpy as np
-from skimage.morphology import erosion, dilation, disk, ball, square, cube
 
 from spinalcordtoolbox.utils import __sct_dir__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8
 # pytest unit tests for spinalcordtoolbox.math
 
+# TODO: Add test for erode and for cases when Image are input
 
 from __future__ import absolute_import
 import sys

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import
 import sys
 import os
-import pytest
 import numpy as np
 import datetime
 
@@ -22,16 +21,12 @@ from create_test_data import dummy_blob
 VERBOSE = int(os.getenv('SCT_VERBOSE', 0))
 DUMP_IMAGES = bool(os.getenv('SCT_DEBUG_IMAGES', False))
 
-# Generate a list of dummy images with single pixel in the middle
-list_im = [
-    # test area
-    (dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4))),
-    ]
 
 # noinspection 801,PyShadowingNames
-@pytest.mark.parametrize('im', list_im)
-def test_morphomath(im):
+def test_dilate():
 
+    # Create dummy image with single pixel in the middle
+    im = dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4))
     if DUMP_IMAGES:
         im.save('tmp_dummy_im_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
 
@@ -43,7 +38,7 @@ def test_morphomath(im):
     data_dil = sct.math.dilate(im.data, size=3, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
 
-    # cube (only asserting along one dimension for convenience)
+    # ball (only asserting along one dimension for convenience)
     data_dil = sct.math.dilate(im.data, size=0, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
     data_dil = sct.math.dilate(im.data, size=1, shape='ball')
@@ -58,3 +53,21 @@ def test_morphomath(im):
     data_dil = sct.math.dilate(im.data, size=1, shape='disk', dim=2)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
+
+    # test with Image as input
+    im_dil = sct.math.dilate(im, size=1, shape='cube')
+    assert np.array_equal(im_dil.data[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
+
+
+# noinspection 801,PyShadowingNames
+def test_erode():
+    # Create dummy image with single pixel
+    im = dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4))
+    # Dilate it
+    im_dil = sct.math.dilate(im, size=1, shape='ball')
+    # Erode it
+    im_dil_erode = sct.math.erode(im_dil, size=1, shape='ball')
+    assert np.array_equal(np.where(im_dil_erode.data), (np.array([4]), np.array([4]), np.array([4])))
+    # Test with data as input
+    data_dil_erode = sct.math.erode(im_dil.data, size=1, shape='ball')
+    assert np.array_equal(np.where(data_dil_erode), (np.array([4]), np.array([4]), np.array([4])))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -9,6 +9,7 @@ import os
 import pytest
 import math
 import numpy as np
+from skimage.morphology import erosion, dilation, disk, ball, square, cube
 
 from spinalcordtoolbox.utils import __sct_dir__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
@@ -24,11 +25,29 @@ DEBUG = False  # Set to True to save images
 # Generate a list of dummy images with single pixel in the middle
 list_im = [
     # test area
-    (dummy_blob(size_arr=(9, 9, 9), debug=DEBUG)),
+    (dummy_blob(size_arr=(9, 9, 9), coordvox=(4, 4, 4), debug=DEBUG)),
     ]
 
 # noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('im', list_im)
 def test_dilate(im):
-    data_dil = math.dilate(im.data, radius=3, shape='disk', dim=0)
-    a=1
+    # cube (only asserting along one dimension for convenience)
+    data_dil = math.dilate(im.data, size=1, shape='cube')
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
+    data_dil = math.dilate(im.data, size=2, shape='cube')
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 0, 0]))
+    data_dil = math.dilate(im.data, size=3, shape='cube')
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
+
+    # cube (only asserting along one dimension for convenience)
+    data_dil = math.dilate(im.data, size=0, shape='ball')
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
+    data_dil = math.dilate(im.data, size=1, shape='ball')
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
+    data_dil = math.dilate(im.data, size=2, shape='ball')
+    assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
+
+    # square in xy plane
+    # data_dil = math.dilate(im.data, size=1, shape='disk', dim=0)
+
+    # assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -10,9 +10,10 @@ import pytest
 import numpy as np
 import datetime
 
+import spinalcordtoolbox as sct
 from spinalcordtoolbox.utils import __sct_dir__
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-import spinalcordtoolbox.math as sctmath
+import spinalcordtoolbox.math
 
 from create_test_data import dummy_blob
 
@@ -34,25 +35,25 @@ def test_morphomath(im):
         im.save('tmp_dummy_im_'+datetime.now().strftime("%Y%m%d%H%M%S%f")+'.nii.gz')
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = sctmath.dilate(im.data, size=1, shape='cube')
+    data_dil = sct.math.dilate(im.data, size=1, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = sctmath.dilate(im.data, size=2, shape='cube')
+    data_dil = sct.math.dilate(im.data, size=2, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 0, 0]))
-    data_dil = sctmath.dilate(im.data, size=3, shape='cube')
+    data_dil = sct.math.dilate(im.data, size=3, shape='cube')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
 
     # cube (only asserting along one dimension for convenience)
-    data_dil = sctmath.dilate(im.data, size=0, shape='ball')
+    data_dil = sct.math.dilate(im.data, size=0, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 0, 1, 0, 0]))
-    data_dil = sctmath.dilate(im.data, size=1, shape='ball')
+    data_dil = sct.math.dilate(im.data, size=1, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
-    data_dil = sctmath.dilate(im.data, size=2, shape='ball')
+    data_dil = sct.math.dilate(im.data, size=2, shape='ball')
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([1, 1, 1, 1, 1]))
 
     # square in xy plane
-    data_dil = sctmath.dilate(im.data, size=1, shape='disk', dim=1)
+    data_dil = sct.math.dilate(im.data, size=1, shape='disk', dim=1)
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[4, 4, 2:7], np.array([0, 1, 1, 1, 0]))
-    data_dil = sctmath.dilate(im.data, size=1, shape='disk', dim=2)
+    data_dil = sct.math.dilate(im.data, size=1, shape='disk', dim=2)
     assert np.array_equal(data_dil[4, 2:7, 4], np.array([0, 1, 1, 1, 0]))
     assert np.array_equal(data_dil[2:7, 4, 4], np.array([0, 1, 1, 1, 0]))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -2,20 +2,15 @@
 # -*- coding: utf-8
 # pytest unit tests for spinalcordtoolbox.math
 
-# TODO: Add test for erode and for cases when Image are input
 
 from __future__ import absolute_import
-import sys
 import os
 import numpy as np
 import datetime
 
 import spinalcordtoolbox as sct
-from spinalcordtoolbox.utils import __sct_dir__
-sys.path.append(os.path.join(__sct_dir__, 'scripts'))
 import spinalcordtoolbox.math
-
-from create_test_data import dummy_blob
+from spinalcordtoolbox.testing.create_test_data import dummy_blob
 
 
 VERBOSE = int(os.getenv('SCT_VERBOSE', 0))

--- a/unit_testing/test_math.py
+++ b/unit_testing/test_math.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# pytest unit tests for spinalcordtoolbox.process_seg
+
+# TODO: add test with known angle (i.e. not found with fitting)
+# TODO: test empty slices and slices with two objects
+
+from __future__ import absolute_import
+import sys
+import os
+import pytest
+import math
+import numpy as np
+
+from spinalcordtoolbox.utils import __sct_dir__
+sys.path.append(os.path.join(__sct_dir__, 'scripts'))
+from spinalcordtoolbox import process_seg
+from spinalcordtoolbox.centerline.core import ParamCenterline
+
+from create_test_data import dummy_segmentation
+
+
+# Define global variables
+VERBOSE = 0  # set to 2 to save files
+DEBUG = False  # Set to True to save images
+
+
+dict_test_orientation = [
+    {'input': 0.0, 'expected': 0.0},
+    {'input': math.pi, 'expected': 0.0},
+    {'input': -math.pi, 'expected': 0.0},
+    {'input': math.pi / 2, 'expected': 90.0},
+    {'input': -math.pi / 2, 'expected': 90.0},
+    {'input': 2 * math.pi, 'expected': 0.0},
+    {'input': math.pi / 4, 'expected': 45.0},
+    {'input': -math.pi / 4, 'expected': 45.0},
+    {'input': 3 * math.pi / 4, 'expected': 45.0},
+    {'input': -3 * math.pi / 4, 'expected': 45.0},
+    {'input': math.pi / 8, 'expected': 22.5},
+    {'input': -math.pi / 8, 'expected': 22.5},
+    {'input': 3 * math.pi / 8, 'expected': 67.5},
+    {'input': -3 * math.pi / 8, 'expected': 67.5},
+    ]
+
+
+# noinspection 801,PyShadowingNames
+@pytest.mark.parametrize('test_orient', dict_test_orientation)
+def test_fix_orientation(test_orient):
+    assert process_seg.fix_orientation(test_orient['input']) == pytest.approx(test_orient['expected'], rel=0.0001)
+
+
+# Generate a list of fake segmentation for testing: (dummy_segmentation(params), dict of expected results)
+im_segs = [
+    # test area
+    (dummy_segmentation(size_arr=(32, 32, 5), debug=DEBUG),
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0, 'length': 5.0},
+     {'angle_corr': False}),
+    # test anisotropic pixel dim
+    (dummy_segmentation(size_arr=(64, 32, 5), pixdim=(0.5, 1, 5), debug=DEBUG),
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
+    # test with angle IS
+    (dummy_segmentation(size_arr=(32, 32, 5), pixdim=(1, 1, 5), angle_IS=15, debug=DEBUG),
+     {'area': 77, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
+    # test with ellipse shape
+    (dummy_segmentation(size_arr=(64, 64, 5), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0,
+                        debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
+    # test with int16. Different bit ordering, which can cause issue when applying transform.warp()
+    (dummy_segmentation(size_arr=(64, 320, 5), pixdim=(1, 1, 1), dtype=np.int16, orientation='RPI',
+                        shape='rectangle', radius_RL=13.0, radius_AP=5.0, angle_RL=0.0, debug=DEBUG),
+     {'area': 297.0, 'angle_RL': 0.0, 'angle_AP': 0.0},
+     {'angle_corr': False}),
+    # test with angled spinal cord (neg angle)
+    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_RL=-30.0,
+                        debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -30.0, 'angle_AP': 0.0, 'length': 23.15},
+     {'angle_corr': True}),
+    # test with AP angled spinal cord
+    (dummy_segmentation(size_arr=(64, 64, 20), shape='ellipse', radius_RL=13.0, radius_AP=5.0, angle_AP=20.0,
+                        debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': 0.0, 'angle_AP': 20.0, 'length': 21.02},
+     {'angle_corr': True}),
+    # test with RL and AP angled spinal cord
+    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
+                        angle_RL=-10.0, angle_AP=15.0, debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -10.0, 'angle_AP': 15.0},
+     {'angle_corr': True}),
+    # Reproduce issue: "LinAlgError: SVD did not converge". Note: due to the cropping, the estimated angle_RL is wrong,
+    # so it had to be made wrong in the expected values
+    (dummy_segmentation(size_arr=(64, 64, 50), shape='ellipse', radius_RL=13.0, radius_AP=5.0,
+                        angle_RL=-10.0, angle_AP=30.0, debug=DEBUG),
+     {'area': 197.0, 'diameter_AP': 10.0, 'diameter_RL': 26.0, 'angle_RL': -11.5, 'angle_AP': 30.0},
+     {'angle_corr': True}),
+    # test uint8 input
+    (dummy_segmentation(size_arr=(32, 32, 50), dtype=np.uint8, angle_RL=15, debug=DEBUG),
+     {'area': 77, 'angle_RL': 15.0, 'angle_AP': 0.0},
+     {'angle_corr': True}),
+    # test all output params
+    (dummy_segmentation(size_arr=(128, 128, 5), pixdim=(1, 1, 1), shape='ellipse', radius_RL=50.0, radius_AP=30.0,
+                        debug=DEBUG),
+     {'area': 4701, 'angle_AP': 0.0, 'angle_RL': 0.0, 'diameter_AP': 60.0, 'diameter_RL': 100.0, 'eccentricity': 0.8,
+      'orientation': 0.0},
+     {'angle_corr': False}),
+    # test with one empty slice
+    (dummy_segmentation(size_arr=(32, 32, 5), zeroslice=[2], debug=DEBUG),
+     {'area': np.nan},
+     {'angle_corr': False, 'slice': 2})
+    ]
+
+# noinspection 801,PyShadowingNames
+@pytest.mark.parametrize('im_seg,expected,params', im_segs)
+def test_compute_shape(im_seg, expected, params):
+    metrics, fit_results = process_seg.compute_shape(im_seg,
+                                                     angle_correction=params['angle_corr'],
+                                                     param_centerline=ParamCenterline(),
+                                                     verbose=VERBOSE)
+    for key in expected.keys():
+        # fetch obtained_value
+        if 'slice' in params:
+            obtained_value = float(metrics['area'].data[params['slice']])
+        else:
+            if key == 'length':
+                # when computing length, sums values across slices
+                obtained_value = metrics[key].data.sum()
+            else:
+                # otherwise, average across slices
+                obtained_value = metrics[key].data.mean()
+        # fetch expected_value
+        if expected[key] is np.nan:
+            assert math.isnan(obtained_value)
+            break
+        else:
+            expected_value = pytest.approx(expected[key], rel=0.05)
+        assert obtained_value == expected_value


### PR DESCRIPTION
This PR brings some improvements to the dilate/erode methods in `sct_maths`:
- ported some of the functions of sct_maths into a new dedicated python module called `math`
- enabled 2D kernel for morpho math operations. Fixes #2615 
- redefinition of selem variable in erosion/dilation kernel.
- added unit tests for morpho math operations
- Updated usage to mention grayscale input. Fixes #2611 
