### PR TITLE
Add a utility functions for `os.path.join(__sct_dir__,...)`

### DIFF
--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -31,7 +31,7 @@ import warnings
 import requirements
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import SmartFormatter
+from spinalcordtoolbox.utils import SmartFormatter, sct_dir_local_path
 
 
 # DEFAULT PARAMETERS
@@ -167,7 +167,7 @@ def add_bash_profile(string):
 
 def get_dependencies(requirements_txt=None):
     if requirements_txt is None:
-        requirements_txt = os.path.join(sct.__sct_dir__, "requirements.txt")
+        requirements_txt = sct_dir_local_path("requirements.txt")
 
     requirements_txt = open(requirements_txt, "r", encoding="utf-8")
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -45,7 +45,7 @@ else:
 
 
 from spinalcordtoolbox import __version__, __sct_dir__, __data_dir__
-from spinalcordtoolbox.utils import check_exe
+from spinalcordtoolbox.utils import check_exe, sct_dir_local_path
 
 
 def init_sct(log_level=1, update=False):
@@ -258,10 +258,10 @@ def run(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_binary=
         name = cmd[0] if isinstance(cmd, list) else cmd.split(" ", 1)[0]
         path = None
         #binaries_location_default = os.path.expanduser("~/.cache/spinalcordtoolbox-{}/bin".format(__version__)
-        binaries_location_default = os.path.join(__sct_dir__, "bin")
+        binaries_location_default = sct_dir_local_path("bin")
         for directory in (
          #binaries_location_default,
-         os.path.join(__sct_dir__, "bin"),
+         sct_dir_local_path("bin"),
          ):
             candidate = os.path.join(directory, name)
             if os.path.exists(candidate):

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import sct_utils as sct
 from ..image import Image
+from spinalcordtoolbox.utils import sct_dir_local_path
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ def detect_centerline(img, contrast, verbose=1):
     """
 
     # Fetch path to Optic model based on contrast
-    optic_models_path = os.path.join(sct.__sct_dir__, 'data', 'optic_models', '{}_model'.format(contrast))
+    optic_models_path = sct_dir_local_path('data', 'optic_models', '{}_model'.format(contrast))
 
     logger.debug('Detecting the spinal cord using OptiC')
     img_orientation = img.orientation

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -14,6 +14,7 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.deepseg_sc.core import find_centerline, crop_image_around_centerline, uncrop_image, _normalize_data
 from spinalcordtoolbox import resampling
+from spinalcordtoolbox.utils import sct_dir_local_path
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
 
     # segment data using 3D convolutions
     logger.info("\nSegmenting the MS lesions using deep learning on 3D patches...")
-    segmentation_model_fname = os.path.join(sct.__sct_dir__, 'data', 'deepseg_lesion_models',
+    segmentation_model_fname = sct_dir_local_path('data', 'deepseg_lesion_models',
                                             '{}_lesion.h5'.format(contrast_type))
     fname_seg_crop_res = sct.add_suffix(fname_res3d, '_lesionseg')
     im_res3d = Image(fname_res3d)

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -15,9 +15,11 @@ from .cnn_models import nn_architecture_seg, nn_architecture_ctr
 from .postprocessing import post_processing_volume_wise, keep_largest_object, fill_holes_2d
 from spinalcordtoolbox.image import Image, empty_like, change_type, zeros_like
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
+from spinalcordtoolbox.utils import sct_dir_local_path
 
 import sct_utils as sct
 from sct_image import concat_data, split_data
+
 
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -75,7 +77,7 @@ def find_centerline(algo, image_fname, contrast_type, brain_bool, folder_output,
                           'dwi': {'features': 8, 'dilation_layers': 2}}
 
         # load model
-        ctr_model_fname = os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_ctr.h5'.format(contrast_type))
+        ctr_model_fname = sct_dir_local_path('data', 'deepseg_sc_models', '{}_ctr.h5'.format(contrast_type))
         ctr_model = nn_architecture_ctr(height=dct_patch_ctr[contrast_type]['size'][0],
                                         width=dct_patch_ctr[contrast_type]['size'][1],
                                         channels=1,
@@ -500,7 +502,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         # segment data using 2D convolutions
         logger.info("Segmenting the spinal cord using deep learning on 2D patches...")
         segmentation_model_fname = \
-            os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc.h5'.format(contrast_type))
+            sct_dir_local_path('data', 'deepseg_sc_models', '{}_sc.h5'.format(contrast_type))
         seg_crop = segment_2d(model_fname=segmentation_model_fname,
                               contrast_type=contrast_type,
                               input_size=(crop_size, crop_size),
@@ -509,7 +511,7 @@ def deep_segmentation_spinalcord(im_image, contrast_type, ctr_algo='cnn', ctr_fi
         # segment data using 3D convolutions
         logger.info("Segmenting the spinal cord using deep learning on 3D patches...")
         segmentation_model_fname = \
-            os.path.join(sct.__sct_dir__, 'data', 'deepseg_sc_models', '{}_sc_3D.h5'.format(contrast_type))
+            sct_dir_local_path('data', 'deepseg_sc_models', '{}_sc_3D.h5'.format(contrast_type))
         seg_crop = segment_3d(model_fname=segmentation_model_fname,
                               contrast_type=contrast_type,
                               im_in=im_norm_in)

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -23,9 +23,9 @@ from scipy.ndimage import map_coordinates
 
 import transforms3d.affines as affines
 from spinalcordtoolbox.types import Coordinate
-from spinalcordtoolbox.utils import __sct_dir__
+from spinalcordtoolbox.utils import sct_dir_local_path
 
-sys.path.append(os.path.join(__sct_dir__, 'scripts'))
+sys.path.append(sct_dir_local_path('scripts'))
 import sct_utils as sct
 
 logger = logging.getLogger(__name__)

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -30,7 +30,7 @@ import matplotlib.colors as color
 import sct_utils as sct
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.reports.slice as qcslice
-from spinalcordtoolbox import __sct_dir__
+from spinalcordtoolbox.utils import sct_dir_local_path
 
 logger = logging.getLogger(__name__)
 
@@ -436,7 +436,7 @@ class QcReport(object):
         self.slice_name = qc_params.orientation
         self.qc_params = qc_params
         self.usage = usage
-        self.assets_folder = os.path.join(__sct_dir__, 'assets')
+        self.assets_folder = sct_dir_local_path('assets')
         self.img_base_name = 'bkg_img'
         self.description_base_name = "qc_results"
 

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -457,8 +457,11 @@ def sct_progress_bar(*args, **kwargs):
 
     return tqdm.tqdm(*args, **kwargs)
 
-
 __sct_dir__ = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 __version__ = _version_string()
 __data_dir__ = os.path.join(__sct_dir__, 'data')
 __deepseg_dir__ = os.path.join(__data_dir__, 'deepseg_models')
+
+def sct_dir_local_path(*args):
+    'Construct a directory path relative to __sct_dir__'
+    return os.path.join(__sct_dir__, *args)


### PR DESCRIPTION
This PR adds a utility function `sct_dir_local_path` for constructing paths under `__sct_dir__`, will be useful in the tests to cut down on line lengths, and changes files currently using these in the script and library directories (saving the tests for when we add the data downloader fixture).
