### PR TITLE
Prevent crash if folder already exists

### DIFF
--- a/scripts/sct_run_batch.py
+++ b/scripts/sct_run_batch.py
@@ -296,7 +296,7 @@ def main(argv):
     script = os.path.abspath(os.path.expanduser(args.script))
 
     for pth in [path_output, path_results, path_data_processed, path_log, path_qc]:
-        os.mkdir(pth, exist_ok=True)
+        os.makedirs(pth, exist_ok=True)
 
     # Check that the script can be found
     if not os.path.exists(script):

--- a/scripts/sct_run_batch.py
+++ b/scripts/sct_run_batch.py
@@ -296,8 +296,7 @@ def main(argv):
     script = os.path.abspath(os.path.expanduser(args.script))
 
     for pth in [path_output, path_results, path_data_processed, path_log, path_qc]:
-        if not os.path.exists(pth):
-            os.mkdir(pth)
+        os.mkdir(pth, exist_ok=True)
 
     # Check that the script can be found
     if not os.path.exists(script):


### PR DESCRIPTION
When launching multiple `sct_run_batch` in parallel using [run_all](https://github.com/sct-pipeline/csa-atrophy/blob/master/run_all.py) with the same output folder, the following error sometimes happens:
~~~
Spinal Cord Toolbox (git-master-253936cfc07712c587d9f4cfbbcb760f151172f0)

/home/jcohen/sct/scripts/sct_run_batch.py:241: UserWarning: Using the `-config|-c` flag with additional arguments is discouraged
  warnings.warn(UserWarning('Using the `-config|-c` flag with additional arguments is discouraged'))
configuring
Traceback (most recent call last):
  File "/home/jcohen/sct/scripts/sct_run_batch.py", line 479, in <module>
    main(sys.argv[1:])
  File "/home/jcohen/sct/scripts/sct_run_batch.py", line 300, in main
    os.mkdir(pth)
FileExistsError: [Errno 17] File exists: '/scratch/jcohen/results_csa_t1/results'
~~~

This PR fixes the problem by changing: `os.mkdir(pth)` for `os.mkdir(pth, exist_ok=True)`

Fixes #2866 
