### PR TITLE
Support Travis testing arbitrary distros via Docker

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# CI testing script
+#  Installs SCT from scratch and runs all the tests we've ever written for it.
+
+set -e # Error build immediately if install script exits with non-zero
+
+echo Installing SCT
+yes | ASK_REPORT_QUESTION=false ./install_sct
+echo $?
+echo "... STATUS"
+
+echo *** CHECK PATH ***
+ls -lA bin  # Make sure all binaries and aliases are there
+source python/etc/profile.d/conda.sh  # to be able to call conda
+conda activate venv_sct  # reactivate conda for the pip install below
+
+echo *** UNIT TESTS ***
+sct_download_data -d sct_testing_data  # for tests
+pytest
+
+echo *** INTEGRATION TESTS ***
+pip install coverage
+echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
+echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
+COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" \
+  sct_testing --abort-on-failure
+coverage combine
+
+# TODO: move this part to a separate travis job; there's no need for each platform to lint the code
+echo *** ANALYZE CODE ***
+pip install pylint
+bash -c 'PYTHONPATH="$PWD/scripts:$PWD" pylint -j3 --py3k --output-format=parseable --errors-only $(git ls-tree --name-only -r HEAD | sort | grep -E "(spinalcordtoolbox|scripts|testing).*\.py" | xargs); exit $(((($?&3))!=0))'
+
+#
+# echo *** BUILD DOCUMENTATION ***
+# pip install sphinx sphinxcontrib.programoutput sphinx_rtd_theme
+# cd documentation/sphinx
+# make html
+# cd -
+
+# python create_package.py -s ${TRAVIS_OS_NAME}  # test package creation
+# cd ../spinalcordtoolbox_v*
+# yes | ./install_sct  # test installation of package
+

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# CI testing script
+# This is meant to be called from .travis.yml -- it works around limitations
+
+set -e # Error build immediately if install script exits with non-zero
+
+# if this is a docker job, set up and then recurse into the container,
+# instead of continuing.
+# TODO: figure out and pass needed environment variables individually with -e
+
+if ! [ -z "$IMAGE" ]; then
+   docker run \
+     --name container \
+     --init \
+     -it -d \
+     --rm \
+     -v `pwd`:/repo -w /repo \
+     "$IMAGE"
+   trap "docker stop container" EXIT
+   # set up groups to match the owner of /repo, so the installer can't tell
+   docker exec container groupadd -g "`id -g`" `id -g -n`
+   docker exec container useradd -m -u "`id -u`" -g "`id -g`" `id -u -n`
+   docker exec container $DEPS    # install platform-specific dependencies
+   # recurse to run the real test script
+   # --user `id -u` makes sure the build script is the owner of the files at /repo
+   docker exec --user `id -u`:`id -g` container "$0"
+   exit 0
+fi
+
+
+echo Installing SCT
+yes | ASK_REPORT_QUESTION=false ./install_sct
+echo $?
+echo "... STATUS"
+PATH="$PATH:$PWD/bin"
+
+echo *** CHECK PATH ***
+echo $PATH  # Make sure PATH includes sct/bin folder
+ls -lA bin  # Make sure all binaries and aliases are there
+sct_download_data -d sct_testing_data  # for tests
+source python/etc/profile.d/conda.sh  # to be able to call conda
+conda activate venv_sct  # reactivate conda for the pip install below
+
+echo *** UNIT TESTS ***
+pytest
+
+echo *** INTEGRATION TESTS ***
+pip install coverage
+echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
+echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 --abort-on-failure
+  coverage combine
+else
+  COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing --abort-on-failure
+  coverage combine
+fi
+
+# TODO: move this part to a separate travis job; there's no need for each platform to lint the code
+echo *** ANALYZE CODE ***
+pip install pylint
+bash -c 'PYTHONPATH="$PWD/scripts:$PWD" pylint -j3 --py3k --output-format=parseable --errors-only $(git ls-tree --name-only -r HEAD | sort | grep -E "(spinalcordtoolbox|scripts|testing).*\.py" | xargs); exit $(((($?&3))!=0))'
+
+#
+# echo *** BUILD DOCUMENTATION ***
+# pip install sphinx sphinxcontrib.programoutput sphinx_rtd_theme
+# cd documentation/sphinx
+# make html
+# cd -
+
+# python create_package.py -s ${TRAVIS_OS_NAME}  # test package creation
+# cd ../spinalcordtoolbox_v*
+# yes | ./install_sct  # test installation of package
+

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,76 +1,18 @@
 #!/bin/bash
