### PR TITLE
sct_testing: Use boolean flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,10 @@ script:
     echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
     echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
     if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 -d 0 --abort-on-failure
+      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 --abort-on-failure
       coverage combine
     else
-      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -d 0 --abort-on-failure
+      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing --abort-on-failure
       coverage combine
     fi
 

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -61,12 +61,12 @@ def fs_ok(sig_a, sig_b, exclude=()):
 # Parameters
 class Param:
     def __init__(self):
-        self.download = 0
+        self.download = False
         self.path_data = 'sct_testing_data'  # path to the testing data
         self.path_output = None
         self.function_to_test = None
-        self.remove_tmp_file = 0
-        self.verbose = 0
+        self.remove_tmp_file = False
+        self.verbose = False
         self.args = []  # list of input arguments to the function
         self.args_with_path = ''  # input arguments to the function, with path
         # self.list_fname_gt = []  # list of fname for ground truth data
@@ -114,7 +114,7 @@ def get_parser():
         return jobs
 
     parser.add_argument("--download", "-d",
-     choices=("0", "1"),
+     action="store_true",
      default=param_default.download,
     )
     parser.add_argument("--path", "-p",
@@ -122,8 +122,8 @@ def get_parser():
      default=param_default.path_data,
     )
     parser.add_argument("--remove-temps", "-r",
-     choices=("0", "1"),
      help='Remove temporary files.',
+     action="store_true",
      default=param_default.remove_tmp_file,
     )
     parser.add_argument("--jobs", "-j",
@@ -132,7 +132,7 @@ def get_parser():
      default=arg_jobs(0),
     )
     parser.add_argument("--verbose", "-v",
-     choices=("0", "1"),
+     action="store_true",
      default=param_default.verbose,
     )
     parser.add_argument("--abort-on-failure",


### PR DESCRIPTION
Switch to using standard boolean exist/nonexisting flags instead of passing an integer value. It's weird to say `--download 0` just to disable downloads, and also the types were broken, possibly because argparse changed?

These were weird:

```
(sct_venv) $ sct_testing -v

--
Spinal Cord Toolbox (git-master-be4f8e9890bfc0ba141a8961d21bc8a12c5c979b)

usage: sct_testing.py [-h] [--function FUNCTION [FUNCTION ...]]
                      [--download {0,1}] [--path PATH] [--remove-temps {0,1}]
                      [--jobs JOBS] [--verbose {0,1}] [--abort-on-failure]
                      [--continue-from CONTINUE_FROM] [--check-filesystem]
                      [--execution-folder EXECUTION_FOLDER]
sct_testing.py: error: argument --verbose/-v: expected one argument
```

```
(sct_venv) $ sct_testing -v 0

--
Spinal Cord Toolbox (git-master-be4f8e9890bfc0ba141a8961d21bc8a12c5c979b)

Traceback (most recent call last):
  File "/home/kousu/src/neuropoly/spinalcordtoolbox/scripts/sct_testing.py", line 619, in <module>
    main()
  File "/home/kousu/src/neuropoly/spinalcordtoolbox/scripts/sct_testing.py", line 227, in main
    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
  File "/home/kousu/src/neuropoly/spinalcordtoolbox/scripts/sct_utils.py", line 73, in init_sct
    logger.setLevel(getattr(logging, dict_log_levels[log_level]))
KeyError: '0'
```

```
(sct_venv) $ sct_testing -v 1

--
Spinal Cord Toolbox (git-master-be4f8e9890bfc0ba141a8961d21bc8a12c5c979b)

Traceback (most recent call last):
  File "/home/kousu/src/neuropoly/spinalcordtoolbox/scripts/sct_testing.py", line 619, in <module>
    main()
  File "/home/kousu/src/neuropoly/spinalcordtoolbox/scripts/sct_testing.py", line 227, in main
    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
  File "/home/kousu/src/neuropoly/spinalcordtoolbox/scripts/sct_utils.py", line 73, in init_sct
    logger.setLevel(getattr(logging, dict_log_levels[log_level]))
KeyError: '1'
```

Now this makes sense:

```
(sct_venv) $ sct_testing -v

--
Spinal Cord Toolbox (git-ko/sct_testing-args-543256ebd265a74d2db410c7d70b50d9bd4637fe)

Path to testing data: /home/kousu/src/neuropoly/spinalcordtoolbox/sct_testing_data

Create temporary folder (/tmp/sct-20200424115653.749587-4ltjyht2)...
Will run through the following tests:
- sequentially: sct_deepseg_gm sct_deepseg_lesion sct_deepseg_sc
- in parallel with 4 jobs: sct_analyze_lesion sct_analyze_texture sct_apply_transfo sct_convert sct_compute_ernst_angle sct_compute_hausdorff_distance sct_compute_mtr sct_compute_mscc sct_compute_snr sct_concat_transfo sct_create_mask sct_crop_image sct_dice_coefficient sct_detect_pmj sct_dmri_compute_dti sct_dmri_concat_b0_and_dwi sct_dmri_concat_bvals sct_dmri_concat_bvecs sct_dmri_create_noisemask sct_dmri_compute_bvalue sct_dmri_moco sct_dmri_separate_b0_and_dwi sct_dmri_transpose_bvecs sct_extract_metric sct_flatten_sagittal sct_fmri_compute_tsnr sct_fmri_moco sct_get_centerline sct_image sct_label_utils sct_label_vertebrae sct_maths sct_merge_images sct_process_segmentation sct_propseg sct_qc sct_register_multimodal sct_register_to_template sct_resample sct_smooth_spinalcord sct_straighten_spinalcord sct_warp_template
Checking sct_deepseg_gm.............................
```