### PR TITLE
WSL CI: DEBCONF_FRONTEND=noninteractive

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -14,6 +14,14 @@ if [ -n "$DOCKER_IMAGE" ]; then
     ./util/dockerize.sh ./.ci.sh
 elif [ "${TRAVIS_OS_NAME}" = "windows" ]; then
     choco install wsl-ubuntu-1804
+
+    # disable apt's helpful (and build-breaking) interactive mode
+    # https://linuxhint.com/debian_frontend_noninteractive/
+    export DEBIAN_FRONTEND="noninteractive"
+    # Use WSLENV to actually pass it into WSL
+    # https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/
+    export WSLENV=DEBIAN_FRONTEND
+
     wsl apt-get update
     #wsl apt-get -y upgrade  # this step is probably important, but it's also sooo slow
     wsl apt-get install -y gcc git curl

--- a/.travis.sh
+++ b/.travis.sh
@@ -14,6 +14,13 @@ if [ -n "$DOCKER_IMAGE" ]; then
     ./util/dockerize.sh ./.ci.sh
 elif [ "${TRAVIS_OS_NAME}" = "windows" ]; then
     choco install wsl-ubuntu-1804
+     # or, instead of choco, use curl + powershell:
+     # https://docs.microsoft.com/en-us/windows/wsl/install-manual#downloading-distros-via-the-command-line
+    # wsl --setdefault "Ubuntu-18.04"
+     # TODO: Travis's version of wsl is too old for --setdefault.
+     # Instead we trust that wsl will default to the installed
+     # Ubuntu because it is the only option, but it would be
+     # better to be explicit when it becomes possible.
 
     # disable apt's helpful (and build-breaking) interactive mode
     # https://linuxhint.com/debian_frontend_noninteractive/

--- a/.travis.sh
+++ b/.travis.sh
@@ -14,10 +14,10 @@ if [ -n "$DOCKER_IMAGE" ]; then
     ./util/dockerize.sh ./.ci.sh
 elif [ "${TRAVIS_OS_NAME}" = "windows" ]; then
     choco install wsl-ubuntu-1804
-    brun="/c/ProgramData/chocolatey/lib/wsl-ubuntu-1804/tools/unzipped/ubuntu1804.exe run"
-    $brun sudo apt update
-    $brun sudo apt install -y gcc git curl
-    $brun ./.ci.sh
+    wsl apt-get update
+    #wsl apt-get -y upgrade  # this step is probably important, but it's also sooo slow
+    wsl apt-get install -y gcc git curl
+    wsl ./.ci.sh
 else
     ./.ci.sh
 fi

--- a/install_sct
+++ b/install_sct
@@ -561,6 +561,9 @@ for file in $SCT_DIR/python/envs/venv_sct/bin/*sct*; do
   fi
 done
 
+# Activate the launchers, particularly sct_download_data and sct_check_requirements
+export PATH="$SCT_DIR/$BIN_DIR:$PATH"
+
 # ----------------------------------------------------------------------------------------------------------------------
 # Download binaries and data
 # ----------------------------------------------------------------------------------------------------------------------
@@ -584,8 +587,6 @@ print info "All requirements installed!"
 if [[ $NO_DATA_INSTALL ]]; then
   print warning "WARNING: data/ will not be (re)-install"
 else
-  # forcing activation if python is not reinstalled
-  run ". $SCT_DIR/$PYTHON_DIR/bin/activate $SCT_DIR/$PYTHON_DIR"
   # Download data
   print info "Installing data..."
   run "rm -rf $SCT_DIR/$DATA_DIR"

--- a/install_sct
+++ b/install_sct
@@ -457,7 +457,6 @@ else
 fi
 
 # Update PATH variables based on Shell type
-UPDATE_PATH="export PATH=\"$SCT_DIR/$BIN_DIR:\$PATH\""
 if [[ $THE_RC == "bash" ]]; then
   DISPLAY_UPDATE_PATH="export PATH=\"$SCT_DIR/$BIN_DIR:\$PATH\""
 elif [[ $THE_RC == "csh" ]]; then
@@ -561,10 +560,6 @@ for file in $SCT_DIR/python/envs/venv_sct/bin/*sct*; do
     die "Problem creating launchers!"
   fi
 done
-
-## Update PATH within this script (to launch sct_check_dependencies)
-$UPDATE_PATH
-
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Download binaries and data

--- a/install_sct
+++ b/install_sct
@@ -457,7 +457,7 @@ else
 fi
 
 # Update PATH variables based on Shell type
-UPDATE_PATH="export PATH=$SCT_DIR/$BIN_DIR:$PATH"
+UPDATE_PATH="export PATH=\"$SCT_DIR/$BIN_DIR:\$PATH\""
 if [[ $THE_RC == "bash" ]]; then
   DISPLAY_UPDATE_PATH="export PATH=\"$SCT_DIR/$BIN_DIR:\$PATH\""
 elif [[ $THE_RC == "csh" ]]; then


### PR DESCRIPTION
This fixes up the issue that, in CI, the WSL install was hanging at `libssl` -- actually, at trying to "configure" it -- with a prompt to the user, which is a concept that only really exists in Debian/Ubuntu:

```
Package configuration
┌──────────────────────┤ Configuring libssl1.1:amd64 ├──────────────────────┐ 
│ There are services installed on your system which need to be restarted    │
| when certain libraries, such as libpam, libc, and libssl, are upgraded.   │
| Since these restarts may cause interruptions of service for the system,   │
│ you will normally be prompted on each upgrade for the list of services    │
│ you wish to restart.  You can choose this option to avoid being           │ 
│ prompted; instead, all necessary restarts will be done for you            │
│ automatically so you can avoid being asked questions on each library      │
│ upgrade.                                                                  │ 
│                                                                           │ 
│ Restart services during package upgrades without asking?                  │ 
│                                                                           │ 
│                    <Yes>                       <No>                       │ 
│                                                                           │ 
└───────────────────────────────────────────────────────────────────────────┘
```

I suspect we never saw this before because our Ubuntu tests use Travis's prebaked VMs that already have all the basics installed.

This also simplifies `install_sct` which was mishandling spaces in `$PATH`, an issue that Windows exposed (since Windows is fond of spaces). But I cut a little bit deeper than just fixing that immediate issue, so take a close look at it please.