### PR TITLE
Figured out what segmentation technique is reproducible across platforms; improve test sensitivity.

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -70,8 +70,8 @@ def main(args=None):
             "https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip",
         ],
         "sct_testing_data": [
-            "https://github.com/sct-data/sct_testing_data/releases/download/r20200707/sct_testing_data-r20200707.zip",
-            "https://osf.io/download/5f04de5a1484ac00b266b3fa/"
+            "https://github.com/sct-data/sct_testing_data/releases/download/r20200707232231/sct_testing_data-r20200707232231.zip",
+            "https://osf.io/download/5f053c176cbca300dad363d3/"
         ],
         "PAM50": [
             "https://github.com/sct-data/PAM50/releases/download/r20191029/20191029_pam50.zip",

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -70,8 +70,8 @@ def main(args=None):
             "https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip",
         ],
         "sct_testing_data": [
-            "https://github.com/sct-data/sct_testing_data/releases/download/r20200504/20200504_sct_testing_data.zip",
-            "https://osf.io/6x5a2/download",
+            "https://github.com/sct-data/sct_testing_data/releases/download/r20200707/sct_testing_data-r20200707.zip",
+            "https://osf.io/download/5f04de5a1484ac00b266b3fa/"
         ],
         "PAM50": [
             "https://github.com/sct-data/PAM50/releases/download/r20191029/20191029_pam50.zip",

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -44,7 +44,7 @@ def get_parser():
 
     parser.add_option(name='-centerline-algo',
                       type_value='multiple_choice',
-                      description='Algorithm for centerline fitting. Only relevant with -angle-corr 1.',
+                      description='Algorithm for centerline fitting. Only relevant with -method fitseg',
                       mandatory=False,
                       example=['polyfit', 'bspline', 'linear', 'nurbs'],
                       default_value='bspline')

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -62,7 +62,7 @@ def get_parser():
     parser = Parser(__file__)
     parser.usage.set_description('''This function takes an anatomical image and its cord segmentation (binary file), and outputs the cord segmentation labeled with vertebral level. The algorithm requires an initialization (first disc) and then performs a disc search in the superior, then inferior direction, using template disc matching based on mutual information score. The automatic method uses the module implemented in "spinalcordtoolbox/vertebrae/detect_c2c3.py" to detect the C2-C3 disc.
     Tips: To run the function with init txt file that includes flags -initz/-initcenter:
-    sct_label_vertebrae -i t2.nii.gz -s t2_seg_manual.nii.gz  "$(< init_label_vertebrae.txt)"
+    sct_label_vertebrae -i t2.nii.gz -s t2_seg-manual.nii.gz  "$(< init_label_vertebrae.txt)"
     ''')
     parser.add_option(name="-i",
                       type_value="file",

--- a/spinalcordtoolbox/math.py
+++ b/spinalcordtoolbox/math.py
@@ -54,6 +54,41 @@ def _get_selem(shape, size, dim):
     return selem
 
 
+def dice(im1, im2):
+    """
+    Computes the Dice coefficient, a measure of set similarity.
+    Parameters
+    ----------
+    im1 : array-like, bool
+        Any array of arbitrary size. If not boolean, will be converted.
+    im2 : array-like, bool
+        Any other array of identical size. If not boolean, will be converted.
+    Returns
+    -------
+    dice : float
+        Dice coefficient as a float on range [0,1].
+        Maximum similarity = 1
+        No similarity = 0
+
+    Notes
+    -----
+    The order of inputs for `dice` is irrelevant. The result will be
+    identical if `im1` and `im2` are switched.
+
+    Source: https://gist.github.com/JDWarner/6730747
+    """
+    im1 = np.asarray(im1).astype(np.bool)
+    im2 = np.asarray(im2).astype(np.bool)
+
+    if im1.shape != im2.shape:
+        raise ValueError("Shape mismatch: im1 and im2 must have the same shape.")
+
+    # Compute Dice coefficient
+    intersection = np.logical_and(im1, im2)
+
+    return 2. * intersection.sum() / (im1.sum() + im2.sum())
+
+
 def dilate(data, size, shape, dim=None):
     """
     Dilate data using ball structuring element

--- a/testing/test_sct_analyze_lesion.py
+++ b/testing/test_sct_analyze_lesion.py
@@ -19,7 +19,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-m t2/t2_seg_manual.nii.gz -s t2/t2_seg_manual.nii.gz']
+    default_args = ['-m t2/t2_seg-manual.nii.gz -s t2/t2_seg-manual.nii.gz']
 
     # assign default params
     if not param_test.args:
@@ -33,7 +33,7 @@ def test_integrity(param_test):
     Test integrity of function
     """
     # Simply check if output pkl file exists
-    if os.path.exists('t2_seg_manual_analyzis.pkl'):
+    if os.path.exists('t2_seg-manual_analyzis.pkl'):
         param_test.output += '--> PASSED'
     else:
         param_test.status = 99

--- a/testing/test_sct_analyze_texture.py
+++ b/testing/test_sct_analyze_texture.py
@@ -22,7 +22,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -m t2/t2_seg.nii.gz -feature contrast -distance 1 -ofolder .']
+    default_args = ['-i t2/t2.nii.gz -m t2/t2_seg-manual.nii.gz -feature contrast -distance 1 -ofolder .']
     param_test.norm_threshold = 0.001
     param_test.file_texture = 't2_contrast_1_mean.nii.gz'
     param_test.fname_gt = 't2/t2_contrast_1_mean_ref.nii.gz'

--- a/testing/test_sct_convert_binary_to_trilinear.py
+++ b/testing/test_sct_convert_binary_to_trilinear.py
@@ -19,7 +19,7 @@ def test(path_data):
 
     # parameters
     folder_data = 't2'
-    file_data = 't2_seg.nii.gz'
+    file_data = 't2_seg-manual.nii.gz'
 
     # define command
     cmd = 'sct_convert_binary_to_trilinear' \
@@ -30,7 +30,7 @@ def test(path_data):
     #return sct.run(cmd, 0)
     return sct.run(cmd)
 
-# call to function
+
 if __name__ == "__main__":
     # call main function
     test()

--- a/testing/test_sct_crop_image.py
+++ b/testing/test_sct_crop_image.py
@@ -27,7 +27,7 @@ def init(param_test):
     ]
     default_args = [
         '-i t2/t2.nii.gz -o {} -xmin 1 -xmax -3 -ymin 2 -ymax 10'.format(param_test.fname_out[0]),
-        '-i t2/t2.nii.gz -o {} -m t2/t2_seg.nii.gz'.format(param_test.fname_out[1]),
+        '-i t2/t2.nii.gz -o {} -m t2/t2_seg-manual.nii.gz'.format(param_test.fname_out[1]),
         '-i t2/t2.nii.gz -o {} -ref mt/mt0.nii.gz'.format(param_test.fname_out[2]),
     ]
     # assign default params

--- a/testing/test_sct_crop_image.py
+++ b/testing/test_sct_crop_image.py
@@ -47,7 +47,7 @@ def test_integrity(param_test):
     if index_args == 0:
         xyz = (57, 9, 52)
     elif index_args == 1:
-        xyz = (10, 55, 13)
+        xyz = (11, 55, 13)
     elif index_args == 2:
         xyz = (37, 55, 34)
 

--- a/testing/test_sct_deepseg_sc.py
+++ b/testing/test_sct_deepseg_sc.py
@@ -26,9 +26,6 @@ def init(param_test):
     """
     # initialization
     default_args = ['-i t2/t2.nii.gz -c t2 -qc testing-qc']  # default parameters
-    param_test.file_seg = 't2_seg.nii.gz'  # output segmentation
-    param_test.fname_gt = 't2/t2_seg-manual.nii.gz'
-    param_test.dice_threshold = 0.8  # TODO: change for 1.0
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_deepseg_sc.py
+++ b/testing/test_sct_deepseg_sc.py
@@ -25,10 +25,10 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -c t2 -igt t2/t2_seg_manual.nii.gz -qc testing-qc']  # default parameters
-    param_test.file_seg = 't2_seg.nii.gz'
-    param_test.fname_gt = 't2/t2_seg_manual.nii.gz'
-    param_test.dice_threshold = 0.8
+    default_args = ['-i t2/t2.nii.gz -c t2 -qc testing-qc']  # default parameters
+    param_test.file_seg = 't2_seg.nii.gz'  # output segmentation
+    param_test.fname_gt = 't2/t2_seg-manual.nii.gz'
+    param_test.dice_threshold = 0.8  # TODO: change for 1.0
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_deepseg_sc.py
+++ b/testing/test_sct_deepseg_sc.py
@@ -39,25 +39,6 @@ def init(param_test):
 
 def test_integrity(param_test):
     """
-    Test integrity of function
+    Integrity test has moved to unit_testing/ and is run with pytest
     """
-    # open output segmentation
-    im_seg = Image(param_test.file_seg)
-    # open ground truth
-    im_seg_manual = Image(param_test.fname_gt)
-    # compute dice coefficient between generated image and image from database
-    dice_segmentation = compute_dice(im_seg, im_seg_manual, mode='3d', zboundaries=False)
-    # display
-    param_test.output += 'Computed dice: '+str(dice_segmentation)
-    param_test.output += '\nDice threshold (if computed Dice smaller: fail): '+str(param_test.dice_threshold)
-
-    if dice_segmentation < param_test.dice_threshold:
-        param_test.status = 99
-        param_test.output += '\n--> FAILED'
-    else:
-        param_test.output += '\n--> PASSED'
-
-    # update Panda structure
-    param_test.results['dice'] = dice_segmentation
-
     return param_test

--- a/testing/test_sct_dice_coefficient.py
+++ b/testing/test_sct_dice_coefficient.py
@@ -22,8 +22,8 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2_seg_manual.nii.gz -d t2/t2_seg_manual.nii.gz']  # default parameters
-    param_test.fname_data = 't2/t2_seg_manual.nii.gz'
+    default_args = ['-i t2/t2_seg-manual.nii.gz -d t2/t2_seg-manual.nii.gz']  # default parameters
+    param_test.fname_data = 't2/t2_seg-manual.nii.gz'
     param_test.dice_value = 1.0
 
     # assign default params

--- a/testing/test_sct_flatten_sagittal.py
+++ b/testing/test_sct_flatten_sagittal.py
@@ -28,7 +28,7 @@ def init(param_test):
     param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz']  # default parameters
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz']  # default parameters
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_get_centerline.py
+++ b/testing/test_sct_get_centerline.py
@@ -12,34 +12,13 @@
 
 from __future__ import absolute_import, division
 
-import os, math
+import math
 
 import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 
-import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
-
-
-def compute_mse(im_true, im_pred):
-    mse_dist = []
-    count_slice = 0
-    for z in range(im_true.dim[2]):
-
-        if np.sum(im_true.data[:, :, z]):
-            x_true, y_true = [np.where(im_true.data[:, :, z] > 0)[i][0] for i in range(len(np.where(im_true.data[:, :, z] > 0)))]
-            x_pred, y_pred = [np.where(im_pred.data[:, :, z] > 0)[i][0] for i in range(len(np.where(im_pred.data[:, :, z] > 0)))]
-
-            x_true, y_true = im_true.transfo_pix2phys([[x_true, y_true, z]])[0][0], im_true.transfo_pix2phys([[x_true, y_true, z]])[0][1]
-            x_pred, y_pred = im_pred.transfo_pix2phys([[x_pred, y_pred, z]])[0][0], im_pred.transfo_pix2phys([[x_pred, y_pred, z]])[0][1]
-
-            dist = ((x_true - x_pred))**2 + ((y_true - y_pred))**2
-            mse_dist.append(dist)
-
-            count_slice += 1
-
-    return math.sqrt(sum(mse_dist) / float(count_slice))
 
 
 def init(param_test):
@@ -61,37 +40,6 @@ def init(param_test):
 
 def test_integrity(param_test):
     """
-    Test integrity of function
+    Integrity test has moved to unit_testing/ and is run with pytest
     """
-
-    # open ground truth
-    im_seg_manual = Image(param_test.fname_gt).change_orientation("RPI")
-
-    # Compute center of mass of the SC seg on each axial slice.
-    center_of_mass_x_y_z_lst = [[int(center_of_mass(im_seg_manual.data[:, :, zz])[0]),
-                                 int(center_of_mass(im_seg_manual.data[:, :, zz])[1]),
-                                 zz] for zz in range(im_seg_manual.dim[2])]
-
-    im_ctr_manual = msct_image.zeros_like(im_seg_manual)
-    for x_y_z in center_of_mass_x_y_z_lst:
-        im_ctr_manual.data[x_y_z[0], x_y_z[1], x_y_z[2]] = 1
-
-    # open output segmentation
-    im_ctr = Image(param_test.file_ctr).change_orientation("RPI")
-
-    # compute MSE between generated ctr and ctr from database
-    mse_detection = compute_mse(im_ctr, im_ctr_manual)
-
-    param_test.output += 'Computed MSE: ' + str(mse_detection)
-    param_test.output += 'MSE threshold (if computed MSE higher: fail): ' + str(param_test.mse_threshold)
-
-    if mse_detection > param_test.mse_threshold:
-        param_test.status = 99
-        param_test.output += '--> FAILED'
-    else:
-        param_test.output += '--> PASSED'
-
-    # update Panda structure
-    param_test.results['mse_detection'] = mse_detection
-
     return param_test

--- a/testing/test_sct_label_utils.py
+++ b/testing/test_sct_label_utils.py
@@ -29,7 +29,7 @@ def init(param_test):
     """
     # initialization
     folder_data = ['t2']
-    file_data = ['t2_seg.nii.gz', 't2_seg_labeled.nii.gz']
+    file_data = ['t2_seg-manual.nii.gz', 't2_seg_labeled.nii.gz']
 
     default_args = ['-i ' + os.path.join(folder_data[0], file_data[0]) + ' -create 1,1,1,1:2,2,2,2',
                     '-i ' + os.path.join(folder_data[0], file_data[0]) + ' -cubic-to-point -o test_centerofmass.nii.gz']

--- a/testing/test_sct_label_vertebrae.py
+++ b/testing/test_sct_label_vertebrae.py
@@ -16,8 +16,8 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -c t2 -initfile t2/init_label_vertebrae.txt -t template -qc testing-qc',
-                    '-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -c t2 -discfile t2/labels.nii.gz']
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz -c t2 -initfile t2/init_label_vertebrae.txt -t template -qc testing-qc',
+                    '-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz -c t2 -discfile t2/labels.nii.gz']
     # assign default params
     if not param_test.args:
         param_test.args = default_args

