### PR TITLE
Don't enforce sct_check_dependencies.

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -677,5 +677,5 @@ $DISPLAY_UPDATE_PATH"
 source $RC_FILE_PATH"
   fi
 else
-  die "Installation validation Failed!"
+  echo "Installation validation Failed!"
 fi


### PR DESCRIPTION
This is only useful for debugging. It's more helpful to us to let the install finish,
even if sct_check_dependencies thinks things are wrong, and then for tests to run,
than to jump to a conclusion, at least until sct_check_dependencies gets some maintainance.