### PR TITLE
dwi counter fix

### DIFF
--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -125,7 +125,7 @@ def main(args=None):
         elif arguments.order[i_item] == 'dwi':
             # read bval/bvec files
             bval, bvec = read_bvals_bvecs(arguments.bval[i_dwi], arguments.bvec[i_dwi])
-            i_dwi += 1
+        i_dwi += 1
         # Concatenate bvals
         bvals_concat += ' '.join(str(v) for v in bval)
         bvals_concat += ' '


### PR DESCRIPTION
Fix a counter for DWI files which reads bvec/bval files.

When I run:

`sct_dmri_concat_b0_and_dwi -i dwi_b0.nii.gz dwi_b1000.nii.gz -bval dwi_b0.bval dwi_b1000.bval -bvec dwi_b0.bvec dwi_b1000.bvec -order b0 dwi -o dwi_b0_b1000.nii.gz -obval dwi_b0_b1000.bval -obvec dwi_b0_b1000.bvec`

I got on output `dwi_b0_b1000.bval` containing only b-values from `dwi_b0.bval`, but two times.

So, I fixed indentation in loop.