### PR TITLE
Moved sct_download_data functions to new download module

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -12,19 +12,10 @@
 
 from __future__ import absolute_import
 
-import cgi
 import os
 import sys
-import tarfile
-import tempfile
-import zipfile
-from shutil import rmtree
-from distutils.dir_util import copy_tree
 
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
-from tqdm import tqdm
+from spinalcordtoolbox.download import DICT_URL, install_data
 
 from msct_parser import Parser
 import sct_utils as sct
@@ -38,6 +29,7 @@ def get_parser():
         type_value="multiple_choice",
         description="Name of the dataset.",
         mandatory=True,
+        # TODO: replace with key dict items
         example=[
             'sct_example_data',
             'sct_testing_data',
@@ -51,6 +43,7 @@ def get_parser():
             'optic_models',
             'pmj_models',
             'binaries_debian',
+            'binaries_centos',
             'binaries_osx',
             'deepseg_gm_models',
             'deepseg_sc_models',
@@ -82,44 +75,6 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
 
-    # initialization
-    # note: mirror servers are listed in order of priority
-    dict_url = {
-        'sct_example_data': ['https://osf.io/kjcgs/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
-        'sct_testing_data': ['https://osf.io/yutrj/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
-        'PAM50': ['https://osf.io/u79sr/download',
-                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
-        'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
-        'gm_model': ['https://osf.io/ugscu/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
-        'optic_models': ['https://osf.io/g4fwn/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
-        'pmj_models': ['https://osf.io/4gufr/?action=download',
-                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
-        'binaries_debian': ['https://osf.io/bt58d/?action=download',
-                            'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux.tar.gz'],
-        'binaries_osx': ['https://osf.io/msjb5/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_osx.tar.gz'],
-        'course_hawaii17': 'https://osf.io/6exht/?action=download',
-        'course_paris18': ['https://osf.io/9bmn5/?action=download',
-                           'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
-        'course_london19': ['https://osf.io/4q3u7/?action=download',
-                            'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
-        'course_beijing19': ['https://osf.io/ef4xz/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
-        'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
-        'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
-        'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip'],
-        'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
-                            'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
-    }
-
     # Get parser info
     parser = get_parser()
     arguments = parser.parse(args)
@@ -128,116 +83,11 @@ def main(args=None):
     sct.init_sct(log_level=verbose, update=True)  # Update log level
     dest_folder = arguments.get('-o', os.path.abspath(os.curdir))
 
-    # Download data
-    url = dict_url[data_name]
-    tmp_file = download_data(url, verbose)
-
-    # unzip
-    dest_tmp_folder = sct.tmp_create()
-    unzip(tmp_file, dest_tmp_folder, verbose)
-    extracted_files_paths = []
-    # Get the name of the extracted files and directories
-    extracted_files = os.listdir(dest_tmp_folder)
-    for extracted_file in extracted_files:
-        extracted_files_paths.append(os.path.join(os.path.abspath(dest_tmp_folder), extracted_file))
-
-    # Check if files and folder already exists
-    sct.printv('\nCheck if folder already exists on the destination path...', verbose)
-    for data_extracted_name in extracted_files:
-        fullpath_dest = os.path.join(dest_folder, data_extracted_name)
-        if os.path.isdir(fullpath_dest):
-            sct.printv("Folder {} already exists. Removing it...".format(data_extracted_name), 1, 'warning')
-            rmtree(fullpath_dest)
-
-    # Destination path
-    # for source_path in extracted_files_paths:
-        # Copy the content of source to destination (and create destination folder)
-    copy_tree(dest_tmp_folder, dest_folder)
-
-    sct.printv("\nRemove temporary folders...", verbose)
-    try:
-        rmtree(os.path.split(tmp_file)[0])
-        rmtree(dest_tmp_folder)
-    except Exception as error:
-        print("Cannot remove temp folder: " + repr(error))
+    url = DICT_URL[data_name]
+    install_data(url, dest_folder)
 
     sct.printv('Done!\n', verbose)
     return 0
-
-
-def unzip(compressed, dest_folder, verbose):
-    """Extract compressed file to the dest_folder. Can handle .zip, .tar.gz."""
-    sct.printv('\nUnzip data to: %s' % dest_folder, verbose)
-    if compressed.endswith('zip'):
-        try:
-            zf = zipfile.ZipFile(compressed)
-            zf.extractall(dest_folder)
-            return
-        except (zipfile.BadZipfile):
-            sct.printv(
-                'ERROR: ZIP package corrupted. Please try downloading again.',
-                verbose, 'error')
-    elif compressed.endswith('tar.gz'):
-        try:
-            tar = tarfile.open(compressed)
-            tar.extractall(path=dest_folder)
-            return
-        except tarfile.TarError:
-            sct.printv('ERROR: ZIP package corrupted. Please try again.', verbose, 'error')
-    else:
-        sct.printv('ERROR: The file %s is of wrong format' % compressed, verbose, 'error')
-
-
-def download_data(urls, verbose):
-    """Download the binaries from a URL and return the destination filename
-
-    Retry downloading if either server or connection errors occur on a SSL
-    connection
-    urls: list of several urls (mirror servers) or single url (string)
-    """
-
-    # if urls is not a list, make it one
-    if not isinstance(urls, (list, tuple)):
-        urls = [urls]
-
-    # loop through URLs
-    for url in urls:
-        try:
-            sct.printv('\nTrying URL: %s' % url, verbose)
-            retry = Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 503, 504])
-            session = requests.Session()
-            session.mount('https://', HTTPAdapter(max_retries=retry))
-            response = session.get(url, stream=True)
-
-            if "Content-Disposition" in response.headers:
-                _, content = cgi.parse_header(response.headers['Content-Disposition'])
-                filename = content["filename"]
-            else:
-                sct.printv("Unexpected: link doesn't provide a filename", type="warning")
-                continue
-
-            tmp_path = os.path.join(tempfile.mkdtemp(), filename)
-            sct.printv('Downloading %s...' % filename, verbose)
-
-            with open(tmp_path, 'wb') as tmp_file:
-                total = int(response.headers.get('content-length', 1))
-                tqdm_bar = tqdm(total=total, unit='B', unit_scale=True,
-                                desc="Status", ascii=True)
-
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        tmp_file.write(chunk)
-                        if verbose > 0:
-                            dl_chunk = len(chunk)
-                            tqdm_bar.update(dl_chunk)
-
-                tqdm_bar.close()
-            return tmp_path
-
-        except Exception as e:
-            sct.printv("Link download error, trying next mirror (error was: %s)" % e, type='warning')
-    else:
-        sct.printv('\nDownload error', type='error')
 
 
 if __name__ == "__main__":

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -15,10 +15,47 @@ from __future__ import absolute_import
 import os
 import sys
 
-from spinalcordtoolbox.download import DICT_URL, install_data
+from spinalcordtoolbox.download import install_data
 
 from msct_parser import Parser
 import sct_utils as sct
+
+# Dictionary containing list of URLs for data names. Mirror servers are listed in order of priority.
+DICT_URL = {
+    'sct_example_data': ['https://osf.io/kjcgs/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
+    'sct_testing_data': ['https://osf.io/yutrj/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
+    'PAM50': ['https://osf.io/u79sr/download',
+              'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
+    'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
+    'gm_model': ['https://osf.io/ugscu/?action=download',
+                 'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
+    'optic_models': ['https://osf.io/g4fwn/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
+    'pmj_models': ['https://osf.io/4gufr/?action=download',
+                   'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
+    'binaries_debian': ['https://osf.io/bt58d/?action=download',
+                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux.tar.gz'],
+    'binaries_osx': ['https://osf.io/msjb5/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_osx.tar.gz'],
+    'course_hawaii17': 'https://osf.io/6exht/?action=download',
+    'course_paris18': ['https://osf.io/9bmn5/?action=download',
+                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
+    'course_london19': ['https://osf.io/4q3u7/?action=download',
+                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
+    'course_beijing19': ['https://osf.io/ef4xz/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
+    'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
+                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
+    'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
+                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
+    'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
+                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip'],
+    'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
+    }
 
 
 def get_parser():

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -66,27 +66,7 @@ def get_parser():
         type_value="multiple_choice",
         description="Name of the dataset.",
         mandatory=True,
-        # TODO: replace with key dict items
-        example=[
-            'sct_example_data',
-            'sct_testing_data',
-            'course_hawaii17',
-            'course_paris18',
-            'course_london19',
-            'course_beijing19',
-            'PAM50',
-            'MNI-Poly-AMU',
-            'gm_model',
-            'optic_models',
-            'pmj_models',
-            'binaries_debian',
-            'binaries_centos',
-            'binaries_osx',
-            'deepseg_gm_models',
-            'deepseg_sc_models',
-            'deepseg_lesion_models',
-            'c2c3_disc_models'
-        ])
+        example=sorted(DICT_URL))
     parser.add_option(
         name="-v",
         type_value="multiple_choice",

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -20,43 +20,6 @@ from spinalcordtoolbox.download import install_data
 from msct_parser import Parser
 import sct_utils as sct
 
-# Dictionary containing list of URLs for data names. Mirror servers are listed in order of priority.
-DICT_URL = {
-    'sct_example_data': ['https://osf.io/kjcgs/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
-    'sct_testing_data': ['https://osf.io/yutrj/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
-    'PAM50': ['https://osf.io/u79sr/download',
-              'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
-    'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
-    'gm_model': ['https://osf.io/ugscu/?action=download',
-                 'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
-    'optic_models': ['https://osf.io/g4fwn/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
-    'pmj_models': ['https://osf.io/4gufr/?action=download',
-                   'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
-    'binaries_debian': ['https://osf.io/bt58d/?action=download',
-                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux.tar.gz'],
-    'binaries_osx': ['https://osf.io/msjb5/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_osx.tar.gz'],
-    'course_hawaii17': 'https://osf.io/6exht/?action=download',
-    'course_paris18': ['https://osf.io/9bmn5/?action=download',
-                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
-    'course_london19': ['https://osf.io/4q3u7/?action=download',
-                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
-    'course_beijing19': ['https://osf.io/ef4xz/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
-    'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
-                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
-    'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
-                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
-    'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip'],
-    'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
-    }
-
 
 def get_parser():
     parser = Parser(__file__)
@@ -66,7 +29,7 @@ def get_parser():
         type_value="multiple_choice",
         description="Name of the dataset.",
         mandatory=True,
-        example=sorted(DICT_URL))
+        example=sorted(dict_url))
     parser.add_option(
         name="-v",
         type_value="multiple_choice",
@@ -89,6 +52,44 @@ def get_parser():
 
 def main(args=None):
 
+    # Dictionary containing list of URLs for data names. Mirror servers are listed in order of priority.
+    dict_url = {
+        'sct_example_data': ['https://osf.io/kjcgs/?action=download',
+                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
+        'sct_testing_data': ['https://osf.io/yutrj/?action=download',
+                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
+        'PAM50': ['https://osf.io/u79sr/download',
+                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
+        'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
+        'gm_model': ['https://osf.io/ugscu/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
+        'optic_models': ['https://osf.io/g4fwn/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
+        'pmj_models': ['https://osf.io/4gufr/?action=download',
+                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
+        'binaries_debian': ['https://osf.io/bt58d/?action=download',
+                            'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux.tar.gz'],
+        'binaries_osx': ['https://osf.io/msjb5/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_osx.tar.gz'],
+        'course_hawaii17': 'https://osf.io/6exht/?action=download',
+        'course_paris18': ['https://osf.io/9bmn5/?action=download',
+                           'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
+        'course_london19': ['https://osf.io/4q3u7/?action=download',
+                            'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
+        'course_beijing19': ['https://osf.io/ef4xz/?action=download',
+                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
+        'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
+                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
+        'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
+                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
+        'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
+                                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models'
+                                  '.zip'],
+        'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
+                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
+        }
+
     if args is None:
         args = sys.argv[1:]
 
@@ -100,7 +101,7 @@ def main(args=None):
     sct.init_sct(log_level=verbose, update=True)  # Update log level
     dest_folder = arguments.get('-o', os.path.abspath(os.curdir))
 
-    url = DICT_URL[data_name]
+    url = dict_url[data_name]
     install_data(url, dest_folder)
 
     sct.printv('Done!\n', verbose)

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -21,7 +21,7 @@ from msct_parser import Parser
 import sct_utils as sct
 
 
-def get_parser():
+def get_parser(dict_url):
     parser = Parser(__file__)
     parser.usage.set_description('''Download binaries from the web.''')
     parser.add_option(
@@ -94,7 +94,7 @@ def main(args=None):
         args = sys.argv[1:]
 
     # Get parser info
-    parser = get_parser()
+    parser = get_parser(dict_url)
     arguments = parser.parse(args)
     data_name = arguments['-d']
     verbose = int(arguments.get('-v'))

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -21,45 +21,6 @@ import spinalcordtoolbox.utils
 
 logger = logging.getLogger(__name__)
 
-# Dictionary containing list of URLs for data names. Mirror servers are listed in order of priority.
-DICT_URL = {
-    'sct_example_data': ['https://osf.io/kjcgs/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
-    'sct_testing_data': ['https://osf.io/yutrj/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
-    'PAM50': ['https://osf.io/u79sr/download',
-              'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
-    'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
-    'gm_model': ['https://osf.io/ugscu/?action=download',
-                 'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
-    'optic_models': ['https://osf.io/g4fwn/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
-    'pmj_models': ['https://osf.io/4gufr/?action=download',
-                   'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
-    'binaries_debian': ['https://osf.io/bt58d/?action=download',
-                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux.tar.gz'],
-    'binaries_centos': ['https://osf.io/8kpt4/?action=download',
-                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux_centos6.tar.gz'],
-    'binaries_osx': ['https://osf.io/msjb5/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_osx.tar.gz'],
-    'course_hawaii17': 'https://osf.io/6exht/?action=download',
-    'course_paris18': ['https://osf.io/9bmn5/?action=download',
-                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
-    'course_london19': ['https://osf.io/4q3u7/?action=download',
-                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
-    'course_beijing19': ['https://osf.io/ef4xz/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
-    'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
-                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
-    'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
-                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
-    'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip'],
-    'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
-    }
-
 
 def download_data(urls):
     """Download the binaries from a URL and return the destination filename

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# Functions dealing with data download and installation from the Internet.
+
+import os
+import shutil
+import distutils.dir_util
+import logging
+import cgi
+import tempfile
+import tarfile
+import zipfile
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util import Retry
+from tqdm import tqdm
+
+import spinalcordtoolbox as sct
+import spinalcordtoolbox.utils
+
+
+logger = logging.getLogger(__name__)
+
+# Dictionary containing list of URLs for data names. Mirror servers are listed in order of priority.
+DICT_URL = {
+    'sct_example_data': ['https://osf.io/kjcgs/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
+    'sct_testing_data': ['https://osf.io/yutrj/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
+    'PAM50': ['https://osf.io/u79sr/download',
+              'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
+    'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
+    'gm_model': ['https://osf.io/ugscu/?action=download',
+                 'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
+    'optic_models': ['https://osf.io/g4fwn/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
+    'pmj_models': ['https://osf.io/4gufr/?action=download',
+                   'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
+    'binaries_debian': ['https://osf.io/bt58d/?action=download',
+                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux.tar.gz'],
+    'binaries_centos': ['https://osf.io/8kpt4/?action=download',
+                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_linux_centos6.tar.gz'],
+    'binaries_osx': ['https://osf.io/msjb5/?action=download',
+                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20190930_sct_binaries_osx.tar.gz'],
+    'course_hawaii17': 'https://osf.io/6exht/?action=download',
+    'course_paris18': ['https://osf.io/9bmn5/?action=download',
+                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
+    'course_london19': ['https://osf.io/4q3u7/?action=download',
+                        'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
+    'course_beijing19': ['https://osf.io/ef4xz/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
+    'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
+                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
+    'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
+                          'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
+    'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
+                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip'],
+    'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
+                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
+    }
+
+
+def download_data(urls):
+    """Download the binaries from a URL and return the destination filename
+
+    Retry downloading if either server or connection errors occur on a SSL
+    connection
+    urls: list of several urls (mirror servers) or single url (string)
+    """
+
+    # make sure urls becomes a list, in case user inputs a str
+    if isinstance(urls, str):
+        urls = [urls]
+
+    # loop through URLs
+    for url in urls:
+        try:
+            logger.info('Trying URL: %s' % url)
+            retry = Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 503, 504])
+            session = requests.Session()
+            session.mount('https://', HTTPAdapter(max_retries=retry))
+            response = session.get(url, stream=True)
+
+            if "Content-Disposition" in response.headers:
+                _, content = cgi.parse_header(response.headers['Content-Disposition'])
+                filename = content["filename"]
+            else:
+                logger.warning("Unexpected: link doesn't provide a filename")
+                continue
+
+            tmp_path = os.path.join(tempfile.mkdtemp(), filename)
+            logger.info('Downloading: %s' % filename)
+
+            with open(tmp_path, 'wb') as tmp_file:
+                total = int(response.headers.get('content-length', 1))
+                tqdm_bar = tqdm(total=total, unit='B', unit_scale=True, desc="Status", ascii=False, position=0)
+
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        tmp_file.write(chunk)
+                        dl_chunk = len(chunk)
+                        tqdm_bar.update(dl_chunk)
+
+                tqdm_bar.close()
+            return tmp_path
+
+        except Exception as e:
+            logger.warning("Link download error, trying next mirror (error was: %s)" % e)
+    else:
+        logger.error('Download error')
+
+
+def unzip(compressed, dest_folder):
+    """
+    Extract compressed file to the dest_folder. Can handle .zip, .tar.gz.
+    """
+    logger.info('Unzip data to: %s' % dest_folder)
+    if compressed.endswith('zip'):
+        try:
+            zf = zipfile.ZipFile(compressed)
+            zf.extractall(dest_folder)
+            return
+        except (zipfile.BadZipfile):
+            logger.error("ZIP package corrupted. Please try downloading again.")
+    elif compressed.endswith('tar.gz'):
+        try:
+            tar = tarfile.open(compressed)
+            tar.extractall(path=dest_folder)
+            return
+        except tarfile.TarError:
+            logger.error("ZIP package corrupted. Please try again.")
+    else:
+        logger.error("The file %s is of wrong format" % compressed)
+
+
+def install_data(url, dest_folder):
+    """
+    Download data from a URL and install in the appropriate folder. Deals with multiple mirrors, retry download,
+    check if data already exist.
+    :param url: string or list or strings. URL or list of URLs (if mirrors).
+    :param dest_folder:
+    :return:
+    """
+
+    # Download data
+    tmp_file = download_data(url)
+
+    # unzip
+    dest_tmp_folder = sct.utils.tmp_create()
+    unzip(tmp_file, dest_tmp_folder)
+    extracted_files_paths = []
+    # Get the name of the extracted files and directories
+    extracted_files = os.listdir(dest_tmp_folder)
+    for extracted_file in extracted_files:
+        extracted_files_paths.append(os.path.join(os.path.abspath(dest_tmp_folder), extracted_file))
+
+    # Check if files and folder already exists
+    logger.info("Destination folder: {}".format(dest_folder))
+    logger.info("Checking if folder already exists...")
+    for data_extracted_name in extracted_files:
+        fullpath_dest = os.path.join(dest_folder, data_extracted_name)
+        if os.path.isdir(fullpath_dest):
+            logger.warning("Folder {} already exists. Removing it...".format(data_extracted_name))
+            shutil.rmtree(fullpath_dest)
+
+    # Destination path
+    # for source_path in extracted_files_paths:
+        # Copy the content of source to destination (and create destination folder)
+    distutils.dir_util.copy_tree(dest_tmp_folder, dest_folder)
+
+    logger.info("Removing temporary folders...")
+    try:
+        shutil.rmtree(os.path.split(tmp_file)[0])
+        shutil.rmtree(dest_tmp_folder)
+    except Exception as error:
+        logger.error("Cannot remove temp folder: " + repr(error))

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -129,8 +129,8 @@ def add_suffix(fname, suffix):
     - add_suffix(t2.nii, _mean) -> t2_mean.nii
     - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
     """
-    parent, stem, ext = extract_fname(fname)
-    return os.path.join(parent, stem + suffix + ext)
+    stem, ext = splitext(fname)
+    return os.path.join(stem + suffix + ext)
 
 
 def check_exe(name):
@@ -154,21 +154,6 @@ def check_exe(name):
                 return exe_file
 
     return None
-
-
-def extract_fname(fpath):
-    """
-    Split a full path into a parent folder component, filename stem and extension.
-
-    Note: for .nii.gz the extension is understandably .nii.gz, not .gz
-    (``os.path.splitext()`` would want to do the latter, hence the special case).
-    """
-    parent, filename = os.path.split(fpath)
-    if filename.endswith(".nii.gz"):
-        stem, ext = filename[:-7], ".nii.gz"
-    else:
-        stem, ext = os.path.splitext(filename)
-    return parent, stem, ext
 
 
 def parse_num_list(str_num):
@@ -242,6 +227,19 @@ def parse_num_list_inv(list_int):
             colon_is_present = False
 
     return str_num
+
+
+def splitext(filename):
+    """
+    Split a filename (folder/file + ext) into a folder/file and extension.
+
+    Note: for .nii.gz the extension is understandably .nii.gz, not .gz
+    (``os.path.splitext()`` would want to do the latter, hence the special case).
+    """
+    dir, filename = os.path.split(filename)
+    stem, ext = filename.split(".", 1)
+    ext = "." + ext
+    return os.path.join(dir, stem), ext
 
 
 def tmp_create(basename=None):

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -2,11 +2,12 @@
 # -*- coding: utf-8
 # Collection of useful functions
 
-from __future__ import absolute_import
 
 import io
 import os
 import re
+import tempfile
+import datetime
 import logging
 import argparse
 import subprocess
@@ -115,6 +116,23 @@ class SmartFormatter(argparse.HelpFormatter):
         return argparse.HelpFormatter._split_lines(self, text, width)
 
 
+def add_suffix(fname, suffix):
+    """
+    Add suffix between end of file name and extension.
+
+    :param fname: absolute or relative file name. Example: t2.nii
+    :param suffix: suffix. Example: _mean
+    :return: file name with suffix. Example: t2_mean.nii
+
+    Examples:
+
+    - add_suffix(t2.nii, _mean) -> t2_mean.nii
+    - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
+    """
+    parent, stem, ext = extract_fname(fname)
+    return os.path.join(parent, stem + suffix + ext)
+
+
 def check_exe(name):
     """
     Ensure that a program exists
@@ -136,6 +154,105 @@ def check_exe(name):
                 return exe_file
 
     return None
+
+
+def extract_fname(fpath):
+    """
+    Split a full path into a parent folder component, filename stem and extension.
+
+    Note: for .nii.gz the extension is understandably .nii.gz, not .gz
+    (``os.path.splitext()`` would want to do the latter, hence the special case).
+    """
+    parent, filename = os.path.split(fpath)
+    if filename.endswith(".nii.gz"):
+        stem, ext = filename[:-7], ".nii.gz"
+    else:
+        stem, ext = os.path.splitext(filename)
+    return parent, stem, ext
+
+
+def parse_num_list(str_num):
+    """
+    Parse numbers in string based on delimiter: , or :
+    Examples:
+      '' -> []
+      '1,2,3' -> [1, 2, 3]
+      '1:3,4' -> [1, 2, 3, 4]
+      '1,1:4' -> [1, 2, 3, 4]
+    :param str_num: string
+    :return: list of ints
+    """
+    list_num = list()
+
+    if not str_num:
+        return list_num
+
+    elements = str_num.split(",")
+    for element in elements:
+        m = re.match(r"^\d+$", element)
+        if m is not None:
+            val = int(element)
+            if val not in list_num:
+                list_num.append(val)
+            continue
+        m = re.match(r"^(?P<first>\d+):(?P<last>\d+)$", element)
+        if m is not None:
+            a = int(m.group("first"))
+            b = int(m.group("last"))
+            list_num += [ x for x in range(a, b+1) if x not in list_num ]
+            continue
+        raise ValueError("unexpected group element {} group spec {}".format(element, str_num))
+
+    return list_num
+
+
+def parse_num_list_inv(list_int):
+    """
+    Take a list of numbers and output a string that reduce this list based on delimiter: ; or :
+    Note: we use ; instead of , for compatibility with csv format.
+    Examples:
+      [] -> ''
+      [1, 2, 3] --> '1:3'
+      [1, 2, 3, 5] -> '1:3;5'
+    :param list_int: list of ints
+    :return: str_num: string
+    """
+    # deal with empty list
+    if not list_int or list_int is None:
+        return ''
+    # Sort list in increasing number
+    list_int = sorted(list_int)
+    # initialize string
+    str_num = str(list_int[0])
+    colon_is_present = False
+    # Loop across list elements and build string iteratively
+    for i in range(1, len(list_int)):
+        # if previous element is the previous integer: I(i-1) = I(i)-1
+        if list_int[i] == list_int[i-1] + 1:
+            # if ":" already there, update the last chars (based on the number of digits)
+            if colon_is_present:
+                str_num = str_num[:-len(str(list_int[i-1]))] + str(list_int[i])
+            # if not, add it along with the new int value
+            else:
+                str_num += ':' + str(list_int[i])
+                colon_is_present = True
+        # I(i-1) != I(i)-1
+        else:
+            str_num += ';' + str(list_int[i])
+            colon_is_present = False
+
+    return str_num
+
+
+def tmp_create(basename=None):
+    """Create temporary folder and return its path
+    """
+    prefix = "sct-%s-" % datetime.datetime.now().strftime("%Y%m%d%H%M%S.%f")
+    if basename:
+        prefix += "%s-" % basename
+    tmpdir = tempfile.mkdtemp(prefix=prefix)
+    logger.info("Creating temporary folder (%s)" % tmpdir)
+    return tmpdir
 
 
 def __get_branch():
@@ -215,76 +332,3 @@ def _version_string():
 __sct_dir__ = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 __version__ = _version_string()
 __data_dir__ = os.path.join(__sct_dir__, 'data')
-
-
-def parse_num_list(str_num):
-    """
-    Parse numbers in string based on delimiter: , or :
-    Examples:
-      '' -> []
-      '1,2,3' -> [1, 2, 3]
-      '1:3,4' -> [1, 2, 3, 4]
-      '1,1:4' -> [1, 2, 3, 4]
-    :param str_num: string
-    :return: list of ints
-    """
-    list_num = list()
-
-    if not str_num:
-        return list_num
-
-    elements = str_num.split(",")
-    for element in elements:
-        m = re.match(r"^\d+$", element)
-        if m is not None:
-            val = int(element)
-            if val not in list_num:
-                list_num.append(val)
-            continue
-        m = re.match(r"^(?P<first>\d+):(?P<last>\d+)$", element)
-        if m is not None:
-            a = int(m.group("first"))
-            b = int(m.group("last"))
-            list_num += [ x for x in range(a, b+1) if x not in list_num ]
-            continue
-        raise ValueError("unexpected group element {} group spec {}".format(element, str_num))
-
-    return list_num
-
-
-def parse_num_list_inv(list_int):
-    """
-    Take a list of numbers and output a string that reduce this list based on delimiter: ; or :
-    Note: we use ; instead of , for compatibility with csv format.
-    Examples:
-      [] -> ''
-      [1, 2, 3] --> '1:3'
-      [1, 2, 3, 5] -> '1:3;5'
-    :param list_int: list of ints
-    :return: str_num: string
-    """
-    # deal with empty list
-    if not list_int or list_int is None:
-        return ''
-    # Sort list in increasing number
-    list_int = sorted(list_int)
-    # initialize string
-    str_num = str(list_int[0])
-    colon_is_present = False
-    # Loop across list elements and build string iteratively
-    for i in range(1, len(list_int)):
-        # if previous element is the previous integer: I(i-1) = I(i)-1
-        if list_int[i] == list_int[i-1] + 1:
-            # if ":" already there, update the last chars (based on the number of digits)
-            if colon_is_present:
-                str_num = str_num[:-len(str(list_int[i-1]))] + str(list_int[i])
-            # if not, add it along with the new int value
-            else:
-                str_num += ':' + str(list_int[i])
-                colon_is_present = True
-        # I(i-1) != I(i)-1
-        else:
-            str_num += ';' + str(list_int[i])
-            colon_is_present = False
-
-    return str_num

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -229,16 +229,20 @@ def parse_num_list_inv(list_int):
     return str_num
 
 
-def splitext(filename):
+def splitext(fname):
     """
-    Split a filename (folder/file + ext) into a folder/file and extension.
+    Split a fname (folder/file + ext) into a folder/file and extension.
 
     Note: for .nii.gz the extension is understandably .nii.gz, not .gz
     (``os.path.splitext()`` would want to do the latter, hence the special case).
     """
-    dir, filename = os.path.split(filename)
-    stem, ext = filename.split(".", 1)
-    ext = "." + ext
+    dir, filename = os.path.split(fname)
+    for special_ext in ['.nii.gz', '.tar.gz']:
+        if filename.endswith(special_ext):
+            stem, ext = filename[:-len(special_ext)], special_ext
+            return os.path.join(dir, stem), ext
+    # If no special case, behaves like the regular splitext
+    stem, ext = os.path.splitext(filename)
     return os.path.join(dir, stem), ext
 
 

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -10,6 +10,8 @@ from spinalcordtoolbox import utils
 def test_add_suffix():
     assert utils.add_suffix('t2.nii', '_mean') == 't2_mean.nii'
     assert utils.add_suffix('t2.nii.gz', 'a') == 't2a.nii.gz'
+    assert utils.add_suffix('var/lib/usr/t2.nii.gz', 'sfx') == 'var/lib/usr/t2sfx.nii.gz'
+    assert utils.add_suffix('var/lib.version.3/usr/t2.nii.gz', 'sfx') == 'var/lib.version.3/usr/t2sfx.nii.gz'
 
 
 def test_splitext():

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -18,6 +18,7 @@ def test_splitext():
     assert utils.splitext('folder/image.nii.gz') == ('folder/image', '.nii.gz')
     assert utils.splitext('nice.image.nii.gz') == ('nice.image', '.nii.gz')
     assert utils.splitext('nice.folder/image.nii.gz') == ('nice.folder/image', '.nii.gz')
+    assert utils.splitext('image.tar.gz') == ('image', '.tar.gz')
 
 
 def test_parse_num_list_inv():

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -7,6 +7,19 @@ from __future__ import print_function, absolute_import, division
 from spinalcordtoolbox import utils
 
 
+def test_add_suffix():
+    assert utils.add_suffix('t2.nii', '_mean') == 't2_mean.nii'
+    assert utils.add_suffix('t2.nii.gz', 'a') == 't2a.nii.gz'
+
+
+def test_splitext():
+    assert utils.splitext('image.nii') == ('image', '.nii')
+    assert utils.splitext('image.nii.gz') == ('image', '.nii.gz')
+    assert utils.splitext('folder/image.nii.gz') == ('folder/image', '.nii.gz')
+    assert utils.splitext('nice.image.nii.gz') == ('nice.image', '.nii.gz')
+    assert utils.splitext('nice.folder/image.nii.gz') == ('nice.folder/image', '.nii.gz')
+
+
 def test_parse_num_list_inv():
     assert utils.parse_num_list_inv([1, 2, 3, 5, 6, 9]) == '1:3;5:6;9'
     assert utils.parse_num_list_inv([3, 2, 1, 5]) == '1:3;5'


### PR DESCRIPTION
While working on https://github.com/neuropoly/spinalcordtoolbox/pull/2639, I had to make `sct_download_data`'s subfunctions callable by other Python processes, so the purpose of this PR was to move those functions (previously located in the CLI script) into a new `spinalcordtoolbox.download` module. 

This PR also introduces the following changes to `sct.utils`:
- added: `add_suffix` and `splitext` (formerly `extract_fname`)
- created unit tests for these
