### PR TITLE
Retrieve data bundles from their new location

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -586,9 +586,8 @@ else
   print info "Installing data..."
   run "rm -rf $SCT_DIR/$DATA_DIR"
   run "mkdir -p $SCT_DIR/$DATA_DIR"
-  run "cd $SCT_DIR/$DATA_DIR"
   for data in PAM50 gm_model optic_models pmj_models deepseg_sc_models deepseg_gm_models deepseg_lesion_models c2c3_disc_models; do
-    run "sct_download_data -d $data"
+    run "sct_download_data -d $data -o $SCT_DIR/$DATA_DIR/$data"
   done
 fi
 

--- a/install_sct
+++ b/install_sct
@@ -573,8 +573,8 @@ if [[ $NO_SCT_BIN_INSTALL ]]; then
   print warning "WARNING: SCT binaries will not be (re)-installed"
 else
   print info "Installing binaries..."
-  run "sct_download_data -d binaries_"$OS" -o $SCT_DIR/$BIN_DIR" || \
-    die "Unsupported OS $OS: can't install binaries."
+  run "sct_download_data -d binaries_${OS} -o ${SCT_DIR}/${BIN_DIR} -k" || \
+      die "Unsupported OS $OS: can't install binaries."
 fi
 print info "All requirements installed!"
 

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -52,43 +52,85 @@ def get_parser(dict_url):
 
 def main(args=None):
 
