### PR TITLE
Upgrade bundled ANTs.

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -98,12 +98,12 @@ def main(args=None):
             "https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip",
         ],
         "binaries_linux": [
-            "https://osf.io/mka78/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200420_sct_binaries_linux.tar.gz",
+            "https://osf.io/cs6zt/?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200801_sct_binaries_linux.tar.gz",
         ],
         "binaries_osx": [
-            "https://osf.io/dn67h/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200420_sct_binaries_osx.tar.gz",
+            "https://osf.io/874cy?action=download",
+            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200801_sct_binaries_osx.tar.gz",
         ],
         "course_hawaii17": "https://osf.io/6exht/?action=download",
         "course_paris18": [


### PR DESCRIPTION
Fixes #2779, by pulling in the fix from https://github.com/ANTsX/ANTs/issues/1040.

This partially follows https://github.com/neuropoly/spinalcordtoolbox/wiki/Package-data-&-binaries, but with the very difficult parts have been replaced by a build script on Github. Reminder: we need to rewrite/remove these wiki pages (https://github.com/neuropoly/spinalcordtoolbox/issues/2815) to incorporate these changes.