### PR TITLE
Do not overwrite existing segmentation during pytest:test_deepseg

### DIFF
--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -40,7 +40,8 @@ def test_segment_nifti():
     """
     output = sct.deepseg.core.segment_nifti(
         'sct_testing_data/t2s/t2s.nii.gz',
-        os.path.join(sct.__deepseg_dir__, 't2star_sc'))
+        os.path.join(sct.__deepseg_dir__, 't2star_sc'),
+        {'o': 't2s_seg_deepseg.nii.gz'})
     # TODO: implement integrity test (for now, just checking if output segmentation file exists)
-    assert output == 'sct_testing_data/t2s/t2s_seg.nii.gz'
+    assert output == 't2s_seg_deepseg.nii.gz'
     assert os.path.isfile(output)


### PR DESCRIPTION
`pytest:test_deepseg:test_segment_nifti` used to overwrite the `t2s_seg.nii.gz` file. When running in Travis, `sct_testing` runs after pytest, and therefore is affected by modifications in the testing data.

In the issue encountered [here](https://travis-ci.org/github/neuropoly/spinalcordtoolbox/builds/702419420?utm_source=github_status&utm_medium=notification), the integrity test `test_sct_get_centerline` uses the (now modified) `t2s_seg.nii.gz` file as a ground truth, which generates this failure. 

This PR fixes the problem by _not_ overwriting the existing segmentation when running `pytest:test_deepseg:test_segment_nifti`.

Also see https://github.com/neuropoly/spinalcordtoolbox/pull/2748#issuecomment-650470407
