### PR TITLE
Apple's OS is now macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ The simplest way to install SCT is to do it via a stable release. First, downloa
 
 Dependencies:
 - OS requirements:
-  * OS X >= 10.12
+  * macOS >= 10.12
   * Debian >=9
   * Ubuntu >= 16.04
   * Fedora >= 19
   * RedHat/CentOS >= 7
   * Windows, see [Installation with Docker](#installation-with-docker).
-- You need to have `gcc` installed. On OS X, we recommend installing [Homebrew](https://brew.sh/) and then run `brew install gcc`. On Linux, we recommend installing it via your package manager. For example on Debian/Ubuntu: `apt install gcc`, and on CentOS/RedHat: `yum -y install gcc`. 
+- You need to have `gcc` installed. On macOS, we recommend installing [Homebrew](https://brew.sh/) and then run `brew install gcc`. On Linux, we recommend installing it via your package manager. For example on Debian/Ubuntu: `apt install gcc`, and on CentOS/RedHat: `yum -y install gcc`. 
 
 Once you have downloaded SCT, unpack it (note: Safari will automatically unzip it). Then, open a new Terminal, go into the created folder and launch the installer:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tensorflow==1.5.0
 # PyTorch's Linux/Windows distribution is very large due to its GPU support,
 # but we only need that for training models. For users, use the CPU-only version
 # (only available directly from the PyTorch project).
-# The OS X version has never had GPU support, so doesn't need the workaround.
+# The macOS version has never had GPU support, so doesn't need the workaround.
 -f https://download.pytorch.org/whl/cpu/torch_stable.html
 torch==1.5.0+cpu; sys_platform != "darwin"
 torch==1.5.0; sys_platform == "darwin"

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -901,7 +901,7 @@ class Os(object):
     def __init__(self):
         import os
         if os.name != 'posix':
-            raise UnsupportedOs('We only support OS X/Linux')
+            raise UnsupportedOs('We only support macOS/Linux')
         import platform
         self.os = platform.system().lower()
         self.arch = platform.machine()


### PR DESCRIPTION
From @rordenlab:

> A pedantic comment on spinalcordtoolbox - the documentation refers to “OS X” (OS ten) extensively. I would suggest changing this to “MacOS”, not only because that is Apple branding, but I guess the upcoming MacOS 11.0 would be “OS XI” (OS eleven)

The instances were found with

```
git grep -i  "OS X" -- './*' ':(exclude)spinalcordtoolbox/reports/*'
```

(reports/ has a lot of archived stuff that I am not going to change!)