### PR TITLE
Change default value for average to maintain cross-compatibility

### DIFF
--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -33,7 +33,7 @@ import argparse
 class Param:
     def __init__(self):
         self.debug = 0
-        self.average = 0
+        self.average = 1
         self.remove_temp_files = 1
         self.verbose = 1
         self.bval_min = 100  # in case user does not have min bvalues at 0, set threshold.


### PR DESCRIPTION
The recent PR #2819 fixed that bug, but also changed the behaviour: the average scan is not more produced, which breaks all the current processing pipelines already in place, e.g.
https://github.com/spine-generic/spine-generic/blob/4143cbfd7a206f06e3fd9f42485d5087129899d7/process_data.sh#L261

This PR changes the default to be average=1 to ensure cross-compatibility.

Fixes #2881 