### PR TITLE
Use Travis Caching

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -7,12 +7,14 @@
 #
 # e.g. DOCKER_IMAGE="centos:8" .travis.sh
 
+set -x
 ls -l $HOME/.cache
 ls -l $HOME/.cache/pip
 du -hs $HOME/.cache/pip
 ls -l ~/.cache/pip/wheels/*/*/*/*/*.whl
 ls -l python
 du -hs python
+set +x
 
 set -e # Error build immediately if install script exits with non-zero
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -7,6 +7,11 @@
 #
 # e.g. DOCKER_IMAGE="centos:8" .travis.sh
 
+ls -l $HOME/.cache
+ls -l $HOME/.cache/pip
+du -hs $HOME/.cache/pip
+ls -l ~/.cache/pip/wheels/*/*/*/*/*.whl
+
 set -e # Error build immediately if install script exits with non-zero
 
 # if this is a docker job, run in the container instead; but if not just run it here.

--- a/.travis.sh
+++ b/.travis.sh
@@ -11,6 +11,8 @@ ls -l $HOME/.cache
 ls -l $HOME/.cache/pip
 du -hs $HOME/.cache/pip
 ls -l ~/.cache/pip/wheels/*/*/*/*/*.whl
+ls -l python
+du -hs python
 
 set -e # Error build immediately if install script exits with non-zero
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ notifications:
 cache:
   directories:
     - ${HOME}/.cache/pip
+    # conda install directory:
+    - python/
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ notifications:
     on_success:change
     on_failure:always
 
-# this enables to avoid recompilation of dipy if it was already compiled previously
-#cache:
-#  directories:
-#    - ${HOME}/.cache/pip
+# this slow avoids recompilation of large python packages
+cache:
+  directories:
+    - ${HOME}/.cache/pip
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ cache:
     - ${HOME}/.cache/pip
     # conda install directory:
     - python/
+before_cache:
+    # these files change run to run, so need to be removed to avoid re-uploading the cache
+    - rm -f python/lib/python3.7/__pycache__/_sysconfigdata_m_linux_x86_64-linux-gnu.cpython-37.pyc
+    - rm -f python/lib/python3.7/__pycache__/_sysconfigdata_m_darwin_darwin.cpython-37.pyc
 
 matrix:
   include:

--- a/install_sct
+++ b/install_sct
@@ -503,26 +503,31 @@ fi
 unset PYTHONPATH
 export PYTHONNOUSERSITE=1
 
-# Remove old python folder
-print info "Installing conda..."
-run "rm -rf $SCT_DIR/$PYTHON_DIR"
-run "mkdir -p $SCT_DIR/$PYTHON_DIR"
+if [ ! -x "$SCT_DIR/$PYTHON_DIR/bin/conda" ]; then
+    # Remove old python folder
+    print info "Installing conda..."
+    run "rm -rf $SCT_DIR/$PYTHON_DIR"
+    run "mkdir -p $SCT_DIR/$PYTHON_DIR"
 
-# Download miniconda
-case $OS in
-linux*)
-  download $TMP_DIR/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  ;;
-osx)
-  download $TMP_DIR/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-  ;;
-esac
+    # Download miniconda
+    case $OS in
+    linux*)
+      download $TMP_DIR/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      ;;
+    osx)
+      download $TMP_DIR/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+      ;;
+    esac
 
-# Run conda installer
-run "bash $TMP_DIR/miniconda.sh -p $SCT_DIR/$PYTHON_DIR -b -f"
+    # Run conda installer
+    run "bash $TMP_DIR/miniconda.sh -p $SCT_DIR/$PYTHON_DIR -b -f"
+fi
 
-# create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-yes | python/bin/conda create -n venv_sct python=3.6
+# create py3.6 venv if it doesn't already exist.
+# (we're temporarily pinned to 3.6 for Keras/TF compatibility with Centos7; see issue #2270)
+if ! ( "$SCT_DIR/$PYTHON_DIR/bin/conda" env list | egrep -q "^venv_sct " ) ; then # this grep could be better
+    yes | "$SCT_DIR/$PYTHON_DIR/bin/conda" create -n venv_sct python=3.6
+fi
 
 # activate miniconda
 source python/etc/profile.d/conda.sh

--- a/util/dockerize.sh
+++ b/util/dockerize.sh
@@ -5,10 +5,13 @@
 
 set -e # Error build immediately if install script exits with non-zero
 
+mkdir -p $HOME/.cache/pip
+
 CONTAINER=$(docker run \
     --init \
     -it -d \
     --rm \
+    -v "$HOME":"$HOME" \
     -v "`pwd`":/repo -w /repo \
     "$DOCKER_IMAGE")
 trap "docker stop "$CONTAINER"" EXIT


### PR DESCRIPTION
This should speed up the tests by a couple of minutes per run.

This caches:
* the user-wide pip packages (which strangely we appear to have despite only using conda?) (which are 350M)
* the conda install, and `venv_sct` (which is 1.1G)

To achieve this, I removed the forcible `rm -rf python/` in the installer, so check that over and tell me if you agree with this strategy.

We might think about also caching:
* the trained models
* `sct_testing_data/`
If we cached those, then we would need to remember to clear the cache manually when we update them. But they change slowly, at the speed of our other dependencies, so it could make a lot of sense to treat them the same.

ref: https://docs.travis-ci.com/user/caching/