--- a/testing/test_sct_merge_images.py
+++ b/testing/test_sct_merge_images.py
@@ -16,7 +16,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i template/template/PAM50_small_cord.nii.gz,t2/t2_seg_manual.nii.gz -w mt/warp_template2mt.nii.gz,t2/warp_template2anat.nii.gz -d mt/mt1.nii.gz']
+    default_args = ['-i template/template/PAM50_small_cord.nii.gz,t2/t2_seg-manual.nii.gz -w mt/warp_template2mt.nii.gz,t2/warp_template2anat.nii.gz -d mt/mt1.nii.gz']
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_process_segmentation.py
+++ b/testing/test_sct_process_segmentation.py
@@ -23,7 +23,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2_seg.nii.gz']
+    default_args = ['-i t2/t2_seg-manual.nii.gz']
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_propseg.py
+++ b/testing/test_sct_propseg.py
@@ -22,8 +22,8 @@ def init(param_test):
     """
     # initialization
     default_args = ['-i t2/t2.nii.gz -c t2 -qc testing-qc']  # default parameters
-    param_test.fname_seg = 't2_seg.nii.gz'
-    param_test.fname_gt = 't2/t2_seg_manual.nii.gz'
+    param_test.fname_seg = 't2_seg.nii.gz'  # output segmentation
+    param_test.fname_gt = 't2/t2_seg-manual.nii.gz'
     # note: propseg does *not* produce the same results across platforms, hence the 0.9 Dice threahold.
     # For more details, see: https://github.com/neuropoly/spinalcordtoolbox/issues/2769
     param_test.dice_threshold = 0.9

--- a/testing/test_sct_propseg.py
+++ b/testing/test_sct_propseg.py
@@ -12,8 +12,6 @@
 
 from __future__ import absolute_import
 
-import sys, io, os
-
 import sct_utils as sct
 from spinalcordtoolbox.image import Image, compute_dice
 

--- a/testing/test_sct_propseg.py
+++ b/testing/test_sct_propseg.py
@@ -26,6 +26,8 @@ def init(param_test):
     default_args = ['-i t2/t2.nii.gz -c t2 -qc testing-qc']  # default parameters
     param_test.fname_seg = 't2_seg.nii.gz'
     param_test.fname_gt = 't2/t2_seg_manual.nii.gz'
+    # note: propseg does *not* produce the same results across platforms, hence the 0.9 Dice threahold.
+    # For more details, see: https://github.com/neuropoly/spinalcordtoolbox/issues/2769
     param_test.dice_threshold = 0.9
 
     # check if isct_propseg compatibility

--- a/testing/test_sct_qc.py
+++ b/testing/test_sct_qc.py
@@ -18,7 +18,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg_manual.nii.gz -p sct_deepseg_sc -qc-dataset sct_testing_data -qc-subject dummy']  # default parameters
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz -p sct_deepseg_sc -qc-dataset sct_testing_data -qc-subject dummy']  # default parameters
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -26,10 +26,10 @@ def init(param_test):
     Initialize class: param_test
     """
     default_args = [
-        '-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -l t2/labels.nii.gz -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares -t template -qc qc-testing',
-        '-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -ldisc t2/labels.nii.gz -ref subject',
+        '-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz -l t2/labels.nii.gz -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:step=2,type=seg,algo=bsplinesyn,iter=5,metric=MeanSquares -t template -qc qc-testing',
+        '-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz -ldisc t2/labels.nii.gz -ref subject',
     ]
