### PR TITLE
Disable pip's progress bar in CI.

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -5,7 +5,7 @@
 set -e # Error build immediately if install script exits with non-zero
 
 echo Installing SCT
-yes | ASK_REPORT_QUESTION=false ./install_sct
+yes | ASK_REPORT_QUESTION=false PIP_PROGRESS_BAR=off ./install_sct
 echo $?
 echo "... STATUS"
 


### PR DESCRIPTION
Travis has a strict 4MB log limit (https://github.com/travis-ci/travis-ci/issues/1382) which the progress bar greedily eats up.