### PR TITLE
Automatically show defaults in argparse help descriptions

### DIFF
--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -79,7 +79,7 @@ class Metavar(Enum):
         return self.value
 
 
-class SmartFormatter(argparse.HelpFormatter):
+class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
     """
     Custom formatter that inherits from HelpFormatter, which adjusts the default width to the current Terminal size,
     and that gives the possibility to bypass argparse's default formatting by adding "R|" at the beginning of the text.
@@ -133,6 +133,12 @@ class SmartFormatter(argparse.HelpFormatter):
                     wrapped = wrapped + [li]
             return wrapped
         return argparse.HelpFormatter._split_lines(self, text, width)
+
+    def _get_help_string(self, action):
+        if action.default is not None:
+            return super()._get_help_string(action)
+        else:
+            return action.help
 
 
 # Modified from http://shallowsky.com/blog/programming/python-tee.html

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -135,7 +135,7 @@ class SmartFormatter(argparse.ArgumentDefaultsHelpFormatter):
         return argparse.HelpFormatter._split_lines(self, text, width)
 
     def _get_help_string(self, action):
-        if action.default is not None:
+        if action.default not in [None, "", [], (), {}]:
             return super()._get_help_string(action)
         else:
             return action.help


### PR DESCRIPTION
### Related issues/PRs

Fixes #2756.

### Description

This PR modifies SCT's `SmartFormatter` so that default values are shown if they are not `None`. 

Two questions:

* Are there any cases where we **want** to show `(default: None)`? (See https://github.com/neuropoly/spinalcordtoolbox/issues/2756#issuecomment-650613090.)
* Should this PR go through all of the descriptions to edit redundant info out? If so, this PR is dependent on #2842. An example:
```
  -ofolder <folder>  Output folder (e.g. "./") (default: ./)
```