### PR TITLE
Downgraded TensorFlow to 1.5 to fix AVX incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ requests
 scipy
 scikit-image
 scikit-learn
-tensorflow
+tensorflow==1.5
 xlrd
 xlutils
 xlwt

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -19,6 +19,7 @@ import argparse
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
+import spinalcordtoolbox.math as sctmath
 
 from sct_utils import printv, extract_fname
 import sct_utils as sct
@@ -336,10 +337,10 @@ def main(args=None):
         data_out = smooth(data, sigmas)
 
     elif arguments.dilate is not None:
-        data_out = dilate(data, convert_list_str(arguments.dilate, "int"))
+        data_out = sctmath.dilate(data, convert_list_str(arguments.dilate, "int"))
 
     elif arguments.erode is not None:
-        data_out = erode(data, convert_list_str(arguments.erode, "int"))
+        data_out = sctmath.erode(data, convert_list_str(arguments.erode, "int"))
 
     elif arguments.denoise is not None:
         # parse denoising arguments
@@ -469,40 +470,6 @@ def perc(data, perc_value):
 
 def binarise(data, bin_thr=0):
     return data > bin_thr
-
-
-def dilate(data, radius):
-    """
-    Dilate data using ball structuring element
-    :param data: 2d or 3d array
-    :param radius: radius of structuring element OR comma-separated int.
-    :return: data dilated
-    """
-    from skimage.morphology import dilation, ball
-    if len(radius) == 1:
-        # define structured element as a ball
-        selem = ball(radius[0])
-    else:
-        # define structured element as a box with input dimensions
-        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
-    return dilation(data, selem=selem, out=None)
-
-
-def erode(data, radius):
-    """
-    Erode data using ball structuring element
-    :param data: 2d or 3d array
-    :param radius: radius of structuring element
-    :return: data eroded
-    """
-    from skimage.morphology import erosion, ball
-    if len(radius) == 1:
-        # define structured element as a ball
-        selem = ball(radius[0])
-    else:
-        # define structured element as a box with input dimensions
-        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
-    return erosion(data, selem=selem, out=None)
 
 
 def get_data(list_fname):

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -5,6 +5,42 @@
 from __future__ import absolute_import
 
 import logging
+import numpy as np
+
+from skimage.morphology import erosion, ball
+
 
 logger = logging.getLogger(__name__)
 
+
+def dilate(data, radius):
+    """
+    Dilate data using ball structuring element
+    :param data: 2d or 3d array
+    :param radius: radius of structuring element OR comma-separated int.
+    :return: data dilated
+    """
+    from skimage.morphology import dilation, ball
+    if len(radius) == 1:
+        # define structured element as a ball
+        selem = ball(radius[0])
+    else:
+        # define structured element as a box with input dimensions
+        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
+    return dilation(data, selem=selem, out=None)
+
+
+def erode(data, radius):
+    """
+    Erode data using ball structuring element
+    :param data: 2d or 3d array
+    :param radius: radius of structuring element
+    :return: data eroded
+    """
+    if len(radius) == 1:
+        # define structured element as a ball
+        selem = ball(radius[0])
+    else:
+        # define structured element as a box with input dimensions
+        selem = np.ones((radius[0], radius[1], radius[2]), dtype=np.dtype)
+    return erosion(data, selem=selem, out=None)

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# Functions that perform mathematical operations on an image.
+
+from __future__ import absolute_import
+
+import logging
+
+logger = logging.getLogger(__name__)
+


### PR DESCRIPTION
Older CPUs do not support AVX, which is a requirement for TF>1.5. Several users (>5) are not able to use SCT because of that, so this PR downgrades TF to 1.5 until we find another solution (e.g., move to Pytorch). 

Fixes #2562 