-    param_test.file_seg = 't2/t2_seg.nii.gz'
+    param_test.file_seg = 't2/t2_seg-manual.nii.gz'
     param_test.fname_gt = ['template/template/PAM50_small_cord.nii.gz', os.path.join(__sct_dir__, 'data/PAM50/template/PAM50_cord.nii.gz')]
 
     param_test.dice_threshold = 0.9

--- a/testing/test_sct_smooth_spinalcord.py
+++ b/testing/test_sct_smooth_spinalcord.py
@@ -16,7 +16,7 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz -smooth 0,0,5']
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz -smooth 0,0,5']
 
     # assign default params
     if not param_test.args:

--- a/testing/test_sct_straighten_spinalcord.py
+++ b/testing/test_sct_straighten_spinalcord.py
@@ -27,8 +27,8 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg.nii.gz']
-    param_test.fname_segmentation = 't2/t2_seg.nii.gz'
+    default_args = ['-i t2/t2.nii.gz -s t2/t2_seg-manual.nii.gz']
+    param_test.fname_segmentation = 't2/t2_seg-manual.nii.gz'
 
     # assign default params
     if not param_test.args:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -25,7 +25,7 @@ def t2_image():
 @pytest.fixture()
 def t2_seg_image():
     sct_test_data = 'sct_testing_data'
