### PR TITLE
Fix and move send_email (2728)

### DIFF
--- a/scripts/sct_pipeline.py
+++ b/scripts/sct_pipeline.py
@@ -68,6 +68,7 @@ import h5py
 import pandas as pd
 
 import sct_utils as sct
+import spinalcordtoolbox.utils as utils
 import msct_parser
 import sct_testing
 
@@ -684,7 +685,7 @@ if __name__ == "__main__":
             with io.open(fname_log, "r") as fp:
                 message = fp.read()
             # send email
-            sct.send_email(addr_to=addr_to, addr_from=addr_from,
+            utils.send_email(addr_to=addr_to, addr_from=addr_from,
              subject=file_log, message=message, filename=fname_log,
              login=login, passwd=passwd_from, smtp_host=smtp_host, smtp_port=smtp_port,
              html=True)

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -824,9 +824,9 @@ def send_email(addr_to, addr_from, passwd, subject, message='', filename=None, h
         login = addr_from
 
     import smtplib
-    from email.MIMEMultipart import MIMEMultipart
-    from email.MIMEText import MIMEText
-    from email.MIMEBase import MIMEBase
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+    from email.mime.base import MIMEBase
     from email import encoders
 
     if html:
@@ -842,10 +842,10 @@ def send_email(addr_to, addr_from, passwd, subject, message='', filename=None, h
     if not isinstance(body, bytes):
         body = body.encode("utf-8")
 
-    body_html = b"""
+    body_html = """
 <html><pre style="font: monospace"><body>
 {}
-</body></pre></html>""".format(body)
+</body></pre></html>""".format(body).encode()
 
     if html:
         msg.attach(MIMEText(body_html, 'html', "utf-8"))

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -814,62 +814,6 @@ def printv(string, verbose=1, type='normal'):
         except Exception as e:
             print(string)
 
-
-def send_email(addr_to, addr_from, passwd, subject, message='', filename=None, html=False, smtp_host=None, smtp_port=None, login=None):
-    if smtp_host is None:
-        smtp_host = os.environ.get("SCT_SMTP_SERVER", "smtp.gmail.com")
-    if smtp_port is None:
-        smtp_port = int(os.environ.get("SCT_SMTP_PORT", 587))
-    if login is None:
-        login = addr_from
-
-    import smtplib
-    from email.mime.multipart import MIMEMultipart
-    from email.mime.text import MIMEText
-    from email.mime.base import MIMEBase
-    from email import encoders
-
-    if html:
-        msg = MIMEMultipart("alternative")
-    else:
-        msg = MIMEMultipart()
-
-    msg['From'] = addr_from
-    msg['To'] = addr_to
-    msg['Subject'] = subject
-
-    body = message
-    if not isinstance(body, bytes):
-        body = body.encode("utf-8")
-
-    body_html = """
-<html><pre style="font: monospace"><body>
-{}
-</body></pre></html>""".format(body).encode()
-
-    if html:
-        msg.attach(MIMEText(body_html, 'html', "utf-8"))
-
-    msg.attach(MIMEText(body, 'plain', "utf-8"))
-
-    # filename = "NAME OF THE FILE WITH ITS EXTENSION"
-    if filename:
-        attachment = open(filename, "rb")
-        part = MIMEBase('application', 'octet-stream')
-        part.set_payload((attachment).read())
-        encoders.encode_base64(part)
-        part.add_header('Content-Disposition', "attachment; filename= %s" % filename)
-        msg.attach(part)
-
-    # send email
-    server = smtplib.SMTP(smtp_host, smtp_port)
-    server.starttls()
-    server.login(login, passwd)
-    text = msg.as_string()
-    server.sendmail(addr_from, addr_to, text)
-    server.quit()
-
-
 #=======================================================================================================================
 # sign
 #=======================================================================================================================

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -184,7 +184,7 @@ def parse_num_list(str_num):
         if m is not None:
             a = int(m.group("first"))
             b = int(m.group("last"))
-            list_num += [ x for x in range(a, b+1) if x not in list_num ]
+            list_num += [x for x in range(a, b + 1) if x not in list_num]
             continue
         raise ValueError("unexpected group element {} group spec {}".format(element, str_num))
 
@@ -213,10 +213,10 @@ def parse_num_list_inv(list_int):
     # Loop across list elements and build string iteratively
     for i in range(1, len(list_int)):
         # if previous element is the previous integer: I(i-1) = I(i)-1
-        if list_int[i] == list_int[i-1] + 1:
+        if list_int[i] == list_int[i - 1] + 1:
             # if ":" already there, update the last chars (based on the number of digits)
             if colon_is_present:
-                str_num = str_num[:-len(str(list_int[i-1]))] + str(list_int[i])
+                str_num = str_num[:-len(str(list_int[i - 1]))] + str(list_int[i])
             # if not, add it along with the new int value
             else:
                 str_num += ':' + str(list_int[i])
@@ -255,6 +255,7 @@ def tmp_create(basename=None):
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     logger.info("Creating temporary folder (%s)" % tmpdir)
     return tmpdir
+
 
 def send_email(addr_to, addr_from, passwd, subject, message='', filename=None, html=False, smtp_host=None, smtp_port=None, login=None):
     if smtp_host is None:
@@ -347,8 +348,8 @@ def __get_commit():
         unclean = True
         for line in output.decode().strip().splitlines():
             line = line.rstrip()
-            if line.startswith("??"): # ignore ignored files, they can't hurt
-               continue
+            if line.startswith("??"):  # ignore ignored files, they can't hurt
+                continue
             break
         else:
             unclean = False
@@ -366,7 +367,7 @@ def _git_info(commit_env='SCT_COMMIT', branch_env='SCT_BRANCH'):
         sct_commit = __get_commit() or sct_commit
         sct_branch = __get_branch() or sct_branch
 
-    if sct_commit is not 'unknown':
+    if sct_commit != 'unknown':
         install_type = 'git'
     else:
         install_type = 'package'


### PR DESCRIPTION
Fix a few import errors and a string interpolation issue in `send_email` and move it from `sct_utils` to `utils`. Fixes #2728