### PR TITLE
Change setup.py for `pip install .` to fix Readthedocs CLI rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,16 +36,8 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     keywords='Magnetic Resonance Imaging MRI spinal cord analysis template',
-    packages=[
-        "spinalcordtoolbox",
-    ],
-    # package_data={'spinalcordtoolbox': ['version.txt']},
-    data_files=[
-        ('', ['version.txt']),
-        # <hack>
-        ("sct_scripts", [os.path.join("scripts", x) for x in os.listdir("scripts") if x.endswith(".py")]),
-        # </hack>
-    ],
+    packages=find_packages(exclude=['.git', 'data', 'dev', 'dev.*',
+                                    'install', 'testing']),
     include_package_data=True,
     extras_require={
         'docs': [


### PR DESCRIPTION
### Description
* `setup.py`: Use `packages=find_packages()` so that all submodules will be installed, not just `spinalcordtoolbox`(Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/2834#issuecomment-670229911)
* Adds `__init__.py` to `scripts/` to have it be installed as a package, which moves the location of the script files to where `spinalcordtoolbox.compat.launcher` expects. (Fixes https://github.com/neuropoly/spinalcordtoolbox/issues/2834#issuecomment-670660230)
     * Note: the `scripts` option in `setup.py` **is not** used. This is because of the limitation that `compat.launcher` imposes, see below:

https://github.com/neuropoly/spinalcordtoolbox/blob/fce82d8c98fab1cc878c4e8c48fa1c515f0db35c/setup.py#L63-L65

### Reference issues/PRs

Fixes #2834.

### Additional comments

Note: This PR is dependent on version changes in #2833. Without #2833, a version error will also be raised.