-# CI testing script
-# This is meant to be called from .travis.yml -- it works around limitations
+# TravisCI testing harness.
+#  Supports running locally (i.e. on whatever platform Travis has loaded us in)
+#  or in a docker container specified by $DOCKER_IMAGE.
+#
+# usage: .travis.sh
+#
+# e.g. DOCKER_IMAGE="centos:8" .travis.sh
 
 set -e # Error build immediately if install script exits with non-zero
 
-# if this is a docker job, set up and recurse into the container,
-# instead of continuing.
+# if this is a docker job, run in the container instead; but if not just run it here.
 if [ -n "$DOCKER_IMAGE" ]; then
-   docker run \
-     --name container \
-     --init \
-     -it -d \
-     --rm \
-     -v "`pwd`":/repo -w /repo \
-     "$DOCKER_IMAGE"
-   trap "docker stop container" EXIT
-   # set up a user:group matching that of the volume mount /repo, so the installer isn't confused
-   #
-   # TODO: it would be nice if the volume was mounted at `pwd`/, to further reduce the distinction
-   # between docker/nondocker runs, but docker gets the permissions wrong:
-   # it does `mkdir -p $mountpoint` *as root* so while the contents of the mountpoint are owned by
-   # $USER, its parents are owned by root, usually including /home/$USER which breaks things like pip.
-   # and there's no way to boot a container, `mkdir -p` manually, then attach the volume *after*.
-   docker exec container groupadd -g "`id -g`" "`id -g -n`"
-   docker exec container useradd -m -u "`id -u`" -g "`id -g`" "`id -u -n`"
-   # install platform-specific dependencies
-   if [ -n "$DOCKER_DEPS_CMD" ]; then
-       docker exec container $DOCKER_DEPS_CMD
-  fi
-   # recurse to run the real test script
-   # --user `id -u` makes sure the build script is the owner of the files at /repo
-   # TODO: pass through the Travis envs: https://docs.travis-ci.com/user/environment-variables/
-   docker exec --user "`id -u`":"`id -g`" container "$0"
-   exit 0
+    ./util/dockerize.sh ./.ci.sh
+else
+    ./.ci.sh
 fi
-
-
-echo Installing SCT
-yes | ASK_REPORT_QUESTION=false ./install_sct
-echo $?
-echo "... STATUS"
-
-echo *** CHECK PATH ***
-ls -lA bin  # Make sure all binaries and aliases are there
-source python/etc/profile.d/conda.sh  # to be able to call conda
-conda activate venv_sct  # reactivate conda for the pip install below
-
-echo *** UNIT TESTS ***
-sct_download_data -d sct_testing_data  # for tests
-pytest
-
-echo *** INTEGRATION TESTS ***
-pip install coverage
-echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
-echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
-COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" \
-  sct_testing --abort-on-failure
-coverage combine
-
-# TODO: move this part to a separate travis job; there's no need for each platform to lint the code
-echo *** ANALYZE CODE ***
-pip install pylint
-bash -c 'PYTHONPATH="$PWD/scripts:$PWD" pylint -j3 --py3k --output-format=parseable --errors-only $(git ls-tree --name-only -r HEAD | sort | grep -E "(spinalcordtoolbox|scripts|testing).*\.py" | xargs); exit $(((($?&3))!=0))'
-
-#
-# echo *** BUILD DOCUMENTATION ***
-# pip install sphinx sphinxcontrib.programoutput sphinx_rtd_theme
-# cd documentation/sphinx
-# make html
-# cd -
-
-# python create_package.py -s ${TRAVIS_OS_NAME}  # test package creation
-# cd ../spinalcordtoolbox_v*
-# yes | ./install_sct  # test installation of package
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -4,29 +4,34 @@
 
 set -e # Error build immediately if install script exits with non-zero
 
-# if this is a docker job, set up and then recurse into the container,
+# if this is a docker job, set up and recurse into the container,
 # instead of continuing.
-# TODO: figure out and pass needed environment variables individually with -e
-
 if [ -n "$DOCKER_IMAGE" ]; then
    docker run \
      --name container \
      --init \
      -it -d \
      --rm \