-    t2_seg_file = os.path.join(sct_test_data, 't2', 't2_seg.nii.gz')
+    t2_seg_file = os.path.join(sct_test_data, 't2', 't2_seg-manual.nii.gz')
     return t2_seg_file
 
 

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -78,7 +78,7 @@ param_optic = [
       'fname_centerline-optic': 'sct_testing_data/t2s/t2s_centerline-optic.nii.gz'}),
     ({'fname_image': 'sct_testing_data/dmri/dwi_mean.nii.gz',
       'contrast': 'dwi',
-      'fname_centerline-optic': 'sct_testing_data/dmri/dwi_centerline-optic.nii.gz'}),
+      'fname_centerline-optic': 'sct_testing_data/dmri/dwi_mean_centerline-optic.nii.gz'}),
     ]
 
 

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -146,7 +146,7 @@ def test_get_centerline_nurbs(img_ctl, expected, params):
 
 # noinspection 801,PyShadowingNames
 def test_get_centerline_optic():
-    """Test extraction of metrics aggregation across slices: All slices by default"""
+    """Test centerline extraction with optic"""
     fname_t2 = os.path.join(__sct_dir__, 'sct_testing_data/t2/t2.nii.gz')  # install: sct_download_data -d sct_testing_data
     img_t2 = Image(fname_t2)
     # Add non-numerical values at the top corner of the image for testing purpose
@@ -156,7 +156,7 @@ def test_get_centerline_optic():
     img_out, arr_out, _, _ = get_centerline(
         img_t2, ParamCenterline(algo_fitting='optic', contrast='t2', minmax=False), verbose=VERBOSE)
     # Open ground truth segmentation and compare
-    fname_t2_seg = os.path.join(__sct_dir__, 'sct_testing_data/t2/t2_seg.nii.gz')
+    fname_t2_seg = os.path.join(__sct_dir__, 'sct_testing_data/t2/t2_seg-manual.nii.gz')
     img_seg_out, arr_seg_out, _, _ = get_centerline(
         Image(fname_t2_seg), ParamCenterline(algo_fitting='bspline', minmax=False), verbose=VERBOSE)
     assert np.linalg.norm(find_and_sort_coord(img_seg_out) - find_and_sort_coord(img_out)) < 3.5

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -9,15 +9,18 @@ import os
 import sys
 import pytest
 import numpy as np
+import nibabel
 
+import spinalcordtoolbox as sct
 from spinalcordtoolbox import __sct_dir__
-sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, find_and_sort_coord, round_and_clip
 from spinalcordtoolbox.image import Image
-
 from spinalcordtoolbox.testing.create_test_data import dummy_centerline
+import spinalcordtoolbox.math
+
+sys.path.append(os.path.join(__sct_dir__, 'scripts'))
 from sct_utils import init_sct
+
 
 init_sct(log_level=2)  # Set logger in debug mode
 VERBOSE = 0  # Set to 2 to save images, 0 otherwise
@@ -64,13 +67,13 @@ im_centerlines = [
     (dummy_centerline(size_arr=(30, 20, 50), subsampling=10),
      {'median': 0, 'rmse': 0.1, 'laplacian': 0.5, 'norm': 3.8},
      {}),
-    # (dummy_centerline(size_arr=(30, 20, 100), subsampling=1, outlier=[20]),
-    #  {'median': 0, 'rmse': 2, 'laplacian': 0.5, 'norm': 11.5},
-    #  {}),
-    # (dummy_centerline(size_arr=(30, 20, 500), subsampling=1, outlier=[20]),
-    #  {'median': 0, 'rmse': 1, 'laplacian': 0.5, 'norm': 11.5},
-    #  {})
 ]
+
+param_optic = [
+    ({'fname_image': 'sct_testing_data/t2/t2.nii.gz',
+      'fname_centerline-optic': 'sct_testing_data/t2/t2_centerline-optic.nii.gz'})
+    ]
+
 
 # noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('img_ctl,expected', im_ctl_find_and_sort_coord)
@@ -145,21 +148,20 @@ def test_get_centerline_nurbs(img_ctl, expected, params):
 
 
 # noinspection 801,PyShadowingNames
-def test_get_centerline_optic():
+@pytest.mark.parametrize('params', param_optic)
+def test_get_centerline_optic(params):
     """Test centerline extraction with optic"""
