### PR TITLE
Fit centerline across all slices with input segmentation

### DIFF
--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -36,9 +36,10 @@ def get_parser():
                       type_value="multiple_choice",
                       description="Method used for extracting the centerline.\n"
                                   "optic: automatic spinal cord detection method\n"
-                                  "viewer: manual selection a few points followed by interpolation.",
+                                  "viewer: manual selection a few points followed by interpolation\n"
+                                  "fitseg: automatic spinal cord detection method on allready segmented image.",
                       mandatory=False,
-                      example=['optic', 'viewer'],
+                      example=['optic', 'viewer', 'fitseg'],
                       default_value='optic')
 
     parser.add_option(name='-centerline-algo',
@@ -52,12 +53,6 @@ def get_parser():
                       description='Degree of smoothing for centerline fitting. Only for -centerline-algo {bspline, linear}.',
                       mandatory=False,
                       default_value=30)
-    parser.add_option(name='-m',
-                      type_value='multiple_choice',
-                      description='Algorithm for centerline fitting. Fits centerline across all slices with input segmentation',
-                      mandatory=False,
-                      example=['polyfit', 'bspline', 'linear', 'nurbs'],
-                      default_value='bspline')
     parser.add_option(name="-o",
                       type_value='file_output',
                       description='File name (without extension) for the centerline output files. By default, output'
@@ -97,10 +92,6 @@ def run_main():
     if "-method" in arguments:
         method = arguments["-method"]
 
-    if "-m" in arguments:
-        method = 'seg'
-        algo_fitting = arguments["-m"]
-
     # Contrast type
     contrast_type = ''
     if "-c" in arguments:
@@ -134,9 +125,8 @@ def run_main():
     if method == 'viewer':
         # Manual labeling of cord centerline
         im_labels = _call_viewer_centerline(Image(fname_data), interslice_gap=interslice_gap)
-    if method == 'seg':
+    if method == 'fitseg':
         im_labels = Image(fname_data)
-        param_centerline.algo_fitting = algo_fitting
     else:
         # Automatic detection of cord centerline
         im_labels = Image(fname_data)

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -16,10 +16,10 @@ from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _
 def get_parser():
     # Initialize the parser
     parser = Parser(__file__)
-    parser.usage.set_description("""This function extracts the spinal cord centerline. Two methods are 
+    parser.usage.set_description("""This function extracts the spinal cord centerline. Two methods are
     available: OptiC (automatic) and Viewer (manual). This function outputs (i) a NIFTI file with labels corresponding
     to the discrete centerline, and (ii) a csv file containing the float (more precise) coordinates of the centerline
-    in the RPI orientation. \n\nReference: C Gros, B De Leener, et al. Automatic spinal cord 
+    in the RPI orientation. \n\nReference: C Gros, B De Leener, et al. Automatic spinal cord
     localization, robust to MRI contrast using global curve optimization (2017). doi.org/10.1016/j.media.2017.12.001""")
 
     parser.add_option(name="-i",
@@ -52,7 +52,12 @@ def get_parser():
                       description='Degree of smoothing for centerline fitting. Only for -centerline-algo {bspline, linear}.',
                       mandatory=False,
                       default_value=30)
-
+    parser.add_option(name='-m',
+                      type_value='multiple_choice',
+                      description='Algorithm for centerline fitting. Fits centerline across all slices with input segmentation',
+                      mandatory=False,
+                      example=['polyfit', 'bspline', 'linear', 'nurbs'],
+                      default_value='bspline')
     parser.add_option(name="-o",
                       type_value='file_output',
                       description='File name (without extension) for the centerline output files. By default, output'
@@ -92,6 +97,10 @@ def run_main():
     if "-method" in arguments:
         method = arguments["-method"]
 
+    if "-m" in arguments:
+        method = 'seg'
+        algo_fitting = arguments["-m"]
+
     # Contrast type
     contrast_type = ''
     if "-c" in arguments:
@@ -125,6 +134,9 @@ def run_main():
     if method == 'viewer':
         # Manual labeling of cord centerline
         im_labels = _call_viewer_centerline(Image(fname_data), interslice_gap=interslice_gap)
+    if method == 'seg':
+        im_labels = Image(fname_data)
+        param_centerline.algo_fitting = algo_fitting
     else:
         # Automatic detection of cord centerline
         im_labels = Image(fname_data)

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -133,8 +133,7 @@ def run_main():
         param_centerline.algo_fitting = 'optic'
         param_centerline.contrast = contrast_type
     else:
-        error = 'ERROR: please refer to help'
-        sct.printv(error, type='error')
+        sct.printv("ERROR: The selected method is not available: {}. Please look at the help.".format(method), type='error')
         return
 
 


### PR DESCRIPTION
> When running sct_create_mask -p CENTERLINE, if the centerline has some slices that are missing (i.e., empty slice), then the mask will also be missing for those slices, which could be problematic when the mask is subsequently used for sct_dmri_moco, where all slices need to have a non-zero mask.

The new feature:  

> An additional option has been added in sct_get_centerline -m where users could input the segmentation, and the output would be the segmentation fitted (e.g. bspline, etc.) for all slices.

My understanding is: if the image has been segmented then the get_centerline function will not skip slices. This new option would be used for images where the spinal cord isn't visible on all slices.

DONE:
-I've added flag -m that takes for argument the centerline fitting method. 
-When the flag -m is called a new method "seg" is used to parameter the `get_centerline` function. 
-With method "seg" the function `get_centerline` has: input a segmented image and output the centerline fitted to the segmentation.

Fixes #2629 