-     -v `pwd`:/repo -w /repo \
+     -v "`pwd`":/repo -w /repo \
      "$DOCKER_IMAGE"
    trap "docker stop container" EXIT
    # set up a user:group matching that of the volume mount /repo, so the installer isn't confused
-   docker exec container groupadd -g "`id -g`" `id -g -n`
-   docker exec container useradd -m -u "`id -u`" -g "`id -g`" `id -u -n`
+   #
+   # TODO: it would be nice if the volume was mounted at `pwd`/, to further reduce the distinction
+   # between docker/nondocker runs, but docker gets the permissions wrong:
+   # it does `mkdir -p $mountpoint` *as root* so while the contents of the mountpoint are owned by
+   # $USER, its parents are owned by root, usually including /home/$USER which breaks things like pip.
+   # and there's no way to boot a container, `mkdir -p` manually, then attach the volume *after*.
+   docker exec container groupadd -g "`id -g`" "`id -g -n`"
+   docker exec container useradd -m -u "`id -u`" -g "`id -g`" "`id -u -n`"
+   # install platform-specific dependencies
    if [ -n "$DOCKER_DEPS_CMD" ]; then
-       docker exec container $DOCKER_DEPS_CMD    # install platform-specific dependencies
-   fi
+       docker exec container $DOCKER_DEPS_CMD
+  fi
    # recurse to run the real test script
    # --user `id -u` makes sure the build script is the owner of the files at /repo
    # TODO: pass through the Travis envs: https://docs.travis-ci.com/user/environment-variables/
-   docker exec --user `id -u`:`id -g` container "$0"
+   docker exec --user "`id -u`":"`id -g`" container "$0"
    exit 0
 fi
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -35,16 +35,14 @@ echo Installing SCT
 yes | ASK_REPORT_QUESTION=false ./install_sct
 echo $?
 echo "... STATUS"
-PATH="$PATH:$PWD/bin"
 
 echo *** CHECK PATH ***
-echo $PATH  # Make sure PATH includes sct/bin folder
 ls -lA bin  # Make sure all binaries and aliases are there
-sct_download_data -d sct_testing_data  # for tests
 source python/etc/profile.d/conda.sh  # to be able to call conda
 conda activate venv_sct  # reactivate conda for the pip install below
 
 echo *** UNIT TESTS ***
+sct_download_data -d sct_testing_data  # for tests
 pytest
 
 echo *** INTEGRATION TESTS ***

--- a/.travis.sh
+++ b/.travis.sh
@@ -51,13 +51,10 @@ echo *** INTEGRATION TESTS ***
 pip install coverage
 echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
 echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
-if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-  COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 --abort-on-failure
-  coverage combine
-else
-  COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing --abort-on-failure
-  coverage combine
-fi
+COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" \
+  sct_testing --abort-on-failure \
+  $([ "$(uname -s)" = "Darwin" ] && echo -n "-j 1")
+coverage combine
 
 # TODO: move this part to a separate travis job; there's no need for each platform to lint the code
 echo *** ANALYZE CODE ***

--- a/.travis.sh
+++ b/.travis.sh
@@ -52,8 +52,7 @@ pip install coverage
 echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
 echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
 COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" \
-  sct_testing --abort-on-failure \
-  $([ "$(uname -s)" = "Darwin" ] && echo -n "-j 1")
+  sct_testing --abort-on-failure
 coverage combine
 
 # TODO: move this part to a separate travis job; there's no need for each platform to lint the code

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,6 @@ matrix:
       name: "CentOS 7"
       env:
         - DEPS="yum install -y which gcc git curl" IMAGE="centos:7"
-    - os: linux
-      dist: trusty # kernel ~= Centos6
-      services:
-        - docker
-      name: "CentOS 6"
-      env:
-        - DEPS="yum install -y which gcc git curl" IMAGE="centos:6"
     # The rest of the OSes can use Travis's built-in images:
     - os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
       name: "Ubuntu 18.04 (Bionic Beaver)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
     # To support OSes that Travis doesn't, we mix in Docker images.
     # Any such OS (CentOS, etc) will be booted in docker instead.
-    # OSes in this case are marked by using IMAGE: instead of dist:.
+    # OSes in this case are marked by using DOCKER_IMAGE: instead of dist:.
     #
     # Since Docker images are usually very barebones,
     # these need a DEPS command that should install the
