### PR TITLE
sct_testing: "allow" download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,10 @@ script:
     echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
     echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
     if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 -d 0 --abort-on-failure
+      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 --abort-on-failure
       coverage combine
     else
-      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -d 0 --abort-on-failure
+      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing --abort-on-failure
       coverage combine
     fi
 

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -232,7 +232,7 @@ def main(args=None):
     param.path_data = os.path.abspath(param.path_data)
 
     # check existence of testing data folder
-    if not os.path.isdir(param.path_data) or param.download:
+    if not os.path.isdir(param.path_data) and param.download:
         downloaddata(param)
 
     # display path to data

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -61,12 +61,12 @@ def fs_ok(sig_a, sig_b, exclude=()):
 # Parameters
 class Param:
     def __init__(self):
-        self.download = 0
+        self.download = False
         self.path_data = 'sct_testing_data'  # path to the testing data
         self.path_output = None
         self.function_to_test = None
-        self.remove_tmp_file = 0
-        self.verbose = 0
+        self.remove_tmp_file = False
+        self.verbose = False
         self.args = []  # list of input arguments to the function
         self.args_with_path = ''  # input arguments to the function, with path
         # self.list_fname_gt = []  # list of fname for ground truth data
@@ -114,7 +114,7 @@ def get_parser():
         return jobs
 
     parser.add_argument("--download", "-d",
-     choices=("0", "1"),
+     action="store_true",
      default=param_default.download,
     )
     parser.add_argument("--path", "-p",
@@ -122,8 +122,8 @@ def get_parser():
      default=param_default.path_data,
     )
     parser.add_argument("--remove-temps", "-r",
-     choices=("0", "1"),
      help='Remove temporary files.',
+     action="store_true",
      default=param_default.remove_tmp_file,
     )
     parser.add_argument("--jobs", "-j",
@@ -132,7 +132,7 @@ def get_parser():
      default=arg_jobs(0),
     )
     parser.add_argument("--verbose", "-v",
-     choices=("0", "1"),
+     action="store_true",
      default=param_default.verbose,
     )
     parser.add_argument("--abort-on-failure",


### PR DESCRIPTION
I want to propose that `--download` means "allow" not "force" download.

It is more intuitive to me that `--download` would control whether `sct_testing` is allowed to download a dataset behind my back, than to say that it *must* download the dataset.
    
If you want to force redownloading you can use `git clean -df` or just `rm -r sct_testing_data; sct_testing`. There's no need for the default behaviour to be `rm -r sct_testing_data; sct_download_data -d sct_testing_data`

This depends on #2672.