### PR TITLE
Pre-install numpy to build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,7 @@ matrix:
       os: osx
       osx_image: xcode9.2
     - name: "Windows Server, 1809"
+      # runs on all branches
       language: bash
       os: windows
 

--- a/install_sct
+++ b/install_sct
@@ -529,6 +529,11 @@ conda activate venv_sct
 
 # Install Python dependencies
 print info "Installing Python dependencies..."
+# numpy is an undeclared build dependency: https://github.com/scikit-image/scikit-image/issues/4919
+# so explicitly install it as a workaround; note that in releases with requirements-freeze.txt
+# this can cause a strange double-install: https://github.com/neuropoly/spinalcordtoolbox/issues/2750
+# but we can live with that until https://github.com/scikit-image/scikit-image/pull/4920 is merged.
+pip install numpy
 # Check if a frozen version of the requirements exist (for release only)
 if [[ -f "requirements-freeze.txt" ]]; then
   print info "Using requirements-freeze.txt (release installation)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy # need to install first otherwise dependency issues
 colored
 dipy
 futures
@@ -7,6 +6,7 @@ ivadomed==2.0.2
 Keras==2.1.5
 matplotlib
 nibabel
+numpy
 pandas
 psutil
 pyqt5==5.11.3


### PR DESCRIPTION
Travis started failing on macOS 10.12 a few weeks ago, e.g. https://travis-ci.org/github/neuropoly/spinalcordtoolbox/jobs/717668875. Due to changes I made earlier this summer (#2690) this only nagged me once a day when the cron build kicked in and I ignored it. But now I'm here to quiet it.

Here's the error:

> ```
> Collecting requirements-parser
>  Downloading requirements-parser-0.2.0.tar.gz (6.3 kB)
> Collecting scipy
>  Downloading scipy-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl (28.8 MB)
> Collecting scikit-image
>  Downloading scikit-image-0.17.2.tar.gz (29.8 MB)
>
>    ERROR: Command errored out with exit status 1:
>     command: /Users/travis/build/neuropoly/spinalcordtoolbox/python/envs/venv_sct/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/bb/n7t3rs157850byt_jfdcq9k80000gn/T/pip-install-d6qkfes3/scikit-image/setup.py'"'"'; __file__='"'"'/private/var/folders/bb/n7t3rs157850byt_jfdcq9k80000gn/T/pip-install-d6qkfes3/scikit-image/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/bb/n7t3rs157850byt_jfdcq9k80000gn/T/pip-pip-egg-info-ekhwucq2
>         cwd: /private/var/folders/bb/n7t3rs157850byt_jfdcq9k80000gn/T/pip-install-d6qkfes3/scikit-image/
>    Complete output (7 lines):
>    Traceback (most recent call last):
>      File "<string>", line 1, in <module>
>      File "/private/var/folders/bb/n7t3rs157850byt_jfdcq9k80000gn/T/pip-install-d6qkfes3/scikit-image/setup.py", line 234, in <module>
>        'build_ext': openmp_build_ext(),
>      File "/private/var/folders/bb/n7t3rs157850byt_jfdcq9k80000gn/T/pip-install-d6qkfes3/scikit-image/setup.py", line 58, in openmp_build_ext
>        from numpy.distutils.command.build_ext import build_ext
>    ModuleNotFoundError: No module named 'numpy'
>    ----------------------------------------
> ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
> ```

The clue that this only happens on 10.12 and nowhere else is important. Notice how just before, it says "Downloading scipy .... something.whl" and then "Downloading scikit-learn ... something.tar.gz"? `.whl` is python's pre-compiled binary package format, which means that .tar.gz is probably the source dist. Looking at https://pypi.org/project/scikit-image/#files we can see that scikit-learn builds for Windows32, Windows64, macOS 10.13, and "Linux" (which [as I have yet to properly document](https://github.com/neuropoly/spinalcordtoolbox/issues/2669#issuecomment-665230020), means CentOS6). So because scikit-image isn't providing Sierra binaries, we can't install ourselves there in any reliable way.

And looking at [that source](https://github.com/scikit-image/scikit-image/blob/59fd9682aad41a1f69a35f05d2a7e15ebdfb8b29/setup.py#L57) we see that their setup.py tries to import numpy, which is because it wants to make use of [`numpy.distutils`](https://numpy.org/doc/stable/f2py/distutils.html), some extensions to python's build system to support linking in Fortran code.

Okay, fair enough, but why can't numpy be declared as a build dependency for it? Lots of other packaging systems make this work. But it looks like that can't work here because setup() expects an [instantiated builder object](https://github.com/scikit-image/scikit-image/blob/59fd9682aad41a1f69a35f05d2a7e15ebdfb8b29/setup.py#L234) and the most obvious way for `numpy.distutils` to provide that is to let itself [be subclassed](https://github.com/scikit-image/scikit-image/blob/59fd9682aad41a1f69a35f05d2a7e15ebdfb8b29/setup.py#L66). So there's a chicken-egg problem here.

PyPA is aware that numpy.distutils is pretty fragile w.r.t. being itself a build-time dependency: https://www.python.org/dev/peps/pep-0518/#rationale
> [..] which means that projects such as numpy.distutils are largely incapable of utilizing it [..]

but lots of packaging systems manage to have separate build/runtime dependencies. So maybe this is `numpy.distutils`'s fault. Or maybe design choices setuptools made forced numpy.distutils to be like this?

Anyway the upshot of all this is that it turns out there was a good reason for installing numpy explicitly, the line that we removed in 2bb19c5c9ad9dfc5919c4431613faa54f806ee2d, and we can't fix any of it from here. But I can readd the build dep and this time at least mark it as one (except, that, according to pep518, it's already old news to do it this way :? 🗑️🔥)

Fixes #2841.