### PR TITLE
Parallel-safe quality-control

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -6,6 +6,7 @@ from __future__ import print_function, absolute_import, division
 import glob
 import sys
 import os
+import fcntl
 import json
 import logging
 import warnings
@@ -477,10 +478,20 @@ class QcReport(object):
         path_json, _ = os.path.split(self.qc_params.qc_results)
         if not os.path.exists(path_json):
             os.makedirs(path_json, exist_ok = True)
-        # Create json file
-        with open(self.qc_params.qc_results, 'w+') as qc_file:
-            json.dump(output, qc_file, indent=1)
-        self._update_html_assets(get_json_data_from_path(path_json))
+
+        # lock the output directory
+        # because this code may be run in parallel
+        path_json_fd = os.open(path_json, os.O_RDONLY)
+        fcntl.flock(path_json_fd, fcntl.LOCK_EX)
+
+        try:
+            # Create json file
+            with open(self.qc_params.qc_results, 'w+') as qc_file:
+                json.dump(output, qc_file, indent=1)
+            self._update_html_assets(get_json_data_from_path(path_json))
+        finally:
+            #fcntl.flock(path_json_fd, fcntl.LOCK_UN) # technically, redundant, since close() triggers this too.
+            os.close(path_json_fd)
 
     def _update_html_assets(self, json_data):
         """Update the html file and assets"""

--- a/unit_testing/test_qc_parallel.py
+++ b/unit_testing/test_qc_parallel.py
@@ -1,5 +1,6 @@
 
 import sys, os
+from tempfile import TemporaryDirectory
 import pytest
 
 import multiprocessing
@@ -12,12 +13,13 @@ from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.reports.slice as qcslice
 
 
+def gen_qc(args):
+    i, path_qc = args
 
-def gen_qc(i):
     t2_image = os.path.join(__sct_dir__, 'sct_testing_data', 't2', 't2.nii.gz')
     t2_seg = os.path.join(__sct_dir__, 'sct_testing_data', 't2', 't2_seg.nii.gz')
 
-    qc.generate_qc(fname_in1 = t2_image, fname_seg = t2_seg, path_qc = "/tmp/qc",
+    qc.generate_qc(fname_in1 = t2_image, fname_seg = t2_seg, path_qc = path_qc,
                    process = "sct_deepseg_gm")
     return True
 
@@ -27,8 +29,7 @@ def test_many_qc():
     if multiprocessing.cpu_count() < 2:
         pytest.skip("Can't test parallel behaviour")
 
-    # install: sct_download_data -d sct_testing_data
-    with multiprocessing.Pool(2) as p:
-        p.map(gen_qc, range(5))
-
-
+    with TemporaryDirectory(prefix="sct-qc-") as tmpdir:
+        # install: sct_download_data -d sct_testing_data
+        with multiprocessing.Pool(2) as p:
+            p.map(gen_qc, ((i, tmpdir) for i in range(5)))


### PR DESCRIPTION
The cause of the crash in #2683 is that `reports.qc.generate_qc()` was not safe to run in parallel, because it creates a single output report from all the .json files it finds in the directory it is pointed at *for each subreport*. The crashes we were seeing were a result of some processes trying to read half-written .json data.

I'm guessing it is meant to be used in a pipeline that runs a bunch of image processing steps and reports the results as .json, with the expectation that this is to be done interactively -- so that you would rerun a test and then reload the summary report.

This fixes it by using POSIX file locking around the entire working directory (er, well, the directory being operated on, that is).

This shouldn't slow down any actual tests that use `qc`, it only affects the generation of reports. But I haven't actually tested this.

I also discovered that the test runner was reusing an output directory, so once I fixed it it didn't seem fixed, because the previous 500 .json files were still there. This fixes that, introducing the small change in behaviour that the test directory is *erased* when finished.

---

To see that this fixes it, I [figured out how to reproduce the crash reliably](https://github.com/neuropoly/spinalcordtoolbox/issues/2683#issuecomment-633775987) and applied that patch both to master and this branch (the indentation changed so the patch to each is different but the code is the same):

* off master: https://github.com/neuropoly/spinalcordtoolbox/tree/ko/2683-repro
* off this branch: https://github.com/neuropoly/spinalcordtoolbox/tree/ko/2683-parallelsafe-qc-repro

On 'master', 100% failure:

```
$ git branch --show-current
ko/2683-repro
$ for i in `seq 20`; do pytest unit_testing/test_qc_parallel.py | tail -n 1; done 
============================== 1 failed in 4.50s ===============================
============================== 1 failed in 4.50s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.48s ===============================
============================== 1 failed in 4.59s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.49s ===============================
============================== 1 failed in 4.49s ===============================
```

(interestingly, the writes can be both too fast or too slow: too fast and they complete before the reads, which hides the bug; too slow and no files get written before the reads, so the result is just empty, which also hides the bug)

On this branch, 100% success:

```
$ git branch --show-current
ko/2683-parallelsafe-qc-repro
$ for i in `seq 20`; do pytest unit_testing/test_qc_parallel.py | tail -n 1; done
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.77s ===============================
============================== 1 passed in 4.77s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.77s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.77s ===============================
============================== 1 passed in 4.87s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.85s ===============================
============================== 1 passed in 4.87s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.77s ===============================
============================== 1 passed in 4.76s ===============================
============================== 1 passed in 4.77s ===============================
```

---

Questions:

1. I used POSIX file locking, which [has](https://loonytek.com/2015/01/15/advisory-file-locking-differences-between-posix-and-bsd-locks/) its [detractors](http://0pointer.de/blog/projects/locking.html). I think it's okay for this since it's only a single lock at a single place, but it might have problems on Windows (hopefully WSL implements locking right?) or if someone tries to extend this.
2. I used `fcntl.flock()` directly -- hence the `try ... finally` -- but there's [this nice context-manager](https://pypi.org/project/flock/) which would be better, but I was hesitant to add another dependency.
3. As mentioned by the detractors, there's confusingly also `lockf()`. Python exposes this as `os.lockf()` which makes me feel like they want me to prefer it -- but `lockf()` doesn't work on directories, I tried it; I could make it work (by using `$DIRECTORY/.lock.txt`) but I don't know which is better or if it matters?

4. (as mentioned in https://github.com/neuropoly/spinalcordtoolbox/pull/2711#issuecomment-633801204) The even deeper underlying issue is that each independent QC report run also tries to generate an overall summary, when what each should do is run in isolation then feed into an aggregation step. But this requires more extensive rewrites and some redesign, and would break interactive use if we're not careful, if that is an important feature; ultimately, the aggregation step will either have to refuse to overwrite files (forcing the user to generate an isolated path for the summary on top of isolated paths for the subreports), or implement this same locking code.
  > If I was designing this from scratch I would do something like:
  > 
  > ```
  > cat jobs.csv | parallel --jobs 2 --pipe generate_qc | generate_qc_summary
  > ```
  > 
  > In this phrasing, the bug is because `generate_qc_summary` is currently embedded inside of   `generate_qc`, so each instance is interdependent on the others.
  > 
  > The python equivalent is:
  > 
  > ```
  > with multiprocessing.Pool() as pool:
  >     jsons = pool.map(generate_qc, jobs)
  > 
  > generate_qc_summary(jsons)  # this is currently named _update_html_assets()
  > ```

