### PR TITLE
Drop support for 2014-era Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,14 +67,6 @@ matrix:
         - docker
       env:
         - DOCKER_IMAGE="debian:9"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
-    - name: "Debian 8"
-      if: branch = release or type = cron
-      os: linux
-      dist: xenial # kernel ~= Debian:8
-      services:
-        - docker
-      env:
-        - DOCKER_IMAGE="debian:8"       DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "CentOS 8"
       # runs on all branches
       os: linux
@@ -100,10 +92,6 @@ matrix:
       name: "Ubuntu 16.04 (Xenial)"
       if: branch = release or type = cron
       dist: xenial
-    - os: linux
-      if: branch = release or type = cron
-      name: "Ubuntu 14.04 (Trusty)"
-      dist: trusty
     - name: "OSX 10.14 (Mojave)"
       # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/


### PR DESCRIPTION
Merging pytorch (6aa1f4e) caused

> OSError: dlopen: cannot load any more object with static TLS

on [Debian 8](https://travis-ci.org/github/neuropoly/spinalcordtoolbox/jobs/690411071) and [Ubuntu Trusty](https://travis-ci.org/github/neuropoly/spinalcordtoolbox/jobs/690411076) ( caught by #2690  :) ).

![Screenshot_2020-05-24 Build #13281 - neuropoly spinalcordtoolbox - Travis CI](https://user-images.githubusercontent.com/987487/82745814-8574e400-9d56-11ea-832c-75e5f536f94b.png)

This is a known issue with pytorch, see e.g.

https://github.com/pytorch/pytorch/issues/2083
https://github.com/scikit-learn/scikit-learn/issues/14485
https://github.com/pytorch/pytorch/issues/2575
https://stackoverflow.com/questions/14892101/cannot-load-any-more-object-with-static-tls

Apparently there might be a workaround involving reordering import statements, but I think the root issue is that pytorch doesn't get testing on "obscure" platforms. Including pytorch means we can't reliably support them.

---

An alternate fix would be to try to reorder the import statements until this works for the old Linux. I'm not sure what we want to do.