### PR TITLE
ONNX model support and addition of tumor segmentation model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cryptography
 dipy
 futures
 h5py
-ivadomed>=1.2.1
+ivadomed==1.2.1
 Keras==2.1.5
 matplotlib
 nibabel

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cryptography
 dipy
 futures
 h5py
-ivadomed
+ivadomed>=1.2.1
 Keras==2.1.5
 matplotlib
 nibabel

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -69,7 +69,8 @@ def is_valid(path_model):
     :param path_model: str: Absolute path to folder that encloses the model files.
     """
     name_model = path_model.rstrip(os.sep).split(os.sep)[-1]
-    return os.path.exists(os.path.join(path_model, name_model + '.pt')) and \
+    return (os.path.exists(os.path.join(path_model, name_model + '.pt')) or
+           os.path.exists(os.path.join(path_model, name_model + '.onnx'))) and \
            os.path.exists(os.path.join(path_model, name_model + '.json'))
 
 

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -30,6 +30,10 @@ MODELS = {
         {'url': 'https://osf.io/mfxwg/download?version=5',
          'description': 'Gray matter segmentation on mouse MRI. Data from University of Queensland.',
          'default': False},
+    't2_tumor':
+        {'url': 'https://osf.io/uwe7k/download?version=1',
+         'description': 'Cord tumor segmentation on T2-weighted contrast.',
+         'default': False}
     }
 
 


### PR DESCRIPTION
Addition of support for ONNX models in sct_deepseg as discussed [here](https://github.com/neuropoly/spinalcordtoolbox/compare/al/onnx-model?expand=1). 

Changes:
- Add support to ONNX models on model's path verification
- Add version requirement on ivadomed (version where ONNX models were implemented)
- Add t2_tumor model 
