### PR TITLE
Fixed README forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ process those files and output quantitative parameters.
 
 - Open a Terminal
 - Run: `$SCT_DIR/batch_processing.sh`
-- While the processing is being done, we encourage you to look at the [batch script](batch_processing.sh) and try to understand the mean of each command line. If you have any question, please do not hesitate to post on the [forum](https://sourceforge.net/p/spinalcordtoolbox/discussion/help/).
+- While the processing is being done, we encourage you to look at the [batch script](batch_processing.sh) and try to understand the mean of each command line. If you have any question, please do not hesitate to post on the [forum](http://forum.spinalcordmri.org/c/sct).
 
 If you would like to get more examples about what SCT can do, please visit [this address](https://github.com/sct-pipeline/).
 Each repository is a pipeline dedicated to a specific research project.


### PR DESCRIPTION
Forum link in the README redirected to sourceforge instead of spinalcordmri.org

