### PR TITLE
initlabel not working

### DIFF
--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -315,7 +315,7 @@ def main(args=None):
             # which does not apply a convolution across all voxels (highly inneficient)
             im_label.save(fname_labelz)
         elif fname_initlabel:
-            fname_labelz = fname_initlabel
+            Image(fname_initlabel).save(fname_labelz)
         else:
             # automatically finds C2-C3 disc
             im_data = Image('data.nii')


### PR DESCRIPTION
Program "sct_label_vertebrae" fails when using flag "initlabel". This is the only case in which "sct_label_vertebrae" fails.

`fname_labelz = fname_initlabel` attributes "fname_initlabel" manually labeled nibabel file path to "fname_labelz". As a consequence "isct_antsAppllyTransforms" does not find "labelz.nii.gz" anymore. A work around is to assign the -initlabel input image to "fname_labelz" existing path.

see error:
[log-error-sct_label_vertebrae.txt](https://github.com/neuropoly/spinalcordtoolbox/files/4702146/log-error-sct_label_vertebrae.txt)

DONE:
- Read image in file "fname_initlabel" and assign "fname_labelz" path