-    fname_t2 = os.path.join(__sct_dir__, 'sct_testing_data/t2/t2.nii.gz')  # install: sct_download_data -d sct_testing_data
-    img_t2 = Image(fname_t2)
+    # TODO: add assert on the output .csv files for more precision
+    im = Image(params['fname_image'])
     # Add non-numerical values at the top corner of the image for testing purpose
-    img_t2.change_type('float32')
-    img_t2.data[0, 0, 0] = np.nan
-    img_t2.data[1, 0, 0] = np.inf
-    img_out, arr_out, _, _ = get_centerline(
-        img_t2, ParamCenterline(algo_fitting='optic', contrast='t2', minmax=False), verbose=VERBOSE)
+    im.change_type('float32')
+    im.data[0, 0, 0] = np.nan
+    im.data[1, 0, 0] = np.inf
+    im_centerline, arr_out, _, _ = get_centerline(
+        im, ParamCenterline(algo_fitting='optic', contrast='t2', minmax=False), verbose=VERBOSE)
     # Open ground truth segmentation and compare
-    fname_t2_seg = os.path.join(__sct_dir__, 'sct_testing_data/t2/t2_seg-manual.nii.gz')
-    img_seg_out, arr_seg_out, _, _ = get_centerline(
-        Image(fname_t2_seg), ParamCenterline(algo_fitting='bspline', minmax=False), verbose=VERBOSE)
-    assert np.linalg.norm(find_and_sort_coord(img_seg_out) - find_and_sort_coord(img_out)) < 3.5
+    assert sct.math.dice(im_centerline.data,
+                         Image(params['fname_centerline-optic']).data) == 1.0
 
 
 def test_round_and_clip():

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -74,8 +74,8 @@ param_optic = [
       'fname_centerline-optic': 'sct_testing_data/t2/t2_centerline-optic.nii.gz'}),
     ({'fname_image': 'sct_testing_data/t2s/t2s.nii.gz',
       'fname_centerline-optic': 'sct_testing_data/t2s/t2s_centerline-optic.nii.gz'}),
-    ({'fname_image': 'sct_testing_data/dwi/dwi_mean.nii.gz',
-      'fname_centerline-optic': 'sct_testing_data/dwi/dwi_centerline-optic.nii.gz'}),
+    ({'fname_image': 'sct_testing_data/dmri/dwi_mean.nii.gz',
+      'fname_centerline-optic': 'sct_testing_data/dmri/dwi_centerline-optic.nii.gz'}),
     ]
 
 

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -71,7 +71,11 @@ im_centerlines = [
 
 param_optic = [
     ({'fname_image': 'sct_testing_data/t2/t2.nii.gz',
-      'fname_centerline-optic': 'sct_testing_data/t2/t2_centerline-optic.nii.gz'})
+      'fname_centerline-optic': 'sct_testing_data/t2/t2_centerline-optic.nii.gz'}),
+    ({'fname_image': 'sct_testing_data/t2s/t2s.nii.gz',
+      'fname_centerline-optic': 'sct_testing_data/t2s/t2s_centerline-optic.nii.gz'}),
+    ({'fname_image': 'sct_testing_data/dwi/dwi_mean.nii.gz',
+      'fname_centerline-optic': 'sct_testing_data/dwi/dwi_centerline-optic.nii.gz'}),
     ]
 
 

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -71,10 +71,13 @@ im_centerlines = [
 
 param_optic = [
     ({'fname_image': 'sct_testing_data/t2/t2.nii.gz',
+      'contrast': 't2',
       'fname_centerline-optic': 'sct_testing_data/t2/t2_centerline-optic.nii.gz'}),
     ({'fname_image': 'sct_testing_data/t2s/t2s.nii.gz',
+      'contrast': 't2s',
       'fname_centerline-optic': 'sct_testing_data/t2s/t2s_centerline-optic.nii.gz'}),
     ({'fname_image': 'sct_testing_data/dmri/dwi_mean.nii.gz',
+      'contrast': 'dwi',
       'fname_centerline-optic': 'sct_testing_data/dmri/dwi_centerline-optic.nii.gz'}),
     ]
 
@@ -162,10 +165,9 @@ def test_get_centerline_optic(params):
     im.data[0, 0, 0] = np.nan
     im.data[1, 0, 0] = np.inf
     im_centerline, arr_out, _, _ = get_centerline(
-        im, ParamCenterline(algo_fitting='optic', contrast='t2', minmax=False), verbose=VERBOSE)
-    # Open ground truth segmentation and compare
-    assert sct.math.dice(im_centerline.data,
-                         Image(params['fname_centerline-optic']).data) == 1.0
+        im, ParamCenterline(algo_fitting='optic', contrast=params['contrast'], minmax=False), verbose=VERBOSE)
+    # Compare with ground truth centerline
+    assert np.all(im_centerline.data == Image(params['fname_centerline-optic']).data)
 
 
 def test_round_and_clip():

--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -6,6 +6,8 @@
 import os
 import pytest
 
+import nibabel
+
 import spinalcordtoolbox as sct
 import spinalcordtoolbox.deepseg.core
 import spinalcordtoolbox.deepseg.models
@@ -55,3 +57,6 @@ def test_segment_nifti(params):
     assert output == fname_out
     # Make sure output file exists
     assert os.path.isfile(output)
+    # Compare with ground-truth
+    assert sct.math.dice(nibabel.load(output).get_fdata(),
+                         nibabel.load(params['fname_seg_manual']).get_fdata()) == 1.0

--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -5,6 +5,7 @@
 
 import os
 import pytest
+import numpy as np
 
 import nibabel
 
@@ -57,6 +58,5 @@ def test_segment_nifti(params):
     assert output == fname_out
     # Make sure output file exists
     assert os.path.isfile(output)
-    # Compare with ground-truth
-    assert sct.math.dice(nibabel.load(output).get_fdata(),
-                         nibabel.load(params['fname_seg_manual']).get_fdata()) == 1.0
+    # Compare with ground-truth segmentation
+    assert np.all(nibabel.load(output).get_fdata() == nibabel.load(params['fname_seg_manual']).get_fdata())

--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -4,10 +4,18 @@
 
 
 import os