-    # Dictionary containing list of URLs for data names. Mirror servers are listed in order of priority.
+    # Dictionary containing list of URLs for data names.
+    # Mirror servers are listed in order of decreasing priority.
+    # If exists, favour release artifact straight from github
     dict_url = {
-        'sct_example_data': ['https://osf.io/kjcgs/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip'],
-        'sct_testing_data': ['https://osf.io/yutrj/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20191031_sct_testing_data.zip'],
-        'PAM50': ['https://osf.io/u79sr/download',
-                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip'],
-        'MNI-Poly-AMU': ['https://osf.io/sh6h4/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip'],
-        'gm_model': ['https://osf.io/ugscu/?action=download',
-                     'https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip'],
-        'optic_models': ['https://osf.io/g4fwn/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip'],
-        'pmj_models': ['https://osf.io/4gufr/?action=download',
-                       'https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip'],
-        'binaries_linux': ['https://osf.io/mka78/?action=download',
-                           'https://www.neuro.polymtl.ca/_media/downloads/sct/20200420_sct_binaries_linux.tar.gz'],
-        'binaries_osx': ['https://osf.io/dn67h/?action=download',
-                         'https://www.neuro.polymtl.ca/_media/downloads/sct/20200420_sct_binaries_osx.tar.gz'],
-        'course_hawaii17': 'https://osf.io/6exht/?action=download',
-        'course_paris18': ['https://osf.io/9bmn5/?action=download',
-                           'https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip'],
-        'course_london19': ['https://osf.io/4q3u7/?action=download',
-                            'https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip'],
-        'course_beijing19': ['https://osf.io/ef4xz/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip'],
-        'deepseg_gm_models': ['https://osf.io/b9y4x/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip'],
-        'deepseg_sc_models': ['https://osf.io/avf97/?action=download',
-                              'https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip'],
-        'deepseg_lesion_models': ['https://osf.io/eg7v9/?action=download',
-                                  'https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models'
-                                  '.zip'],
-        'c2c3_disc_models': ['https://osf.io/t97ap/?action=download',
-                             'https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip']
-        }
+        "sct_example_data": [
+            "https://github.com/sct-data/sct_example_data/releases/download/r20180525/20180525_sct_example_data.zip",
+            "https://osf.io/kjcgs/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip",
+        ],
+        "sct_testing_data": [
+            "https://github.com/sct-data/sct_testing_data/releases/download/r20200504/20200504_sct_testing_data.zip",
+            "https://osf.io/6x5a2/download",
+        ],
+        "PAM50": [
+            "https://github.com/sct-data/PAM50/releases/download/r20191029/20191029_pam50.zip",
+            "https://osf.io/u79sr/download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip",
+        ],
+        "MNI-Poly-AMU": [
+            "https://github.com/sct-data/MNI-Poly-AMU/releases/download/r20170310/20170310_MNI-Poly-AMU.zip",
+            "https://osf.io/sh6h4/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip",
+        ],
+        "gm_model": [
+            "https://osf.io/ugscu/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip",
+        ],
+        "optic_models": [
+            "https://github.com/sct-data/optic_models/releases/download/r20170413/20170413_optic_models.zip",
+            "https://osf.io/g4fwn/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip",
+        ],
+        "pmj_models": [
+            "https://github.com/sct-data/pmj_models/releases/download/r20170922/20170922_pmj_models.zip",
+            "https://osf.io/4gufr/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip",
+        ],
+        "binaries_linux": [
+            "https://osf.io/mka78/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200420_sct_binaries_linux.tar.gz",
+        ],
+        "binaries_osx": [
+            "https://osf.io/dn67h/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200420_sct_binaries_osx.tar.gz",
+        ],
+        "course_hawaii17": "https://osf.io/6exht/?action=download",
+        "course_paris18": [
+            "https://osf.io/9bmn5/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip",
+        ],
+        "course_london19": [
+            "https://osf.io/4q3u7/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip",
+        ],
+        "course_beijing19": [
+            "https://osf.io/ef4xz/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip",
+        ],
+        "deepseg_gm_models": [
+            "https://github.com/sct-data/deepseg_gm_models/releases/download/r20180205/20180205_deepseg_gm_models.zip",
+            "https://osf.io/b9y4x/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip",
+        ],
+        "deepseg_sc_models": [
+            "https://github.com/sct-data/deepseg_sc_models/releases/download/r20180610/20180610_deepseg_sc_models.zip",
+            "https://osf.io/avf97/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip",
+        ],
+        "deepseg_lesion_models": [
+            "https://github.com/sct-data/deepseg_lesion_models/releases/download/r20180613/20180613_deepseg_lesion_models.zip",
+            "https://osf.io/eg7v9/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip",
+        ],
+        "c2c3_disc_models": [
+            "https://github.com/sct-data/c2c3_disc_models/releases/download/r20190117/20190117_c2c3_disc_models.zip",
+            "https://osf.io/t97ap/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip",
+        ],
+    }
 
     if args is None:
         args = sys.argv[1:]

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -40,7 +40,10 @@ def get_parser(dict_url):
     parser.add_option(
         name="-o",
         type_value="folder_creation",
-        description="Path where to save the downloaded data (defaults to dataset name in current working directory)",
+        description=("Path where to save the downloaded data"
+         " (defaults to ./${dataset-name})."
+         " Directory will be created."
+         " Warning: existing data in the directory will be erased."),
         mandatory=False)
     parser.add_option(
         name="-h",

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -43,12 +43,17 @@ def get_parser(dict_url):
         description=("Path where to save the downloaded data"
          " (defaults to ./${dataset-name})."
          " Directory will be created."
-         " Warning: existing data in the directory will be erased."),
+         " Warning: existing data in the directory will be erased unless -k is provided."),
         mandatory=False)
     parser.add_option(
         name="-h",
         type_value=None,
         description="Display this help",
+        mandatory=False)
+    parser.add_option(
+        name="-k",
+        type_value=None,
+        description="Keep existing data in destination directory",
         mandatory=False)
     return parser
 
@@ -147,7 +152,7 @@ def main(args=None):
     dest_folder = arguments.get('-o', os.path.join(os.path.abspath(os.curdir), data_name))
 
     url = dict_url[data_name]
