### PR TITLE
Add GitHub Action workflow for automatically updating custom Wiki sidebar

### DIFF
--- a/.github/workflows/generate-sidebar.yml
+++ b/.github/workflows/generate-sidebar.yml
@@ -1,0 +1,24 @@
+name: Update wiki sidebar if page titles have changed
+
+on:
+  # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#gollum
+  gollum
+
+jobs:
+  generate-sidebar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Each repo with at least 1 wiki page has a corresponding <repo>.wiki repo
+          repository: "${{ github.repository }}.wiki"  
+
+      - uses: actions/setup-node@v1
+      - run: npm install github-wiki-sidebar -g
+      
+      # Dummy credentials to be listed in _Sidebar.md update commit for Wiki 
+      - run: git config --global user.name "github-actions"
+      - run: git config --global user.email "github-actions@github.com"
+        
+      # --silent uses the options.json file added to the SCT Wiki git repo
+      - run: github-wiki-sidebar --silent --git-push


### PR DESCRIPTION
### Reference issues/PRs

Fixes #2855.

### What does this implement/fix? Explain your changes.

This PR adds a GitHub Actions workflow that automatically updates the Wiki sidebar whenever a Wiki page is added or a page title is changed. It does this using a third-party [`github-wiki-sidebar`](https://github.com/adriantanasa/github-wiki-sidebar) tool. This way, the sidebar doesn't have to be manually updated each time a page changes. _(It's a shame that GH doesn't do this natively, but alas!)_

I tested this workflow on a personal repo ([`joshuacwnewton/test-github-action-wiki`](https://github.com/joshuacwnewton/test-github-action-wiki)) and it works nicely:
* [Test page](https://github.com/joshuacwnewton/test-github-action-wiki/wiki/General%3A-Test-page-(should-show-up-In-sidebar)) to check if the GH Actions workflow would automatically add the page to the sidebar.
* [Corresponding job](https://github.com/joshuacwnewton/test-github-action-wiki/runs/1034458412?check_suite_focus=true) that did in fact update the sidebar! :D

I can document exactly how to format pages so that they nest properly in this new sidebar, as well.