+import pytest
 
 import spinalcordtoolbox as sct
 import spinalcordtoolbox.deepseg.core
 import spinalcordtoolbox.deepseg.models
+
+
+param_deepseg = [
+    ({'fname_image': 'sct_testing_data/t2s/t2s.nii.gz',
+      'model': os.path.join(sct.__deepseg_dir__, 't2star_sc'),
+      'fname_seg_manual': 'sct_testing_data/t2s/t2s_seg-deepseg.nii.gz'}),
+]
 
 
 def test_install_model():
@@ -33,15 +41,17 @@ def test_model_dict():
         assert('default' in value)
 
 
-def test_segment_nifti():
+# noinspection 801,PyShadowingNames
+@pytest.mark.parametrize('params', param_deepseg)
+def test_segment_nifti(params):
     """
     Uses the locally-installed sct_testing_data
-    :return:
     """
+    fname_out = 't2s_seg_deepseg.nii.gz'
     output = sct.deepseg.core.segment_nifti(
-        'sct_testing_data/t2s/t2s.nii.gz',
-        os.path.join(sct.__deepseg_dir__, 't2star_sc'),
-        param={'o': 't2s_seg_deepseg.nii.gz'})
+        params['fname_image'], params['model'], param={'o': fname_out})
     # TODO: implement integrity test (for now, just checking if output segmentation file exists)
-    assert output == 't2s_seg_deepseg.nii.gz'
+    # Make sure output file is correct
+    assert output == fname_out
+    # Make sure output file exists
     assert os.path.isfile(output)

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -81,7 +81,7 @@ def test_segment_2d():
     model_path = os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc.h5'.format(contrast_test))   
 
     fname_t2 = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2.nii.gz')  # install: sct_download_data -d sct_testing_data
-    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg.nii.gz')  # install: sct_download_data -d sct_testing_data
+    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg-manual.nii.gz')  # install: sct_download_data -d sct_testing_data
 
     img, gt = _preprocess_segment(fname_t2, fname_t2_seg, contrast_test)
 
@@ -101,7 +101,7 @@ def test_segment_3d():
     model_path = os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc_3D.h5'.format(contrast_test))   
 
     fname_t2 = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2.nii.gz')  # install: sct_download_data -d sct_testing_data
-    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg.nii.gz')  # install: sct_download_data -d sct_testing_data
+    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg-manual.nii.gz')  # install: sct_download_data -d sct_testing_data
 
     img, gt = _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=True)
 

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -87,11 +87,8 @@ def test_uncrop_image():
     nii = nib.nifti1.Nifti1Image(data_in, affine)
     img_in = Image(data_in, hdr=nii.header, dim=nii.header.get_data_shape())
 
-    img_uncrop = sct.deepseg_sc.core.uncrop_image(ref_in=img_in,
-                                        data_crop=data_crop,
-                                        x_crop_lst=x_crop_lst,
-                                        y_crop_lst=y_crop_lst,
-                                        z_crop_lst=z_crop_lst)
+    img_uncrop = sct.deepseg_sc.core.uncrop_image(
+        ref_in=img_in, data_crop=data_crop, x_crop_lst=x_crop_lst, y_crop_lst=y_crop_lst, z_crop_lst=z_crop_lst)
 
     assert img_uncrop.data.shape == input_shape
     z_rand = np.random.randint(0, input_shape[2])

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -16,81 +16,81 @@ from spinalcordtoolbox import resampling
 from spinalcordtoolbox.testing.create_test_data import dummy_centerline
 
 