-    install_data(url, dest_folder)
+    install_data(url, dest_folder, keep=arguments.get("-k", False))
 
     sct.printv('Done!\n', verbose)
     return 0

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -40,7 +40,7 @@ def get_parser(dict_url):
     parser.add_option(
         name="-o",
         type_value="folder_creation",
-        description="path to save the downloaded data",
+        description="Path where to save the downloaded data (defaults to dataset name in current working directory)",
         mandatory=False)
     parser.add_option(
         name="-h",
@@ -141,7 +141,7 @@ def main(args=None):
     data_name = arguments['-d']
     verbose = int(arguments.get('-v'))
     sct.init_sct(log_level=verbose, update=True)  # Update log level
-    dest_folder = arguments.get('-o', os.path.abspath(os.curdir))
+    dest_folder = arguments.get('-o', os.path.join(os.path.abspath(os.curdir), data_name))
 
     url = dict_url[data_name]
     install_data(url, dest_folder)

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -17,29 +17,48 @@ logger = logging.getLogger(__name__)
 
 # List of models. The convention for model names is: (species)_(university)_(contrast)_region
 # Regions could be: sc, gm, lesion, tumor
-# TODO: add mirror
 MODELS = {
-    't2star_sc':
-        {'url': 'https://osf.io/v9hs8/download?version=5',
-         'description': 'Cord segmentation model on T2*-weighted contrast.',
-         'default': True},
-    'mice_uqueensland_sc':
-        {'url': 'https://osf.io/nu3ma/download?version=6',
-         'description': 'Cord segmentation model on mouse MRI. Data from University of Queensland.',
-         'default': False},
-    'mice_uqueensland_gm':
-        {'url': 'https://osf.io/mfxwg/download?version=6',
-         'description': 'Gray matter segmentation model on mouse MRI. Data from University of Queensland.',
-         'default': False},
-    't2_tumor':
-        {'url': 'https://osf.io/uwe7k/download?version=2',
-         'description': 'Cord tumor segmentation model, trained on T2-weighted contrast.',
-         'default': False},
-    'findcord_tumor':
-        {'url': 'https://osf.io/qj6d5/download?version=1',
-         'description': 'Cord localisation model, trained on T2-weighted images with tumor.',
-         'default': False}
-    }
+    "t2star_sc": {
+        "url": [
+            "https://github.com/ivadomed/t2star_sc/releases/download/r20200622/r20200622_t2star_sc.zip",
+            "https://osf.io/v9hs8/download?version=5",
+        ],
+        "description": "Cord segmentation model on T2*-weighted contrast.",
+        "default": True,
+    },
+    "mice_uqueensland_sc": {
+        "url": [
+            "https://github.com/ivadomed/mice_uqueensland_sc/releases/download/r20200622/r20200622_mice_uqueensland_sc.zip",
+            "https://osf.io/nu3ma/download?version=6",
+        ],
+        "description": "Cord segmentation model on mouse MRI. Data from University of Queensland.",
+        "default": False,
+    },
+    "mice_uqueensland_gm": {
+        "url": [
+            "https://github.com/ivadomed/mice_uqueensland_gm/releases/download/r20200622/r20200622_mice_uqueensland_gm.zip",
+            "https://osf.io/mfxwg/download?version=6",
+        ],
+        "description": "Gray matter segmentation model on mouse MRI. Data from University of Queensland.",
+        "default": False,
+    },
+    "t2_tumor": {
+        "url": [
+            "https://github.com/ivadomed/t2_tumor/releases/download/r20200621/r20200621_t2_tumor.zip",
+            "https://osf.io/uwe7k/download?version=2",
+        ],
+        "description": "Cord tumor segmentation model, trained on T2-weighted contrast.",
+        "default": False,
+    },
+    "findcord_tumor": {
+        "url": [
+            "https://github.com/ivadomed/findcord_tumor/releases/download/r20200621/r20200621_findcord_tumor.zip",
+            "https://osf.io/qj6d5/download?version=1",
+        ],
+        "description": "Cord localisation model, trained on T2-weighted images with tumor.",
+        "default": False,
+    },
+}
 
 # List of task. The convention for task names is: action_(animal)_region_(contrast)
 # Regions could be: sc, gm, lesion, tumor

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -94,7 +94,7 @@ def install_model(name_model):
     :return: None
     """
     logger.info("\nINSTALLING MODEL: {}".format(name_model))
-    sct.download.install_data(MODELS[name_model]['url'], os.path.dirname(folder(name_model)))
+    sct.download.install_data(MODELS[name_model]['url'], folder(name_model))
 
 
 def install_default_models():

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -141,6 +141,8 @@ def install_data(url, dest_folder):
         # tarball with single-directory -> go under
         with os.scandir(extraction_folder) as it:
             for entry in it:
+                if entry.name in ("__MACOSX",):
+                    continue
                 bundle_folder = entry.path
     else:
         # bomb scenario -> stay here

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -131,6 +131,8 @@ def install_data(url, dest_folder):
         has_dir = False
         nb_entries = 0
         for entry in it:
+            if entry.name in ("__MACOSX",):
+                continue
             nb_entries += 1
             if entry.is_dir():
                 has_dir = True
@@ -152,6 +154,8 @@ def install_data(url, dest_folder):
         ds.sort()
         fs.sort()
         for d in ds:
+            if d in ("__MACOSX",):
+                continue
             srcpath = os.path.join(cwd, d)
             relpath = os.path.relpath(srcpath, bundle_folder)
             dstpath = os.path.join(dest_folder, relpath)

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -140,6 +140,7 @@ def install_data(url, dest_folder, keep=False):
     """
 
     if not keep and os.path.exists(dest_folder):