@@ -30,21 +30,21 @@ matrix:
         - docker
       name: "ArchLinux"
       env:
-        - IMAGE="archlinux" DEPS="pacman -Sy --noconfirm which gcc git curl"
+        - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm which gcc git curl"
     - os: linux
       dist: bionic # kernel ~= Centos8
       services:
         - docker
       name: "CentOS 8"
       env:
-        - DEPS="yum install -y which gcc git curl" IMAGE="centos:8"
+        - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
     - os: linux
       dist: xenial # kernel ~= Centos7
       services:
         - docker
       name: "CentOS 7"
       env:
-        - DEPS="yum install -y which gcc git curl" IMAGE="centos:7"
+        - DOCKER_IMAGE="centos:7" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
     # The rest of the OSes can use Travis's built-in images:
     - os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
       name: "Ubuntu 18.04 (Bionic Beaver)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # testing file for Travis
 # https://travis-ci.org/neuropoly/spinalcordtoolbox
 
-sudo: false  # To use travis container infrastructure
-
 notifications:
   slack: neuropoly:YA3mt28aeHN3A0Iu7RvMFigK
     on_success:change
@@ -15,6 +13,46 @@ notifications:
 
 matrix:
   include:
+    # To support OSes that Travis doesn't, we mix in Docker images.
+    # Any such OS (CentOS, etc) will be booted in docker instead.
+    # OSes in this case are marked by using IMAGE: instead of dist:.
+    #
+    # Since Docker images are usually very barebones,
+    # these need a DEPS command that should install the
+    # basic dependencies needed for conda etc.
+    #
+    # Testing this way is imperfect -- these docker images are not
+    # identical to freshly installed VMs, and by using docker we're
+    # mismatching kernels, but it is a lot better than not testing.
+    - os: linux
+      dist: bionic  # Arch needs a recent kernel
+      services:
+        - docker
+      name: "ArchLinux"
+      env:
+        - IMAGE="archlinux" DEPS="pacman -Sy --noconfirm which gcc git curl"
+    - os: linux
+      dist: bionic # kernel ~= Centos8
+      services:
+        - docker
+      name: "CentOS 8"
+      env:
+        - DEPS="yum install -y which gcc git curl" IMAGE="centos:8"
+    - os: linux
+      dist: xenial # kernel ~= Centos7
+      services:
+        - docker
+      name: "CentOS 7"
+      env:
+        - DEPS="yum install -y which gcc git curl" IMAGE="centos:7"
+    - os: linux
+      dist: trusty # kernel ~= Centos6
+      services:
+        - docker
+      name: "CentOS 6"
+      env:
+        - DEPS="yum install -y which gcc git curl" IMAGE="centos:6"
+    # The rest of the OSes can use Travis's built-in images:
     - os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
       name: "Ubuntu 18.04 (Bionic Beaver)"
       dist: bionic
@@ -34,60 +72,4 @@ matrix:
       name: "OSX 10.12 (Sierra)"
       osx_image: xcode9.2
 
-install:
-  - |
-    echo Installing SCT
-    set -e  # Error build immediately if install script exits with non-zero
-    yes | ASK_REPORT_QUESTION=false ./install_sct
-    echo $?
-    echo "... STATUS"
-    PATH="$PATH:$PWD/bin"
-
-before_script:
-  - |
-    echo *** CHECK PATH ***
-    echo $PATH  # Make sure PATH includes sct/bin folder
-    ls -lA bin  # Make sure all binaries and aliases are there
-    sct_download_data -d sct_testing_data  # for tests
-    source python/etc/profile.d/conda.sh  # to be able to call conda
-    conda activate venv_sct  # reactivate conda for the pip install below
-
-script:
-  - |
-    echo *** UNIT TESTS ***
-    pytest
-
-  - |
-    echo *** INTEGRATION TESTS ***
-    pip install coverage
-    echo -ne "import coverage\ncov = coverage.process_startup()\n" > sitecustomize.py
-    echo -ne "[run]\nconcurrency = multiprocessing\nparallel = True\n" > .coveragerc
-    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing -j 1 --abort-on-failure
-      coverage combine
-    else
-      COVERAGE_PROCESS_START="$PWD/.coveragerc" COVERAGE_FILE="$PWD/.coverage" sct_testing --abort-on-failure
-      coverage combine
-    fi
-
-  - |
-    echo *** ANALYZE CODE ***
-    pip install pylint
-    bash -c 'PYTHONPATH="$PWD/scripts:$PWD" pylint -j3 --py3k --output-format=parseable --errors-only $(git ls-tree --name-only -r HEAD | sort | grep -E "(spinalcordtoolbox|scripts|testing).*\.py" | xargs); exit $(((($?&3))!=0))'
-
-#  - |
-#    echo *** BUILD DOCUMENTATION ***
-#    pip install sphinx sphinxcontrib.programoutput sphinx_rtd_theme
-#    cd documentation/sphinx
-#    make html
-#    cd -
-
-#  - python create_package.py -s ${TRAVIS_OS_NAME}  # test package creation
-#  - cd ../spinalcordtoolbox_v*
-#  - yes | ./install_sct  # test installation of package
-#   - |
-#     pip install coveralls
-#     echo "This is the end, thanks for reading up to here."
-
-# after_success:
-#   - CI=true TRAVIS=true coveralls
+script: ./.travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,41 @@ matrix:
       env:
         - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm which gcc git curl"
     - os: linux