-def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
-    tmp_folder = sct.TempFolder()
-    tmp_folder_path = tmp_folder.get_path()
-    tmp_folder.chdir()
-
-    img = Image(fname_t2)
-    gt = Image(fname_t2_seg)
-
-    fname_t2_RPI, fname_t2_seg_RPI = 'img_RPI.nii.gz', 'seg_RPI.nii.gz'
-
-    img.change_orientation('RPI')
-    gt.change_orientation('RPI')
-    new_resolution = 'x'.join(['0.5', '0.5', str(img.dim[6])])
-    
-    img_res = \
-        resampling.resample_nib(img, new_size=[0.5, 0.5, img.dim[6]], new_size_type='mm', interpolation='linear')
-    gt_res = \
-        resampling.resample_nib(gt, new_size=[0.5, 0.5, img.dim[6]], new_size_type='mm', interpolation='linear')
-
-    img_res.save(fname_t2_RPI)
-
-    _, ctr_im, _ = deepseg_sc.find_centerline(algo='svm',
-                                                image_fname=fname_t2_RPI,
-                                                contrast_type=contrast_test,
-                                                brain_bool=False,
-                                                folder_output=tmp_folder_path,
-                                                remove_temp_files=1,
-                                                centerline_fname=None)
-
-    _, _, _, img = deepseg_sc.crop_image_around_centerline(im_in=img_res,
-                                                        ctr_in=ctr_im,
-                                                        crop_size=64)
-    _, _, _, gt = deepseg_sc.crop_image_around_centerline(im_in=gt_res,
-                                                        ctr_in=ctr_im,
-                                                        crop_size=64)
-    del ctr_im
-
-    img = deepseg_sc.apply_intensity_normalization(im_in=img)
-
-    if dim_3:  # If 3D kernels
-        fname_t2_RPI_res_crop, fname_t2_seg_RPI_res_crop = 'img_RPI_res_crop.nii.gz', 'seg_RPI_res_crop.nii.gz'
-        img.save(fname_t2_RPI_res_crop)
-        gt.save(fname_t2_seg_RPI_res_crop)
-        del img, gt
-
-        fname_t2_RPI_res_crop_res = 'img_RPI_res_crop_res.nii.gz'
-        fname_t2_seg_RPI_res_crop_res = 'seg_RPI_res_crop_res.nii.gz'
-        resampling.resample_file(fname_t2_RPI_res_crop, fname_t2_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
-        resampling.resample_file(fname_t2_seg_RPI_res_crop, fname_t2_seg_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
-        img, gt = Image(fname_t2_RPI_res_crop_res), Image(fname_t2_seg_RPI_res_crop_res)
-
-    tmp_folder.chdir_undo()
-    tmp_folder.cleanup()
-
-    return img, gt
+# def _preprocess_segment(fname_t2, fname_t2_seg, contrast_test, dim_3=False):
+#     tmp_folder = sct.TempFolder()
+#     tmp_folder_path = tmp_folder.get_path()
+#     tmp_folder.chdir()
+#
+#     img = Image(fname_t2)
+#     gt = Image(fname_t2_seg)
+#
+#     fname_t2_RPI, fname_t2_seg_RPI = 'img_RPI.nii.gz', 'seg_RPI.nii.gz'
+#
+#     img.change_orientation('RPI')
+#     gt.change_orientation('RPI')
+#     new_resolution = 'x'.join(['0.5', '0.5', str(img.dim[6])])
+#
+#     img_res = \
+#         resampling.resample_nib(img, new_size=[0.5, 0.5, img.dim[6]], new_size_type='mm', interpolation='linear')
+#     gt_res = \
+#         resampling.resample_nib(gt, new_size=[0.5, 0.5, img.dim[6]], new_size_type='mm', interpolation='linear')
+#
+#     img_res.save(fname_t2_RPI)
+#
+#     _, ctr_im, _ = deepseg_sc.find_centerline(algo='svm',
+#                                                 image_fname=fname_t2_RPI,
+#                                                 contrast_type=contrast_test,
+#                                                 brain_bool=False,
+#                                                 folder_output=tmp_folder_path,
+#                                                 remove_temp_files=1,
+#                                                 centerline_fname=None)
+#
+#     _, _, _, img = deepseg_sc.crop_image_around_centerline(im_in=img_res,
+#                                                         ctr_in=ctr_im,
+#                                                         crop_size=64)
+#     _, _, _, gt = deepseg_sc.crop_image_around_centerline(im_in=gt_res,
+#                                                         ctr_in=ctr_im,
+#                                                         crop_size=64)
+#     del ctr_im
+#
+#     img = deepseg_sc.apply_intensity_normalization(im_in=img)
+#
+#     if dim_3:  # If 3D kernels
+#         fname_t2_RPI_res_crop, fname_t2_seg_RPI_res_crop = 'img_RPI_res_crop.nii.gz', 'seg_RPI_res_crop.nii.gz'
+#         img.save(fname_t2_RPI_res_crop)
+#         gt.save(fname_t2_seg_RPI_res_crop)
+#         del img, gt
+#
+#         fname_t2_RPI_res_crop_res = 'img_RPI_res_crop_res.nii.gz'
+#         fname_t2_seg_RPI_res_crop_res = 'seg_RPI_res_crop_res.nii.gz'
+#         resampling.resample_file(fname_t2_RPI_res_crop, fname_t2_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
+#         resampling.resample_file(fname_t2_seg_RPI_res_crop, fname_t2_seg_RPI_res_crop_res, new_resolution, 'mm', 'linear', verbose=0)
+#         img, gt = Image(fname_t2_RPI_res_crop_res), Image(fname_t2_seg_RPI_res_crop_res)
+#
+#     tmp_folder.chdir_undo()
+#     tmp_folder.cleanup()
+#
+#     return img, gt
 
 
 def test_segment_2d():
     from keras import backend as K
     K.set_image_data_format("channels_last")  # Set at channels_first in test_deepseg_lesion.test_segment()
 
-    contrast_test = 't2'
-    model_path = os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc.h5'.format(contrast_test))   
+    contrast_type = 't2'
+    # model_path = os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc.h5'.format(contrast_type))
 
-    fname_t2 = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2.nii.gz')  # install: sct_download_data -d sct_testing_data
-    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg-manual.nii.gz')  # install: sct_download_data -d sct_testing_data
+    fname_im = 'sct_testing_data/t2/t2.nii.gz'
+    fname_centerline_manual = 'sct_testing_data/t2/t2_centerline-manual.nii.gz'
+    fname_seg_manual = 'sct_testing_data/t2/t2_seg-manual.nii.gz'
 
-    img, gt = _preprocess_segment(fname_t2, fname_t2_seg, contrast_test)
-
-    seg = deepseg_sc.segment_2d(model_fname=model_path, contrast_type=contrast_test, input_size=(64,64), im_in=img)
-    assert seg.dtype == np.dtype('float32')
-
-    seg_im = img.copy()
-    seg_im.data = (seg > 0.5).astype(np.uint8)
-    assert msct_image.compute_dice(seg_im, gt) > 0.80
+    # img, gt = _preprocess_segment(fname_t2, fname_t2_seg, contrast_test)
+    kernel_size = '2d'
+    im_seg, _, _ = deepseg_sc.deep_segmentation_spinalcord(
+        Image(fname_im), contrast_type, ctr_algo='file', ctr_file=fname_centerline_manual, brain_bool=False,
+        kernel_size=kernel_size, threshold_seg=0.5)
+    assert im_seg.data.dtype == np.dtype('uint8')
+    assert msct_image.compute_dice(im_seg, Image(fname_seg_manual)) == 1.0
 
 
 def test_segment_3d():

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -1,17 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# pytest unit tests for spinalcordtoolbox.deepseg_sc
+
+
 from __future__ import absolute_import
 
-import os
-import sys
 import pytest
-
 import numpy as np
 import nibabel as nib
 
-from spinalcordtoolbox.utils import __sct_dir__
-sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-import sct_utils as sct
 from spinalcordtoolbox.image import Image
-import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.deepseg_sc import core as deepseg_sc
 from spinalcordtoolbox.testing.create_test_data import dummy_centerline
 
@@ -19,7 +17,7 @@ from spinalcordtoolbox.testing.create_test_data import dummy_centerline
 param_deepseg = [
     ({'fname_seg_manual': 'sct_testing_data/t2/t2_seg-deepseg_sc-2d.nii.gz', 'contrast': 't2', 'kernel': '2d'}),
     ({'fname_seg_manual': 'sct_testing_data/t2/t2_seg-deepseg_sc-3d.nii.gz', 'contrast': 't2', 'kernel': '3d'}),
-]
+    ]
 
 # noinspection 801,PyShadowingNames
 @pytest.mark.parametrize('params', param_deepseg)
@@ -31,7 +29,8 @@ def test_deep_segmentation_spinalcord(params):
         Image(fname_im), params['contrast'], ctr_algo='file', ctr_file=fname_centerline_manual, brain_bool=False,
         kernel_size=params['kernel'], threshold_seg=0.5)
     assert im_seg.data.dtype == np.dtype('uint8')