+        logger.warning("Removing existing destination folder “%s”", dest_folder)
         shutil.rmtree(dest_folder)
     os.makedirs(dest_folder, exist_ok=True)
 
@@ -193,7 +194,7 @@ def install_data(url, dest_folder, keep=False):
             dstpath = os.path.join(dest_folder, relpath)
             if os.path.exists(dstpath):
                 logger.debug("- f! %s", relpath)
-                logger.warning("Updating existing %s", dstpath)
+                logger.warning("Updating existing “%s”", dstpath)
                 os.unlink(dstpath)
             else:
                 logger.debug("- f+ %s", relpath)

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -153,9 +153,8 @@ def install_data(url, dest_folder):
     for cwd, ds, fs in os.walk(bundle_folder):
         ds.sort()
         fs.sort()
+        ds[:] = [ d for ds if d not in ("__MACOSX",) ]
         for d in ds:
-            if d in ("__MACOSX",):
-                continue
             srcpath = os.path.join(cwd, d)
             relpath = os.path.relpath(srcpath, bundle_folder)
             dstpath = os.path.join(dest_folder, relpath)

--- a/spinalcordtoolbox/download.py
+++ b/spinalcordtoolbox/download.py
@@ -153,7 +153,7 @@ def install_data(url, dest_folder):
     for cwd, ds, fs in os.walk(bundle_folder):
         ds.sort()
         fs.sort()
-        ds[:] = [ d for ds if d not in ("__MACOSX",) ]
+        ds[:] = [ d for d in ds if d not in ("__MACOSX",) ]
         for d in ds:
             srcpath = os.path.join(cwd, d)
             relpath = os.path.relpath(srcpath, bundle_folder)


### PR DESCRIPTION
For #2415.

Using Github releases as CDN, but another CDN fetching data from the releases can also be used.

### History Recreation

Data in sct_download_data is converted to be in their own repository, using a conversion script (https://github.com/sct-data/sct-data-archeology), which:

- [x] Looks in spinalcordtoolbox history for different versions of the various bundles
  - [x] in sct_download_data
  - [x] in [speenalcordtoolbox.deepseg.models](https://github.com/neuropoly/spinalcordtoolbox/blob/master/spinalcordtoolbox/deepseg/models.py#L20)
- [x] One repo for a set of bundles (one or more)
- [x] Recreate a (linear) git DAG
- [x] Commits have date, corresponding SCT commit ref
- [x] Releases: create releases
- [x] Releases: script adds release artifact with the original bundle archive

Data is stored in the new https://github.com/sct-data/

### Bundle Release Process

Introduce a tool used to automate deployment.