+      dist: bionic
+      services:
+        - docker
+      name: "Debian Rolling Release"
+      env:
+        - DOCKER_IMAGE="debian:sid"     DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
+    - os: linux
+      dist: bionic
+      services:
+        - docker
+      name: "Debian Testing"
+      env:
+        - DOCKER_IMAGE="debian:testing" DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
+    - os: linux
+      dist: bionic # kernel ~= Debian:10
+      services:
+        - docker
+      name: "Debian 10"
+      env:
+        - DOCKER_IMAGE="debian:10"      DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
+    - os: linux
+      dist: xenial # kernel ~= Debian:9
+      services:
+        - docker
+      name: "Debian 9"
+      env:
+        - DOCKER_IMAGE="debian:9"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
+    - os: linux
+      dist: xenial # kernel ~= Debian:8
+      services:
+        - docker
+      name: "Debian 8"
+      env:
+        - DOCKER_IMAGE="debian:8"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
+    - os: linux
       dist: bionic # kernel ~= Centos8
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,65 +24,65 @@ matrix:
     # Testing this way is imperfect -- these docker images are not
     # identical to freshly installed VMs, and by using docker we're
     # mismatching kernels, but it is a lot better than not testing.
-    - os: linux
+    - name: "ArchLinux"
+      os: linux
       dist: bionic  # Arch needs a recent kernel
       services:
         - docker
-      name: "ArchLinux"
       env:
         - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm which gcc git curl"
-    - os: linux
+    - name: "Debian Rolling Release"
+      os: linux
       dist: bionic
       services:
         - docker
-      name: "Debian Rolling Release"
       env:
         - DOCKER_IMAGE="debian:sid"     DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
-    - os: linux
+    - name: "Debian Testing"
+      os: linux
       dist: bionic
       services:
         - docker
-      name: "Debian Testing"
       env:
         - DOCKER_IMAGE="debian:testing" DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
-    - os: linux
+    - name: "Debian 10"
+      os: linux
       dist: bionic # kernel ~= Debian:10
       services:
         - docker
-      name: "Debian 10"
       env:
         - DOCKER_IMAGE="debian:10"      DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
-    - os: linux
+    - name: "Debian 9"
+      os: linux
       dist: xenial # kernel ~= Debian:9
       services:
         - docker
-      name: "Debian 9"
       env:
         - DOCKER_IMAGE="debian:9"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
-    - os: linux
+    - name: "Debian 8"
+      os: linux
       dist: xenial # kernel ~= Debian:8
       services:
         - docker
-      name: "Debian 8"
       env:
         - DOCKER_IMAGE="debian:8"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
-    - os: linux
+    - name: "CentOS 8"
+      os: linux
       dist: bionic # kernel ~= Centos8
       services:
         - docker
-      name: "CentOS 8"
       env:
         - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
-    - os: linux
+    - name: "CentOS 7"
+      os: linux
       dist: xenial # kernel ~= Centos7
       services:
         - docker
-      name: "CentOS 7"
       env:
         - DOCKER_IMAGE="centos:7" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
     # The rest of the OSes can use Travis's built-in images:
-    - os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
-      name: "Ubuntu 18.04 (Bionic Beaver)"
+    - name: "Ubuntu 18.04 (Bionic Beaver)"
+      os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
       dist: bionic
     - os: linux
       name: "Ubuntu 16.04 (Xenial)"
@@ -90,14 +90,14 @@ matrix:
     - os: linux
       name: "Ubuntu 14.04 (Trusty)"
       dist: trusty
-    - os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
-      name: "OSX 10.14 (Mojave)"
+    - name: "OSX 10.14 (Mojave)"
+      os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode11.2
-    - os: osx
-      name: "OSX 10.13 (High Sierra)"
+    - name: "OSX 10.13 (High Sierra)"
+      os: osx
       osx_image: xcode9.4
-    - os: osx
-      name: "OSX 10.12 (Sierra)"
+    - name: "OSX 10.12 (Sierra)"
+      os: osx
       osx_image: xcode9.2
 
 script: ./.travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     # identical to freshly installed VMs, and by using docker we're
     # mismatching kernels, but it is a lot better than not testing.
     - name: "ArchLinux"
+      if: branch = release or type = cron
       os: linux
       dist: bionic  # Arch needs a recent kernel
       services:
@@ -32,6 +33,7 @@ matrix:
       env:
         - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm which gcc git curl"
     - name: "Debian Rolling Release"
+      if: branch = release or type = cron
       os: linux
       dist: bionic
       services:
@@ -39,6 +41,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:sid"     DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian Testing"
+      if: branch = release or type = cron
       os: linux
       dist: bionic
       services:
@@ -46,6 +49,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:testing" DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 10"
+      if: branch = release or type = cron
       os: linux
       dist: bionic # kernel ~= Debian:10
       services:
@@ -53,6 +57,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:10"      DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 9"
+      if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Debian:9
       services:
@@ -60,6 +65,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:9"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 8"
+      if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Debian:8
       services:
@@ -67,6 +73,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:8"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "CentOS 8"
+      # runs on all branches
       os: linux
       dist: bionic # kernel ~= Centos8
       services:
@@ -74,6 +81,7 @@ matrix:
       env:
         - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
     - name: "CentOS 7"
+      if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Centos7
       services:
@@ -82,21 +90,27 @@ matrix:
         - DOCKER_IMAGE="centos:7" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
     # The rest of the OSes can use Travis's built-in images:
     - name: "Ubuntu 18.04 (Bionic Beaver)"
+      # runs on all branches
       os: linux  # list of Linux env: https://docs.travis-ci.com/user/reference/overview/
       dist: bionic
     - os: linux
       name: "Ubuntu 16.04 (Xenial)"
+      if: branch = release or type = cron
       dist: xenial
     - os: linux
+      if: branch = release or type = cron
       name: "Ubuntu 14.04 (Trusty)"
       dist: trusty
     - name: "OSX 10.14 (Mojave)"
+      # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode11.2
     - name: "OSX 10.13 (High Sierra)"
+      if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
     - name: "OSX 10.12 (Sierra)"
+      if: branch = release or type = cron
       os: osx
       osx_image: xcode9.2
 

--- a/util/dockerize.sh
+++ b/util/dockerize.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# dockerize.sh: run a script inside of another.
+#
+# usage: DOCKER_IMAGE="<image>" DOCKER_DEPS_CMD="<command to run before script>" dockerize.sh script.sh
+
+set -e # Error build immediately if install script exits with non-zero
+
+docker run \
+    --name container \
+    --init \
+    -it -d \
+    --rm \
+    -v "`pwd`":/repo -w /repo \
+    "$DOCKER_IMAGE"
+trap "docker stop container" EXIT
+# set up a user:group matching that of the volume mount /repo, so the installer isn't confused
+#
+# TODO: it would be nice if the volume was mounted at `pwd`/, to further reduce the distinction
+# between docker/nondocker runs, but docker gets the permissions wrong:
+# it does `mkdir -p $mountpoint` *as root* so while the contents of the mountpoint are owned by
+# $USER, its parents are owned by root, usually including /home/$USER which breaks things like pip.
+# and there's no way to boot a container, `mkdir -p` manually, then attach the volume *after*.
+docker exec container groupadd -g "`id -g`" "`id -g -n`"
+docker exec container useradd -m -u "`id -u`" -g "`id -g`" "`id -u -n`"
+# install platform-specific dependencies
+if [ -n "$DOCKER_DEPS_CMD" ]; then
+    docker exec container $DOCKER_DEPS_CMD
+fi
+# recurse to run the real test script
+# --user `id -u` makes sure the build script is the owner of the files at /repo
+# TODO: pass through the Travis envs: https://docs.travis-ci.com/user/environment-variables/
+docker exec --user "`id -u`":"`id -g`" container "$1"