-    assert msct_image.compute_dice(im_seg, Image(params['fname_seg_manual'])) == 1.0
+    # Compare with ground-truth segmentation
+    assert np.all(im_seg.data == Image(params['fname_seg_manual']))
 
 
 def test_intensity_normalization():
@@ -94,7 +93,6 @@ def test_uncrop_image():
     assert img_uncrop.data.shape == input_shape
     z_rand = np.random.randint(0, input_shape[2])
     assert np.allclose(img_uncrop.data[x_crop_lst[z_rand]:x_crop_lst[z_rand]+crop_size,
-                                        y_crop_lst[z_rand]:y_crop_lst[z_rand]+crop_size,
-                                        z_rand],
-                        data_crop[:, :, z_rand])
-
+                       y_crop_lst[z_rand]:y_crop_lst[z_rand]+crop_size,
+                       z_rand],
+                       data_crop[:, :, z_rand])

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -30,7 +30,7 @@ def test_deep_segmentation_spinalcord(params):
         kernel_size=params['kernel'], threshold_seg=0.5)
     assert im_seg.data.dtype == np.dtype('uint8')
     # Compare with ground-truth segmentation
-    assert np.all(im_seg.data == Image(params['fname_seg_manual']))
+    assert np.all(im_seg.data == Image(params['fname_seg_manual']).data)
 
 
 def test_intensity_normalization():

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import pytest
 import numpy as np
 import nibabel as nib
+from keras import backend as K
 
 import spinalcordtoolbox as sct
 from spinalcordtoolbox.image import Image
@@ -26,6 +27,9 @@ def test_deep_segmentation_spinalcord(params):
     """High level segmentation API"""
     fname_im = 'sct_testing_data/t2/t2.nii.gz'
     fname_centerline_manual = 'sct_testing_data/t2/t2_centerline-manual.nii.gz'
+    # Set at channels_first in test_deepseg_lesion.test_segment()
+    K.set_image_data_format("channels_last")
+    # Call segmentation function
     im_seg, _, _ = sct.deepseg_sc.core.deep_segmentation_spinalcord(
         Image(fname_im), params['contrast'], ctr_algo='file', ctr_file=fname_centerline_manual, brain_bool=False,
         kernel_size=params['kernel'], threshold_seg=0.5)

--- a/unit_testing/test_qc_parallel.py
+++ b/unit_testing/test_qc_parallel.py
@@ -17,10 +17,9 @@ def gen_qc(args):
     i, path_qc = args
 
     t2_image = os.path.join(__sct_dir__, 'sct_testing_data', 't2', 't2.nii.gz')
-    t2_seg = os.path.join(__sct_dir__, 'sct_testing_data', 't2', 't2_seg.nii.gz')
+    t2_seg = os.path.join(__sct_dir__, 'sct_testing_data', 't2', 't2_seg-manual.nii.gz')
 
-    qc.generate_qc(fname_in1 = t2_image, fname_seg = t2_seg, path_qc = path_qc,
-                   process = "sct_deepseg_gm")
+    qc.generate_qc(fname_in1=t2_image, fname_seg=t2_seg, path_qc=path_qc, process="sct_deepseg_gm")
     return True
 
 

--- a/unit_testing/test_straightening.py
+++ b/unit_testing/test_straightening.py
@@ -20,7 +20,7 @@ VERBOSE = 0  # Set to 2 to save images, 0 otherwise
 def test_straighten():
     """Test straightening with default params"""
     fname_t2 = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2.nii.gz')  # sct_download_data -d sct_testing_data
-    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg.nii.gz')
+    fname_t2_seg = os.path.join(sct.__sct_dir__, 'sct_testing_data/t2/t2_seg-manual.nii.gz')
     sc_straight = SpinalCordStraightener(fname_t2, fname_t2_seg)
     sc_straight.accuracy_results = True
     sc_straight.straighten()


### PR DESCRIPTION
Some segmentation methods are not reproducible across OSs, leading to non-reproducible pipelines across OSs.  This PR was initiated by https://github.com/neuropoly/spinalcordtoolbox/issues/2769. 

The purpose of this PR is to:
- [x] Check if `sct_get_centerline -method optic` is reproducible across OSs
  - [x] if it is, make the test more sensitive by asserting a Dice of 1.0. Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/2773.
- [x] Check if `sct_deepseg_sc` is reproducible across OSs
  - [x] if it is, make the test more sensitive. 
- [x] Fixes minor issue in usage of `sct_get_centerline`. Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/2772
- [x] Check if `sct_deepseg` is reproducible across OSs
  - [x] if it is, make the test more sensitive. 
- Update [sct_testing_data](https://github.com/sct-data/sct_testing_data) repository with the following changes:
  - [x] create a ground truth specific to the segmentation method: `t2_seg-deepseg_sc-2d`, `t2_seg-deepseg_sc-3d`, `t2s_seg-deepseg`
  - [x] for other SCT functions that take the segmentation as input, always use the file: `t2_seg-manual.nii.gz`
  - [x] create a ground truth for `sct_get_centerline` on the following contrasts: t2, t2s, dwi
  - [ ] Create release
- Remove the redundancy of integrity testing between `sct_testing` and `pytest` for:
  - [x] test_deepseg_sc
  - [x] test_get_centerline
- [ ] Update `sct_download_data` with URL to latest sct_testing_data release
- [x] Introduce the function `spinalcordtoolbox.math.dice()`