--- a/util/dockerize.sh
+++ b/util/dockerize.sh
@@ -24,7 +24,7 @@ docker exec container groupadd -g "`id -g`" "`id -g -n`"
 docker exec container useradd -m -u "`id -u`" -g "`id -g`" "`id -u -n`"
 # install platform-specific dependencies
 if [ -n "$DOCKER_DEPS_CMD" ]; then
-    docker exec container $DOCKER_DEPS_CMD
+    docker exec container sh -c "$DOCKER_DEPS_CMD"
 fi
 # recurse to run the real test script
 # --user `id -u` makes sure the build script is the owner of the files at /repo


### PR DESCRIPTION
This adds Debian, CentOS, and ArchLinux to Travis, and it is easy to add other Linux distros thanks to Docker.

I could not decide on a better way than to [take Travis' advice](https://docs.travis-ci.com/user/job-lifecycle/#complex-build-commands) and move the entire test script to a separate shell script because we depend deeply on being able to pass environment variables from one step to the next in order to set up our venv (for `bin/` and for `conda`), and that just doesn't work with a series of `docker exec`s. This means losing the nice collapsing of sections that Travis does, but I don't think that's a big deal; I usually look at the raw plaintext logs anyway.

This adds only minimal time to CI because each build runs in mostly parallel. I've seen Travis running 6 at a time. I predict on average it adds 10 minutes to the time.

~CentOS6 is failing because of [Tensorflow](https://github.com/neuropoly/spinalcordtoolbox/issues/2675#issuecomment-623978583) and because of [antsSliceRegularizedRegistration](https://github.com/neuropoly/spinalcordtoolbox/issues/2600). I did not fix the latter in #2642, it was too hard for me, and the former is out of our purview.~ **Depends on** #2699, which removes CentOS6.

## TODO

* [x] Decide if we will deprecate CentOS6 ( #2675 ) now, or try to fix the issues to keep it alive, or just comment out the CentOS6 case and leave it untested. => yes, drop it
* [x] Drop centos6
* [x] Test script cleanups:
  * [x] There's no need to edit PATH manually; it's only for accessing `sct_*` and those are available by `conda activate`.
  * [x] The splitbrain `if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ... -j 1 ...` can be simplified
* ~~Mount the docker volume at the *same* `pwd` as the outer OS, to improve consistency between the environments~~ this isn't going to work: 15fbb00
  * ~~done in https://github.com/neuropoly/spinalcordtoolbox/tree/ko/CI-centos7-2 but not yet merged because I want to see what Travis says about individual steps~~

### Optional/future TODOs

* [x] Pull the deep docker magic into its own wrapper shell script: https://github.com/neuropoly/spinalcordtoolbox/pull/2698#discussion_r422447848
  * done in https://github.com/neuropoly/spinalcordtoolbox/tree/ko/CI-centos7-3 but not yet merged back here because I want to see what Travis says about it
* [x] Test if we can drop the `-j 1` restriction on OS X entirely
  * testing in https://github.com/neuropoly/spinalcordtoolbox/tree/ko/CI-centos7-testosx
* [x] Add more distros
  * [x] Debian `sid`
  * [x] Debian `testing`
  * [x] Debian 10
  * [x] Debian 9
  * [x] Debian 8
    * done in https://github.com/neuropoly/spinalcordtoolbox/tree/ko/CI-centos7-4; waiting on CI to see if it's worth merging here
  * ~~NixOS~~
* [ ] Detect and pass relevant environment variables into Docker
  - Docker is usually meant to be an isolated environment so it inherits no envs by default; but we probably want to at least pass through all the TRAVIS_ envs.
*  ~~Move pylint to an entirely separate travis job~~
  - ~~this should speed up the build; linting takes about 30s to a minute each run; no need to duplicate the work~~
  - I'm planning to do this on the same PR that adds PEP8 (https://github.com/neuropoly/spinalcordtoolbox/issues/1538)
* ~~Verify that `coverage` is actually producing useful information.~~ @ #2702.

Fixes #2313.