### PR TITLE
Refactor sct_label_utils into proper API

### DIFF
--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -92,10 +92,10 @@ def get_parser():
         default='')
     optional.add_argument(
         "-x",
-        help=""" Interpolation method. The 'label' method is to be used if you would like to apply a transformation 
-        on a file that has single-voxel labels (classical interpolation methods won't work, as resampled labels might 
-        disappear or their values be altered). The function will dilate each label, apply the transformation using 
-        nearest neighbour interpolation, and then take the center-of-mass of each "blob" and output a single voxel per 
+        help=""" Interpolation method. The 'label' method is to be used if you would like to apply a transformation
+        on a file that has single-voxel labels (classical interpolation methods won't work, as resampled labels might
+        disappear or their values be altered). The function will dilate each label, apply the transformation using
+        nearest neighbour interpolation, and then take the center-of-mass of each "blob" and output a single voxel per
         blob.""",
         required=False,
         default='spline',
@@ -299,8 +299,7 @@ class Transform:
 
         if islabel:
             sct.printv("\nTake the center of mass of each registered dilated labels...")
-            out = cubic_to_point(im_src_reg)
-            out.save(path=fname_out)
+            cubic_to_point(im_src_reg).save(path=fname_out)
             if remove_temp_files:
                 sct.printv('\nRemove temporary files...', verbose)
                 sct.rmtree(path_tmp, verbose=verbose)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -23,6 +23,7 @@ from spinalcordtoolbox.utils import Metavar, SmartFormatter
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
+from spinalcordtoolbox.labels import cubic_to_point
 
 import sct_utils as sct
 import sct_image
@@ -298,10 +299,8 @@ class Transform:
 
         if islabel:
             sct.printv("\nTake the center of mass of each registered dilated labels...")
-            sct.run(['sct_label_utils',
-                     '-i', fname_out,
-                     '-o', fname_out,
-                     '-cubic-to-point'])
+            out = cubic_to_point(im_src_reg)
+            out.save(path=fname_out)
             if remove_temp_files:
                 sct.printv('\nRemove temporary files...', verbose)
                 sct.rmtree(path_tmp, verbose=verbose)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -299,7 +299,8 @@ class Transform:
 
         if islabel:
             sct.printv("\nTake the center of mass of each registered dilated labels...")
-            cubic_to_point(im_src_reg).save(path=fname_out)
+            labeled_img = cubic_to_point(im_src_reg)
+            labeled_img.save(path=fname_out)
             if remove_temp_files:
                 sct.printv('\nRemove temporary files...', verbose)
                 sct.rmtree(path_tmp, verbose=verbose)

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -30,7 +30,6 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from sct_image import concat_data
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
-from sct_label_utils import display_voxel
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate
 
@@ -216,7 +215,7 @@ def create_mask(param):
     if method_type == 'point':
         # extract coordinate of point
         sct.printv('\nExtract coordinate of point...', param.verbose)
-        coord = display_voxel(Image("point_RPI.nii"), verbose=param.verbose)
+        coord = Image("point_RPI.nii").getNonZeroCoordinates()
 
     if method_type == 'center':
         # set coordinate at center of FOV

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -214,13 +214,9 @@ def create_mask(param):
         coord = [x for x in map(int, method_val.split('x'))]
 
     if method_type == 'point':
-        # get file name
         # extract coordinate of point
         sct.printv('\nExtract coordinate of point...', param.verbose)
         coord = display_voxel(Image("point_RPI.nii"), verbose=param.verbose)
-        # parse to get coordinate
-        # TODO fixup... this is quite magic
-        # coord = output[output.find('Position=') + 10:-17].split(',')
 
     if method_type == 'center':
         # set coordinate at center of FOV

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -307,8 +307,7 @@ def create_line(param, fname, coord, nz):
         # compat
         labels = [ Coordinate([coord[0], coord[1], iz, 1]) for iz in range(nz) ]
 
-    out = create_labels(Image("line.nii"), labels)
-    out.save(path="line.nii")
+    create_labels(Image("line.nii"), labels).save(path="line.nii")
 
     return 'line.nii'
 

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -30,6 +30,9 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from sct_image import concat_data
 from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from sct_label_utils import display_voxel
+from spinalcordtoolbox.labels import create_labels
+from spinalcordtoolbox.types import Coordinate
 
 
 # DEFAULT PARAMETERS
@@ -214,11 +217,10 @@ def create_mask(param):
         # get file name
         # extract coordinate of point
         sct.printv('\nExtract coordinate of point...', param.verbose)
-        # TODO: change this way to remove dependence to sct.run. ProcessLabels.display_voxel returns list of coordinates
-        status, output = sct.run(['sct_label_utils', '-i', 'point_RPI.nii', '-display'], verbose=param.verbose)
+        coord = display_voxel(Image("point_RPI.nii"), verbose=param.verbose)
         # parse to get coordinate
         # TODO fixup... this is quite magic
-        coord = output[output.find('Position=') + 10:-17].split(',')
+        # coord = output[output.find('Position=') + 10:-17].split(',')
 
     if method_type == 'center':
         # set coordinate at center of FOV
@@ -299,15 +301,14 @@ def create_line(param, fname, coord, nz):
     # set all voxels to zero
     sct.run(['sct_maths', '-i', 'line.nii', '-mul', '0', '-o', 'line.nii'], param.verbose)
 
-    create_add_str = ""
-    for iz in range(nz):
-        if iz == nz - 1:
-            create_add_str += str(int(coord[0])) + ',' + str(int(coord[1])) + ',' + str(iz) + ',1'
-        else:
-            create_add_str += str(int(coord[0])) + ',' + str(int(coord[1])) + ',' + str(iz) + ',1:'
+    if isinstance(coord[0], Coordinate):
+        labels = coord
+    else:
+        # compat
+        labels = [ Coordinate([coord[0], coord[1], iz, 1]) for iz in range(nz) ]
 
-    cmd = ['sct_label_utils', '-i', 'line.nii', '-o', 'line.nii', '-create-add', create_add_str]
-    sct.run(cmd, param.verbose)
+    out = create_labels(Image("line.nii"), labels)
+    out.save(path="line.nii")
 
     return 'line.nii'
 

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -296,11 +296,14 @@ def create_line(param, fname, coord, nz):
     # set all voxels to zero
     sct.run(['sct_maths', '-i', 'line.nii', '-mul', '0', '-o', 'line.nii'], param.verbose)
 
+    labels = []
+
     if isinstance(coord[0], Coordinate):
-        labels = coord
+        for x, y, _, _ in coord:
+            labels.extend([ Coordinate([x, y, iz, 1]) for iz in range(nz) ])
     else:
-        # compat
-        labels = [ Coordinate([coord[0], coord[1], iz, 1]) for iz in range(nz) ]
+        # backwards compat
+        labels.extend([ Coordinate([coord[0], coord[1], iz, 1]) for iz in range(nz) ])
 
     create_labels(Image("line.nii"), labels).save(path="line.nii")
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -259,6 +259,8 @@ def main(args=None):
         out = sct_labels.increment_z_inverse(img)
     elif arguments.vert_body is not None:
         levels = arguments.vert_body
+        if len(levels) == 1 and levels[0] == 0:
+            levels = None # all levels
         out = sct_labels.label_vertebrae(img, levels)
     elif arguments.vert_continuous:
         out = sct_labels.continuous_vertebral_levels(img)

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -249,7 +249,10 @@ def main(args=None):
         labels = arguments.create_add
         out = sct_labels.create_labels(img, labels)
     elif arguments.create_seg is not None:
-        labels = arguments.create_seg
+        labels = []
+        for str_pair in arguments.create_seg:
+            z, z_val = str_pair.split(',')
+            labels.append(tuple([int(z), int(z_val)]))
         out = sct_labels.create_labels_along_segmentation(img, labels)
     elif arguments.cubic_to_point:
         out = sct_labels.cubic_to_point(img)

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -244,10 +244,7 @@ def main(args=None):
         labels = arguments.create_add
         out = sct_labels.create_labels(img, labels)
     elif arguments.create_seg is not None:
-        labels = []
-        for str_pair in arguments.create_seg:
-            z, z_val = str_pair.split(',')
-            labels.append(tuple([int(z), int(z_val)]))
+        labels = arguments.create_seg
         out = sct_labels.create_labels_along_segmentation(img, labels)
     elif arguments.cubic_to_point:
         out = sct_labels.cubic_to_point(img)

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -300,7 +300,7 @@ def main(args=None):
                     subject=arguments.qc_subject, process='sct_label_utils')
 
 
-def display_voxel(img: Image, verbose: int) -> Sequence[Coordinate]:
+def display_voxel(img: Image, verbose: int = 1) -> Sequence[Coordinate]:
     """
     Display all the labels that are contained in the input image.
     :param img: source image

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -320,8 +320,6 @@ def display_voxel(img: Image, verbose: int = 1) -> Sequence[Coordinate]:
     sct.printv('All labels (useful syntax):', verbose=verbose)
     sct.printv(useful_notation, verbose=verbose)
 
-    return coordinates_input
-
 
 # TODO [AJ] -> just print warnings or log or raise?
 def check_distance_between_labels(img: Image, max_dist_mm: float):

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -62,8 +62,8 @@ def get_parser():
     io_group.add_argument(
         '-o',
         metavar=Metavar.file,
-        help=("Output image. Example: t2_labels.nii.gz"
-              "Note: If no output image is provided, input image will be overwritten!")
+        default='labels.nii.gz',
+        help=("Output image. Example: t2_labels.nii.gz")
     )
 
     io_group.add_argument(
@@ -231,13 +231,10 @@ def main(args=None):
     sct.init_sct(log_level=verbosity, update=True)  # Update log level
 
     input_filename = arguments.i
+    output_fname = arguments.o
+
     img = Image(input_filename)
     dtype = None
-
-    if arguments.o is not None:
-        output_fname = arguments.o
-    else:
-        output_fname = input_filename
 
     if arguments.add is not None:
         value = arguments.add

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -250,6 +250,7 @@ def main(args=None):
         out = sct_labels.cubic_to_point(img)
     elif arguments.display:
         display_voxel(img, verbosity)
+        return
     elif arguments.increment:
         out = sct_labels.increment_z_inverse(img)
     elif arguments.vert_body is not None:

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -277,8 +277,7 @@ def main(args=None):
 
         # second pass use previous pass result as reference
         ref_out = sct_labels.remove_missing_labels(ref, out)
-        ref_out.absolutepath = ref.absolutepath
-        ref_out.save()
+        ref_out.save(path=ref.absolutepath)
     elif arguments.remove is not None:
         labels = arguments.remove
         out = sct_labels.remove_labels_from_image(img, labels)

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -45,7 +45,7 @@ def get_parser():
         prog=os.path.basename(__file__).strip(".py")
     )
 
-    req_group = parser.add_argument_group("\nREQUIRED")
+    req_group = parser.add_argument_group("\nREQUIRED I/O")
     req_group.add_argument(
         '-i',
         metavar=Metavar.file,

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -187,8 +187,10 @@ def get_parser():
 
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
+        choices=[0, 1, 2],
         default=1,
+        metavar=Metavar.int,
+        type=int,
         help="Verbose. 0: nothing. 1: basic. 2: extended."
     )
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -265,7 +265,7 @@ def main(args=None):
         out = sct_labels.label_vertebrae(img, levels)
     elif arguments.vert_continuous:
         out = sct_labels.continuous_vertebral_levels(img)
-        dtype='float32'
+        dtype = 'float32'
     elif arguments.MSE is not None:
         ref = Image(arguments.MSE)
         mse = sct_labels.compute_mean_squared_error(img, ref)
@@ -324,6 +324,7 @@ def display_voxel(img: Image, verbose: int):
     sct.printv('All labels (useful syntax):', verbose=verbose)
     sct.printv(useful_notation, verbose=verbose)
 
+
 # TODO [AJ] -> just print warnings or log or raise?
 def check_distance_between_labels(img: Image, max_dist_mm: float):
     """
@@ -345,7 +346,7 @@ def check_distance_between_labels(img: Image, max_dist_mm: float):
                 coordinates_input[i + 1].value) + ' is larger than ' + str(max_dist_mm) + '. Distance=' + str(dist))
 
 
-def launch_sagittal_viewer(img: Image, labels: Sequence[int], previous_points: Sequence[Coordinate] = None, output_img: Image = None, msg: str = "") -> Image:
+def launch_sagittal_viewer(img: Image, labels: Sequence[int], msg: str, previous_points: Sequence[Coordinate] = None, output_img: Image = None) -> Image:
     params = base.AnatomicalParams()
     params.vertebraes = labels
     params.input_file_name = img.absolutepath
@@ -367,7 +368,7 @@ def launch_sagittal_viewer(img: Image, labels: Sequence[int], previous_points: S
     return out
 
 
-def launch_manual_label_gui(img: Image, input_labels_img: Image, labels: Sequence[int], msg: str = None):
+def launch_manual_label_gui(img: Image, input_labels_img: Image, labels: Sequence[int], msg):
     # the input image is reoriented to 'SAL' when open by the GUI
     input_labels_img.change_orientation('SAL')
     mid = int(np.round(input_labels_img.data.shape[2] / 2))
@@ -400,7 +401,7 @@ def launch_manual_label_gui(img: Image, input_labels_img: Image, labels: Sequenc
         for i in range(len(previous_label)):
             previous_label[i][2] = mid
 
-    out = launch_sagittal_viewer(labels, previous_points=previous_label)
+    out = launch_sagittal_viewer(img, labels, msg, previous_points=previous_label)
 
     return out
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -296,8 +296,7 @@ def main(args=None):
         else:
             out = launch_sagittal_viewer(img, arguments.create_viewer, msg)
 
-    out.absolutepath = output_fname
-    out.save(dtype=dtype)
+    out.save(path=output_fname, dtype=dtype)
 
     if arguments.qc is not None:
         generate_qc(fname_in1=input_filename, fname_seg=output_fname, args=args,

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -192,7 +192,7 @@ def get_parser():
     optional.add_argument(
         '-v',
         choices=['0', '1', '2'],
-        default=param_default.verbose,
+        default=1,
         help="Verbose. 0: nothing. 1: basic. 2: extended."
     )
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -30,11 +30,7 @@ from scipy import ndimage
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.gui import base
-from spinalcordtoolbox.gui.sagittal import launch_sagittal_dialog
 import spinalcordtoolbox.labels as sct_labels
-
-# TODO: Properly test when first PR (that includes list_type) gets merged
 from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
 import sct_utils as sct
 
@@ -346,6 +342,8 @@ def check_distance_between_labels(img: Image, max_dist_mm: float):
 
 
 def launch_sagittal_viewer(img: Image, labels: Sequence[int], msg: str, previous_points: Sequence[Coordinate] = None, output_img: Image = None) -> Image:
+    from spinalcordtoolbox.gui import base
+    from spinalcordtoolbox.gui.sagittal import launch_sagittal_dialog
     params = base.AnatomicalParams()
     params.vertebraes = labels
     params.input_file_name = img.absolutepath

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -267,6 +267,7 @@ def main(args=None):
         ref = Image(arguments.MSE)
         mse = sct_labels.compute_mean_squared_error(img, ref)
         sct.printv(f"Computed MSE: {mse}")
+        return
     elif arguments.remove_reference is not None:
         ref = Image(arguments.remove_reference)
         out = sct_labels.remove_missing_labels(img, ref)

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -272,14 +272,14 @@ def main(args=None):
         sct.printv(f"Computed MSE: {mse}")
     elif arguments.remove_reference is not None:
         ref = Image(arguments.remove_reference)
-        out = sct_labels.remove_labels_from_image(img, ref)
+        out = sct_labels.remove_missing_labels(img, ref)
     elif arguments.remove_sym is not None:
         # first pass use img as source
         ref = Image(arguments.remove_reference)
-        out = sct_labels.remove_labels_from_image(img, ref)
+        out = sct_labels.remove_missing_labels(img, ref)
 
         # second pass use previous pass result as reference
-        ref_out = sct_labels.remove_labels_from_image(ref, out)
+        ref_out = sct_labels.remove_missing_labels(ref, out)
         ref_out.absolutepath = ref.absolutepath
         ref_out.save()
     elif arguments.remove is not None:

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -118,6 +118,12 @@ def get_parser():
     )
 
     func_group.add_argument(
+        '-disc',
+        metavar=Metavar.file,
+        help="Create an image with regions labelized depending on values from reference"
+    )
+
+    func_group.add_argument(
         '-display',
         action="store_true",
         help="Display all labels (i.e. non-zero values)."
@@ -253,6 +259,9 @@ def main(args=None):
         return
     elif arguments.increment:
         out = sct_labels.increment_z_inverse(img)
+    elif arguments.disc is not None:
+        ref = Image(arguments.disc)
+        out = sct_labels.labelize_from_discs(img, ref)
     elif arguments.vert_body is not None:
         levels = arguments.vert_body
         if len(levels) == 1 and levels[0] == 0:

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -25,6 +25,7 @@ import logging
 from typing import Sequence
 
 import numpy as np
+from scipy import ndimage
 
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
@@ -190,10 +191,9 @@ def get_parser():
 
     optional.add_argument(
         '-v',
-        type=int,
-        help='Verbose. 0: nothing. 1: basic. 2: extended.',
-        default=1,
-        choices=(0, 1, 2),
+        choices=['0', '1', '2'],
+        default=param_default.verbose,
+        help="Verbose. 0: nothing. 1: basic. 2: extended."
     )
 
     optional.add_argument(

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -304,7 +304,7 @@ def main(args=None):
                     subject=arguments.qc_subject, process='sct_label_utils')
 
 
-def display_voxel(img: Image, verbose: int):
+def display_voxel(img: Image, verbose: int) -> Sequence[Coordinate]:
     """
     Display all the labels that are contained in the input image.
     :param img: source image
@@ -322,6 +322,8 @@ def display_voxel(img: Image, verbose: int):
 
     sct.printv('All labels (useful syntax):', verbose=verbose)
     sct.printv(useful_notation, verbose=verbose)
+
+    return coordinates_input
 
 
 # TODO [AJ] -> just print warnings or log or raise?

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -98,7 +98,7 @@ def get_parser():
     func_group.add_argument(
         '-create-seg',
         metavar=Metavar.list,
-        type=list_type(':', str),
+        type=list_type(':', list_type(',', int)),
         help="R|Create labels along cord segmentation (or centerline) defined by '-i'. First value is 'z', second is "
              "the value of the label. Separate labels with ':'. Example: 5,1:14,2:23,3. \n"
              "To select the mid-point in the superior-inferior direction, set z to '-1'. For example if you know that "

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -321,27 +321,6 @@ def display_voxel(img: Image, verbose: int = 1) -> Sequence[Coordinate]:
     sct.printv(useful_notation, verbose=verbose)
 
 
-# TODO [AJ] -> just print warnings or log or raise?
-def check_distance_between_labels(img: Image, max_dist_mm: float):
-    """
-    Calculate the distances between each label in the input image.
-    If a distance is larger than max_dist_mm, a warning message is displayed.
-    :param img: input image
-    :param max_dist: maximum distance (in mm) allowed between labels
-    """
-    coordinates_input = img.getNonZeroCoordinates()
-
-    # for all points with non-zeros neighbors, force the neighbors to 0
-    for i in range(0, len(coordinates_input) - 1):
-        dist = np.sqrt((coordinates_input[i].x - coordinates_input[i + 1].x)**2 + (coordinates_input[i].y - coordinates_input[i + 1].y)**2 + (coordinates_input[i].z - coordinates_input[i + 1].z)**2)
-
-        if dist < max_dist_mm:
-            sct.printv('Warning: the distance between label ' + str(i) + '[' + str(coordinates_input[i].x) + ',' + str(coordinates_input[i].y) + ',' + str(
-                coordinates_input[i].z) + ']=' + str(coordinates_input[i].value) + ' and label ' + str(i + 1) + '[' + str(
-                coordinates_input[i + 1].x) + ',' + str(coordinates_input[i + 1].y) + ',' + str(coordinates_input[i + 1].z) + ']=' + str(
-                coordinates_input[i + 1].value) + ' is larger than ' + str(max_dist_mm) + '. Distance=' + str(dist))
-
-
 def launch_sagittal_viewer(img: Image, labels: Sequence[int], msg: str, previous_points: Sequence[Coordinate] = None, output_img: Image = None) -> Image:
     from spinalcordtoolbox.gui import base
     from spinalcordtoolbox.gui.sagittal import launch_sagittal_dialog

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -238,7 +238,7 @@ def main(args=None):
 
     if arguments.add is not None:
         value = arguments.add
-        out = sct_labels.add_faster(img, value)
+        out = sct_labels.add(img, value)
     elif arguments.create is not None:
         labels = arguments.create
         out = sct_labels.create_labels_empty(img, labels)

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -59,7 +59,7 @@ def get_parser():
         '-o',
         metavar=Metavar.file,
         default='labels.nii.gz',
-        help=("Output image. Example: t2_labels.nii.gz")
+        help=("Output image. Note: Only some label utilities create an output image. Example: t2_labels.nii.gz")
     )
 
     io_group.add_argument(

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -41,9 +41,6 @@ logger = logging.getLogger(__name__)
 
 
 def get_parser():
-    # initialize default param
-    # param_default = Param()
-    # Initialize the parser
     parser = argparse.ArgumentParser(
         description="Utility functions for label images.",
         formatter_class=SmartFormatter,

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -358,9 +358,9 @@ def main(args=None):
             im_label.data = dilate(im_label.data, 3, 'ball')
             im_label.save(fname_labelz)
 
-
         elif fname_initlabel:
             Image(fname_initlabel).save(fname_labelz)
+
         else:
             # automatically finds C2-C3 disc
             im_data = Image('data.nii')

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -23,8 +23,8 @@ from spinalcordtoolbox.vertebrae.core import create_label_z, get_z_and_disc_valu
 from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
+from spinalcordtoolbox.labels import create_labels_along_segmentation
 
-from sct_label_utils import ProcessLabels
 # TODO: Properly test when first PR (that includes list_type) gets merged
 from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
 import sct_utils as sct
@@ -353,13 +353,12 @@ def main(args=None):
                 nx, ny, nz, nt, px, py, pz, pt = nii.dim  # Get dimensions
                 z_center = int(np.round(nz / 2))  # get z_center
                 initz = [z_center, initcenter]
-            # create single label and output as labels.nii.gz
-            label = ProcessLabels('segmentation.nii', fname_output='tmp.labelz.nii.gz',
-                                      coordinates=['{},{}'.format(initz[0], initz[1])])
-            im_label = label.process('create-seg')
-            im_label.data = dilate(im_label.data, 3, 'ball')  # TODO: create a dilation method specific to labels,
-            # which does not apply a convolution across all voxels (highly inneficient)
+
+            im_label = create_labels_along_segmentation(Image('segmentation.nii'), [(initz[0],initz[1])])
+            im_label.data = dilate(im_label.data, 3, 'ball')
             im_label.save(fname_labelz)
+
+
         elif fname_initlabel:
             Image(fname_initlabel).save(fname_labelz)
         else:

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -851,14 +851,11 @@ def resample_labels(fname_labels, fname_dest, fname_output):
     sampling_factor = [float(nx) / nxd, float(ny) / nyd, float(nz) / nzd]
 
     og_labels = display_voxel(Image(fname_labels))
-    new_labels = []
-
-    for x, y, z, v in og_labels:
-        x_ = int(np.round(int(x) / sampling_factor[0]))
-        y_ = int(np.round(int(y) / sampling_factor[1]))
-        z_ = int(np.round(int(z) / sampling_factor[2]))
-        v_ = int(float(v))
-        new_labels.append(Coordinate([x_, y_, z_, v_]))
+    new_labels = [Coordinate([int(np.round(int(x) / sampling_factor[0])),
+                              int(np.round(int(y) / sampling_factor[1])),
+                              int(np.round(int(z) / sampling_factor[2])),
+                              int(float(v))])
+                  for x, y, z, v in og_labels]
 
     sct_labels.create_labels_empty(Image(fname_dest), new_labels).save(path=fname_output)
 

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -16,7 +16,9 @@
 
 from __future__ import division, absolute_import
 
-import sys, os, time
+import sys
+import os
+import time
 import argparse
 
 import numpy as np
@@ -466,7 +468,6 @@ def main(args=None):
         ftmp_seg = Image(ftmp_seg).change_orientation("RPI", generate_path=True).save().absolutepath
         ftmp_label = Image(ftmp_label).change_orientation("RPI", generate_path=True).save().absolutepath
 
-
         ftmp_seg_, ftmp_seg = ftmp_seg, add_suffix(ftmp_seg, '_crop')
         if level_alignment:
             # cropping the segmentation based on the label coverage to ensure good registration with level alignment
@@ -508,12 +509,12 @@ def main(args=None):
         cache_input_files = [ftmp_seg]
         if level_alignment:
             cache_input_files += [
-             ftmp_template_seg,
-             ftmp_label,
-             ftmp_template_label,
+                ftmp_template_seg,
+                ftmp_label,
+                ftmp_template_label,
             ]
         cache_sig = sct.cache_signature(
-         input_files=cache_input_files,
+            input_files=cache_input_files,
         )
         cachefile = os.path.join(curdir, "straightening.cache")
         if sct.cache_valid(cachefile, cache_sig) and os.path.isfile(fn_warp_curve2straight) and os.path.isfile(fn_warp_straight2curve) and os.path.isfile(fn_straight_ref):
@@ -563,7 +564,6 @@ def main(args=None):
             # Remove unused label on template. Keep only label present in the input label image
             sct.printv('\nRemove unused label on template. Keep only label present in the input label image...', verbose)
             sct_labels.remove_missing_labels(Image(ftmp_template_label), Image(ftmp_label)).save(path=ftmp_template_label)
-
 
             # Dilating the input label so they can be straighten without losing them
             sct.printv('\nDilating input labels using 3vox ball radius')
@@ -633,21 +633,21 @@ def main(args=None):
         # find min-max of anat2template (for subsequent cropping)
         zmin_template, zmax_template = msct_image.find_zmin_zmax(im_new, threshold=0.5)
         # save binarized segmentation
-        im_new.save(add_suffix(ftmp_seg, '_bin')) # unused?
+        im_new.save(add_suffix(ftmp_seg, '_bin'))  # unused?
         # crop template in z-direction (for faster processing)
         # TODO: refactor to use python module instead of doing i/o
         sct.printv('\nCrop data in template space (for faster processing)...', verbose)
         ftmp_template_, ftmp_template = ftmp_template, add_suffix(ftmp_template, '_crop')
-        msct_image.spatial_crop(Image(ftmp_template_), dict(((2, (zmin_template,zmax_template)),))).save(ftmp_template)
+        msct_image.spatial_crop(Image(ftmp_template_), dict(((2, (zmin_template, zmax_template)),))).save(ftmp_template)
 
         ftmp_template_seg_, ftmp_template_seg = ftmp_template_seg, add_suffix(ftmp_template_seg, '_crop')
-        msct_image.spatial_crop(Image(ftmp_template_seg_), dict(((2, (zmin_template,zmax_template)),))).save(ftmp_template_seg)
+        msct_image.spatial_crop(Image(ftmp_template_seg_), dict(((2, (zmin_template, zmax_template)),))).save(ftmp_template_seg)
 
         ftmp_data_, ftmp_data = ftmp_data, add_suffix(ftmp_data, '_crop')
-        msct_image.spatial_crop(Image(ftmp_data_), dict(((2, (zmin_template,zmax_template)),))).save(ftmp_data)
+        msct_image.spatial_crop(Image(ftmp_data_), dict(((2, (zmin_template, zmax_template)),))).save(ftmp_data)
 
         ftmp_seg_, ftmp_seg = ftmp_seg, add_suffix(ftmp_seg, '_crop')
-        msct_image.spatial_crop(Image(ftmp_seg_), dict(((2, (zmin_template,zmax_template)),))).save(ftmp_seg)
+        msct_image.spatial_crop(Image(ftmp_seg_), dict(((2, (zmin_template, zmax_template)),))).save(ftmp_seg)
 
         # sub-sample in z-direction
         # TODO: refactor to use python module instead of doing i/o
@@ -666,7 +666,7 @@ def main(args=None):
 
         # TODO: find a way to input initwarp, corresponding to straightening warp
         # Set the angle of the template orientation to 0 (destination image)
-        for key in list(paramregmulti.steps.keys()) :
+        for key in list(paramregmulti.steps.keys()):
             paramregmulti.steps[key].rot_dest = 0
         fname_src2dest, fname_dest2src, warp_forward, warp_inverse = register_wrapper(
             ftmp_data, ftmp_template, param, paramregmulti, fname_src_seg=ftmp_seg, fname_dest_seg=ftmp_template_seg,
@@ -731,7 +731,7 @@ def main(args=None):
             # im_label.absolutepath = 'label_rpi_modif.nii.gz'
             im_label.save()
         # Set the angle of the template orientation to 0 (source image)
-        for key in list(paramregmulti.steps.keys()) :
+        for key in list(paramregmulti.steps.keys()):
             paramregmulti.steps[key].rot_src = 0
         fname_src2dest, fname_dest2src, warp_forward, warp_inverse = register_wrapper(
             ftmp_template, ftmp_data, param, paramregmulti, fname_src_seg=ftmp_template_seg, fname_dest_seg=ftmp_seg,
@@ -802,7 +802,7 @@ def project_labels_on_spinalcord(fname_label, fname_seg, param_centerline):
     # convert pixel into physical coordinates
     centerline_xyz_transposed = \
         [im_seg.transfo_pix2phys([[x_centerline_fit[i], y_centerline_fit[i], z_centerline[i]]])[0]
-                                 for i in range(len(x_centerline_fit))]
+         for i in range(len(x_centerline_fit))]
     # transpose list
     centerline_phys_x = [i[0] for i in centerline_xyz_transposed]
     centerline_phys_y = [i[1] for i in centerline_xyz_transposed]
@@ -891,11 +891,12 @@ def check_labels(fname_landmarks, label_type='body'):
             sct.printv('ERROR: Label should be integer.', 1, 'error')
     # check if there are duplicates in label values
     n_labels = len(labels)
-    list_values = [labels[i].value for i in range(0,n_labels)]
+    list_values = [labels[i].value for i in range(0, n_labels)]
     list_duplicates = [x for x in list_values if list_values.count(x) > 1]
     if not list_duplicates == []:
         sct.printv('ERROR: Found two labels with same value.', 1, 'error')
     return labels
+
 
 def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg='', fname_dest_seg='', fname_src_label='',
                      fname_dest_label='', fname_mask='', fname_initwarp='', fname_initwarpinv='', identity=False,
@@ -924,7 +925,6 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
     """
     # TODO: move interp inside param.
     # TODO: merge param inside paramregmulti by having a "global" sets of parameters that apply to all steps
-
 
     # Extract path, file and extension
     path_src, file_src, ext_src = sct.extract_fname(fname_src)
@@ -1203,45 +1203,45 @@ def register(src, dest, step, param):
     # # landmark-based registration
     if step.type in ['label']:
         warp_forward_out, warp_inverse_out = register_step_label(
-         src=src,
-         dest=dest,
-         step=step,
-         verbose=param.verbose,
+            src=src,
+            dest=dest,
+            step=step,
+            verbose=param.verbose,
         )
 
     elif step.algo == 'slicereg':
         warp_forward_out, warp_inverse_out = register_step_ants_slice_regularized_registration(
-         src=src,
-         dest=dest,
-         step=step,
-         metricSize=metricSize,
-         fname_mask=fname_mask,
-         verbose=param.verbose,
+            src=src,
+            dest=dest,
+            step=step,
+            metricSize=metricSize,
+            fname_mask=fname_mask,
+            verbose=param.verbose,
         )
 
     # ANTS 3d
-    elif step.algo.lower() in ants_registration_params and step.slicewise == '0': # FIXME [AJ]
+    elif step.algo.lower() in ants_registration_params and step.slicewise == '0':  # FIXME [AJ]
         warp_forward_out, warp_inverse_out = register_step_ants_registration(
-         src=src,
-         dest=dest,
-         step=step,
-         masking=masking,
-         ants_registration_params=ants_registration_params,
-         padding=param.padding,
-         metricSize=metricSize,
-         verbose=param.verbose,
+            src=src,
+            dest=dest,
+            step=step,
+            masking=masking,
+            ants_registration_params=ants_registration_params,
+            padding=param.padding,
+            metricSize=metricSize,
+            verbose=param.verbose,
         )
 
     # ANTS 2d
-    elif step.algo.lower() in ants_registration_params and step.slicewise == '1': # FIXME [AJ]
+    elif step.algo.lower() in ants_registration_params and step.slicewise == '1':  # FIXME [AJ]
         warp_forward_out, warp_inverse_out = register_step_slicewise_ants(
-         src=src,
-         dest=dest,
-         step=step,
-         ants_registration_params=ants_registration_params,
-         fname_mask=fname_mask,
-         remove_temp_files=param.remove_temp_files,
-         verbose=param.verbose,
+            src=src,
+            dest=dest,
+            step=step,
+            ants_registration_params=ants_registration_params,
+            fname_mask=fname_mask,
+            remove_temp_files=param.remove_temp_files,
+            verbose=param.verbose,
         )
 
     # slice-wise transfo
@@ -1251,12 +1251,12 @@ def register(src, dest, step, param):
             sct.printv('\nWARNING: algo ' + step.algo + ' will ignore the provided mask.\n', 1, 'warning')
 
         warp_forward_out, warp_inverse_out = register_step_slicewise(
-         src=src,
-         dest=dest,
-         step=step,
-         ants_registration_params=ants_registration_params,
-         remove_temp_files=param.remove_temp_files,
-         verbose=param.verbose,
+            src=src,
+            dest=dest,
+            step=step,
+            ants_registration_params=ants_registration_params,
+            remove_temp_files=param.remove_temp_files,
+            verbose=param.verbose,
         )
 
     else:

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -415,11 +415,12 @@ def main(args=None):
     if label_type == 'body':
         sct.printv('\nGenerate labels from template vertebral labeling', verbose)
         ftmp_template_label_, ftmp_template_label = ftmp_template_label, sct.add_suffix(ftmp_template_label, "_body")
-        sct_labels.label_vertebrae(Image(ftmp_template_label_), [0]).save(path=ftmp_template_label)
+        sct_labels.label_vertebrae(Image(ftmp_template_label_)).save(path=ftmp_template_label)
 
     # check if provided labels are available in the template
     sct.printv('\nCheck if provided labels are available in the template', verbose)
     image_label_template = Image(ftmp_template_label)
+
     labels_template = image_label_template.getNonZeroCoordinates(sorting='value')
     if labels[-1].value > labels_template[-1].value:
         sct.printv('ERROR: Wrong landmarks input. Labels must have correspondence in template space. \nLabel max '

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -860,7 +860,7 @@ def resample_labels(fname_labels, fname_dest, fname_output):
         v_ = int(float(v))
         new_labels.append(Coordinate([x_, y_, z_, v_]))
 
-    sct_labels.create_labels(Image(fname_dest), new_labels).save(path=fname_output)
+    sct_labels.create_labels_empty(Image(fname_dest), new_labels).save(path=fname_output)
 
 
 def check_labels(fname_landmarks, label_type='body'):

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -34,10 +34,10 @@ from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
 import spinalcordtoolbox.image as msct_image
+import spinalcordtoolbox.labels as sct_labels
 
 import sct_utils as sct
 import sct_maths
-import sct_label_utils
 from sct_utils import add_suffix
 from sct_convert import convert
 from sct_image import split_data, concat_warp2d
@@ -414,7 +414,7 @@ def main(args=None):
     if label_type == 'body':
         sct.printv('\nGenerate labels from template vertebral labeling', verbose)
         ftmp_template_label_, ftmp_template_label = ftmp_template_label, sct.add_suffix(ftmp_template_label, "_body")
-        sct_label_utils.main(args=['-i', ftmp_template_label_, '-vert-body', '0', '-o', ftmp_template_label])
+        sct_labels.label_vertebrae(Image(ftmp_template_label_), [0]).save(path=ftmp_template_label)
 
     # check if provided labels are available in the template
     sct.printv('\nCheck if provided labels are available in the template', verbose)
@@ -560,7 +560,8 @@ def main(args=None):
             # --------------------------------------------------------------------------------
             # Remove unused label on template. Keep only label present in the input label image
             sct.printv('\nRemove unused label on template. Keep only label present in the input label image...', verbose)
-            sct.run(['sct_label_utils', '-i', ftmp_template_label, '-o', ftmp_template_label, '-remove-reference', ftmp_label])
+            sct_labels.remove_missing_labels(Image(ftmp_template_label), Image(ftmp_label)).save(path=ftmp_template_label)
+
 
             # Dilating the input label so they can be straighten without losing them
             sct.printv('\nDilating input labels using 3vox ball radius')
@@ -707,7 +708,7 @@ def main(args=None):
 
         # Remove unused label on template. Keep only label present in the input label image
         sct.printv('\nRemove unused label on template. Keep only label present in the input label image...', verbose)
-        sct.run(['sct_label_utils', '-i', ftmp_template_label, '-o', ftmp_template_label, '-remove-reference', ftmp_label])
+        sct_labels.remove_missing_labels(Image(ftmp_template_label), Image(ftmp_label)).save(path=ftmp_template_label)
 
         # Add one label because at least 3 orthogonal labels are required to estimate an affine transformation. This
         # new label is added at the level of the upper most label (lowest value), at 1cm to the right.

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -38,7 +38,6 @@ from spinalcordtoolbox.registration.landmarks import *
 from spinalcordtoolbox.types import Coordinate
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels
-from sct_label_utils import display_voxel
 
 import sct_utils as sct
 import sct_maths
@@ -850,7 +849,7 @@ def resample_labels(fname_labels, fname_dest, fname_output):
     nxd, nyd, nzd, _, _, _, _, _ = Image(fname_dest).dim
     sampling_factor = [float(nx) / nxd, float(ny) / nyd, float(nz) / nzd]
 
-    og_labels = display_voxel(Image(fname_labels))
+    og_labels = Image(fname_labels).getNonZeroCoordinates()
     new_labels = [Coordinate([int(np.round(int(x) / sampling_factor[0])),
                               int(np.round(int(y) / sampling_factor[1])),
                               int(np.round(int(z) / sampling_factor[2])),

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -35,6 +35,7 @@ from spinalcordtoolbox.resampling import resample_file
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
+from spinalcordtoolbox.types import Coordinate
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels
 from sct_label_utils import display_voxel
@@ -849,18 +850,15 @@ def resample_labels(fname_labels, fname_dest, fname_output):
     nxd, nyd, nzd, _, _, _, _, _ = Image(fname_dest).dim
     sampling_factor = [float(nx) / nxd, float(ny) / nyd, float(nz) / nzd]
 
-
     og_labels = display_voxel(Image(fname_labels))
     new_labels = []
 
     for x, y, z, v in og_labels:
-        l = [
-            int(np.round(int(x) / sampling_factor[0])),
-            int(np.round(int(y) / sampling_factor[1])),
-            int(np.round(int(z) / sampling_factor[2])),
-            int(float(v))
-        ]
-        new_labels.append(l)
+        x_ = int(np.round(int(x) / sampling_factor[0]))
+        y_ = int(np.round(int(y) / sampling_factor[1]))
+        z_ = int(np.round(int(z) / sampling_factor[2]))
+        v_ = int(float(v))
+        new_labels.append(Coordinate([x_, y_, z_, v_]))
 
     sct_labels.create_labels(Image(fname_dest), new_labels).save(path=fname_output)
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -415,7 +415,7 @@ def _get_physical_coordinates(img: Image) -> Sequence[CoordinateValue]:
     return phys_coord
 
 
-def get_coordinates_in_destination(img: Image, dst: Image, type: str = 'discrete') -> Sequence[CoordinateValue]:
+def get_coordinates_in_destination(img: Image, dst: Image, tp: str = 'discrete') -> Sequence[CoordinateValue]:
     """
     This function calculates the position of labels in the pixelar space of a destination image
     :param img: source Image
@@ -426,9 +426,9 @@ def get_coordinates_in_destination(img: Image, dst: Image, type: str = 'discrete
     phys_coord = _get_physical_coordinates(img)
     dest_coord = []
     for c in phys_coord:
-        if type is 'discrete':
+        if tp == 'discrete':
             c_p = dst.transfo_phys2pix([[c.x, c.y, c.y]])[0]
-        elif type is 'continuous':
+        elif tp == 'continuous':
             c_p = dst.transfo_phys2pix([[c.x, c.y, c.y]], real=False)[0]
         else:
             raise ValueError("The value of 'type' should either be 'discrete' or 'continuous'!")

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -28,25 +28,7 @@ logger = logging.getLogger(__name__)
 # TODO: currently it seems like cross_radius is given in pixel instead of mm
 
 
-# TODO [AJ]: deprecate this in favor of add_faster if it ok in code review
 def add(img: Image, value: int) -> Image:
-    """
-    This function adds a specified value to all non-zero voxels.
-    :param img: source image
-    :param value: numeric value to add
-    :returns new image with value added
-    """
-    out = img.copy()
-    coordinates_input = img.getNonZeroCoordinates()
-
-    # for all points with non-zeros neighbors, force the neighbors to 0
-    for coord in coordinates_input:
-        out.data[int(coord.x), int(coord.y), int(coord.z)] = out.data[int(coord.x), int(coord.y), int(coord.z)] + float(value)
-
-    return out
-
-
-def add_faster(img: Image, value: int) -> Image:
     """
     This function adds a specified value to all non-zero voxels.
     :param img: source image

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -208,7 +208,7 @@ def increment_z_inverse(img: Image) -> Image:
     return out
 
 
-def labelize_from_disks(img: Image, ref: Image) -> Image:
+def labelize_from_discs(img: Image, ref: Image) -> Image:
     """
     Create an image with regions labelized depending on values from reference.
     Typically, user inputs a segmentation image, and labels with disks position, and this function produces

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -98,13 +98,13 @@ def _add_labels(img: Image, coordinates: Sequence[Coordinate]) -> Image:
         if len(img.data.shape) == 3:
             img.data[int(coord.x), int(coord.y), int(coord.z)] = coord.value
         elif len(img.data.shape) == 2:
-            if str(coord.z) != '0':
-                raise ValueError(f"2D coordinates should have a Z value of 0! Current value: {str(coord.z)}")
+            if coord.z != 0:
+                raise ValueError(f"2D coordinates should have a Z value of 0! Current value: {coord.z}")
             img.data[int(coord.x), int(coord.y)] = coord.value
         else:
-            raise ValueError(f"Data should be 2D or 3D. Current shape is: {str(img.data.shape)}")
+            raise ValueError(f"Data should be 2D or 3D. Current shape is: {img.data.shape}")
 
-        logger.info(f"Label #{str(i)}: {str(coord.x)}, {str(coord.y)}, {str(coord.z)} --> {str(coord.value)}")
+        logger.info(f"Label #{i}: {coord.x}, {coord.y}, {coord.z} --> {coord.value}")
 
     return img
 
@@ -144,13 +144,13 @@ def create_labels_along_segmentation(img: Image, labels: Sequence[Tuple[int, int
         x, y = int(np.round(x)), int(np.round(y))
 
         # display info
-        logger.info(f"Label # {str(idx_label)}: {str(x)}, {str(y)}. {str(z_rpi)} --> {str(value)}")
+        logger.info(f"Label # {idx_label}: {x}, {y}. {z_rpi} --> {value}")
 
         if len(out.data.shape) == 3:
             out.data[x, y, z_rpi] = value
         elif len(out.data.shape) == 2:
-            if str(z) != '0':
-                raise ValueError(f"2D coordinates should have a Z value of 0! Current value: {str(coord.z)}")
+            if z != 0:
+                raise ValueError(f"2D coordinates should have a Z value of 0! Current value: {coord.z}")
 
             out.data[x, y] = value
 
@@ -245,9 +245,9 @@ def cubic_to_point(img: Image) -> Image:
     # 3. Compute the center of mass of each group of voxels and write them into the output image
     for _, list_coord in groups.items():
         center_of_mass = sum(list_coord) / float(len(list_coord))
-        logger.info(f"Value = {str(center_of_mass.value)} : ({str(center_of_mass.x)},\
-         {str(center_of_mass.y) }, {str(center_of_mass.z)}) --> ({str(np.round(center_of_mass.x))}, \
-         {str(np.round(center_of_mass.y))}, {str(np.round(center_of_mass.z))})")
+        logger.info(f"Value = {center_of_mass.value} : ({center_of_mass.x},\
+         {center_of_mass.y}, {center_of_mass.z}) --> ({np.round(center_of_mass.x)}, \
+         {np.round(center_of_mass.y)}, {np.round(center_of_mass.z)})")
 
         out.data[int(np.round(center_of_mass.x)), int(np.round(center_of_mass.y)), int(np.round(center_of_mass.z))] = center_of_mass.value
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -407,11 +407,11 @@ def labels_diff(img: Image, ref: Image) -> Tuple[Sequence[Coordinate], Sequence[
     for ref_coord in ref_coords:
         exists = False
         for src_coord in src_coords:
-            if src_coord.value == ref_coord.value:
+            if ref_coord.value == src_coord.value:
                 exists = True
                 break
         if not exists:
-            missing_from_src.append(src_coord)
+            missing_from_src.append(ref_coord)
             logger.info(f"Missing ref label: {ref_coord.value} from src image")
 
     return missing_from_ref, missing_from_src

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -68,8 +68,7 @@ def create_labels_empty(img: Image, coordinates: Sequence[Coordinate]) -> Image:
     :param coordinates: list of Coordinate objects (see spinalcordtoolbox.types)
     :returns: empty image with labels
     """
-    out = zeros_like(img)
-    out = _add_labels(img, coordinates)
+    out = _add_labels(zeros_like(img), coordinates)
 
     return out
 
@@ -83,8 +82,7 @@ def create_labels(img: Image, coordinates: Sequence[Coordinate]) -> Image:
     :param coordinates: list of Coordinate objects (see spinalcordtoolbox.types)
     :returns: labeled source image
     """
-    out = img.copy()
-    out = _add_labels(img, coordinates)
+    out = _add_labels(img.copy(), coordinates)
 
     return out
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -296,25 +296,21 @@ def compute_mean_squared_error(img: Image, ref: Image) -> float:
 
     # check if all the labels in both the images match
     if len(coordinates_input) != len(coordinates_ref):
-        raise ValueError(f"Input and reference image don't have the same number of labels!")
+        raise ValueError(f"Input and reference image don't have the same number of labels! {len(coordinates_input)} vs {len(coordinates_ref)}")
 
-    rounded_coord_ref_values = [np.round(coord_ref.value) for coord_ref in coordinates_ref]
-    rounded_coord_in_values = [np.round(coord.value) for coord in coordinates_input]
-
-    for coord in coordinates_input:
-        if np.round(coord.value) not in rounded_coord_ref_values:
-            raise ValueError("Labels mismatch")  # FIXME [AJ] be more specific
-
-    for coord_ref in coordinates_ref:
-        if np.round(coord_ref.value) not in rounded_coord_in_values:
-            raise ValueError("Labels mismatch")  # FIXME [AJ] be more specific
-
+    rounded_coord_ref_values = [np.round(c.value) for c in coordinates_ref]
+    rounded_coord_in_values = [np.round(c.value) for c in coordinates_input]
     result = 0.0
 
     for coord, coord_ref in zip(coordinates_input, coordinates_ref):
+        if np.round(coord.value) not in rounded_coord_ref_values:
+            logger.warning(f"Missing input label {coord} in reference!")
+
+        if np.round(coord_ref.value) not in rounded_coord_in_values:
+            logger.warning(f"Missing reference label {coord_ref} in reference!")
+
         if np.round(coord_ref.value) == np.round(coord.value):
             result += (coord_ref.z - coord.z) ** 2
-            break
 
     result = np.sqrt(result / len(coordinates_input))
     logger.info(f"MSE error in Z direction = {result}mm")

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -331,7 +331,7 @@ def remove_missing_labels(img: Image, ref: Image) -> Image:
     coord_input = img.getNonZeroCoordinates(coordValue=True)
     coord_ref = ref.getNonZeroCoordinates(coordValue=True)
 
-    coord_intersection = list(set(coord_input.intersection(set(coord_ref))))
+    coord_intersection = list(set(coord_input).intersection(set(coord_ref)))
 
     for coord in coord_intersection:
         out.data[int(coord.x), int(coord.y), int(coord.z)] = int(np.round(coord.value))

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -160,58 +160,6 @@ def create_labels_along_segmentation(img: Image, labels: Sequence[Tuple[int, int
     return out
 
 
-# FIXME [AJ] better name for this? insert_plane_between_labels() ?
-def plan(img: Image, width: int, offset: int = 0, gap: int = 1) -> Image:
-    """
-    Create a plane of thickness="width" and changes its value with an offset and a gap between labels.
-    :param img: Source image
-    :param width: thickness
-    :param offset: offset
-    :param gap: gap
-    :returns: image with plane
-    """
-    out = zeros_like(img)
-    coordinates = img.getNonZeroCoordinates()
-
-    for coord in coordinates:
-        out.data[:, :, int(coord.z) - width:int(coord.z) + width] = offset + gap * coord.value
-
-    return out
-
-
-# FIXME [AJ] better name for this? generate_plane_for_label() ?
-def plan_ref(img: Image, ref: Image) -> Image:
-    """
-    Generate a plane in the reference space for each label present in the input image
-    :param img: source image
-    :param ref: reference image
-    :returns: new image with plane in ref space for each label
-    """
-
-    out = zeros_like(ref)
-
-    image_input_neg = zeros_like(img)
-    image_input_pos = zeros_like(img)
-
-    X, Y, Z = (img.data < 0).nonzero()
-    for i in range(len(X)):
-        image_input_neg.data[X[i], Y[i], Z[i]] = -img.data[X[i], Y[i], Z[i]]  # in order to apply getNonZeroCoordinates
-
-    X_pos, Y_pos, Z_pos = (img.data > 0).nonzero()
-    for i in range(len(X_pos)):
-        image_input_pos.data[X_pos[i], Y_pos[i], Z_pos[i]] = img.data[X_pos[i], Y_pos[i], Z_pos[i]]
-
-    coordinates_input_neg = image_input_neg.getNonZeroCoordinates()
-    coordinates_input_pos = image_input_pos.getNonZeroCoordinates()
-
-    out.change_type('float32')
-    for coord in coordinates_input_neg:
-        out.data[:, :, int(coord.z)] = -coord.value  # PB: takes the int value of coord.value
-    for coord in coordinates_input_pos:
-        out.data[:, :, int(coord.z)] = coord.value
-
-    return out
-
 
 def cubic_to_point(img: Image) -> Image:
     """

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -287,15 +287,18 @@ def compute_mean_squared_error(img: Image, ref: Image) -> float:
     rounded_coord_in_values = [np.round(c.value) for c in coordinates_input]
     result = 0.0
 
-    for coord, coord_ref in zip(coordinates_input, coordinates_ref):
-        if np.round(coord.value) not in rounded_coord_ref_values:
-            logger.warning(f"Missing input label {coord} in reference!")
 
-        if np.round(coord_ref.value) not in rounded_coord_in_values:
-            logger.warning(f"Missing reference label {coord_ref} in reference!")
+    for coord in coordinates_input:
+        for coord_ref in coordinates_ref:
+            if np.round(coord.value) not in rounded_coord_in_values:
+                logger.warning(f"Missing input label {coord} in reference!")
 
-        if np.round(coord_ref.value) == np.round(coord.value):
-            result += (coord_ref.z - coord.z) ** 2
+            if np.round(coord_ref.value) not in rounded_coord_ref_values:
+                logger.warning(f"Missing reference label {coord_ref} in reference!")
+
+            if np.round(coord_ref.value) == np.round(coord.value):
+                result += (coord_ref.z - coord.z) ** 2
+                break
 
     result = np.sqrt(result / len(coordinates_input))
     logger.info(f"MSE error in Z direction = {result}mm")

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -94,17 +94,18 @@ def _add_labels(img: Image, coordinates: Sequence[Coordinate]) -> Image:
     :param coordinates: list of Coordinate objects (see spinalcordtoolbox.types)
     :returns: labeled source image
     """
-    for i, coord in enumerate(coordinates):
+
+    for i, (x, y, z, v) in enumerate(coordinates):
         if len(img.data.shape) == 3:
-            img.data[int(coord.x), int(coord.y), int(coord.z)] = coord.value
+            img.data[int(x), int(y), int(z)] = v
         elif len(img.data.shape) == 2:
-            if coord.z != 0:
-                raise ValueError(f"2D coordinates should have a Z value of 0! Current value: {coord.z}")
-            img.data[int(coord.x), int(coord.y)] = coord.value
+            if z != 0:
+                raise ValueError(f"2D coordinates should have a Z value of 0! Current value: {z}")
+            img.data[x, y] = v
         else:
             raise ValueError(f"Data should be 2D or 3D. Current shape is: {img.data.shape}")
 
-        logger.debug(f"Label #{i}: {coord.x}, {coord.y}, {coord.z} --> {coord.value}")
+        logger.debug(f"Label #{i}: {x}, {y}, {z} --> {v}")
 
     return img
 
@@ -217,8 +218,8 @@ def increment_z_inverse(img: Image) -> Image:
     coordinates_input = img.getNonZeroCoordinates(sorting='z', reverse_coord=True)
 
     # for all points with non-zeros neighbors, force the neighbors to 0
-    for i, coord in enumerate(coordinates_input):
-        out.data[int(coord.x), int(coord.y), int(coord.z)] = i + 1
+    for i, (x, y, z, _) in enumerate(coordinates_input):
+        out.data[int(x), int(y), int(z)] = i + 1
 
     if out.orientation != og_orientation:
         out.change_orientation(og_orientation)

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -59,7 +59,6 @@ def add_faster(img: Image, value: int) -> Image:
     return out
 
 
-# FIXME [AJ] is it really needed? Haven't seen a caller use sct_label_utils -create without add
 def create_labels_empty(img: Image, coordinates: Sequence[Coordinate]) -> Image:
     """
     Create an empty image with labels listed by the user.

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -382,44 +382,6 @@ def get_coordinates_in_destination(img: Image, dst: Image, tp: str = 'discrete')
     return dest_coord
 
 
-def labels_diff(img: Image, ref: Image) -> Tuple[Sequence[Coordinate], Sequence[Coordinate]]:
-    """
-    Detect any label mismatch between input image and reference image
-    :param img: source Image
-    :param ref: reference image
-    :returns: tuple of list of src and ref labels missing as per scheme below:
-    -> (list_of_src_labels_missing_from_ref, list_of_ref_labels_missing_from_src)
-    """
-
-    src_coords = img.getNonZeroCoordinates()
-    ref_coords = ref.getNonZeroCoordinates()
-
-    missing_from_ref = list()
-    missing_from_src = list()
-
-    for src_coord in src_coords:
-        exists = False
-        for ref_coord in ref_coords:
-            if src_coord.value == ref_coord.value:
-                exists = True
-                break
-        if not exists:
-            missing_from_ref.append(src_coord)
-            logger.info(f"Missing src label: {src_coord.value} from reference image")
-
-    for ref_coord in ref_coords:
-        exists = False
-        for src_coord in src_coords:
-            if ref_coord.value == src_coord.value:
-                exists = True
-                break
-        if not exists:
-            missing_from_src.append(ref_coord)
-            logger.info(f"Missing ref label: {ref_coord.value} from src image")
-
-    return missing_from_ref, missing_from_src
-
-
 def continuous_vertebral_levels(img: Image) -> Image:
     """
     This function transforms the vertebral levels file from the template into a continuous file.

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -322,46 +322,6 @@ def remove_missing_labels(img: Image, ref: Image):
     return out
 
 
-def _get_physical_coordinates(img: Image) -> Sequence[CoordinateValue]:
-    """
-    This function returns the coordinates of the labels in the physical referential system.
-    :param img: source image
-    :returns: a list of CoordinateValue, in the physical (scanner) space
-    """
-
-    coord = img.getNonZeroCoordinates(sorting='value')
-    phys_coord = []
-
-    for c in coord:
-        # convert pixelar coordinates to physical coordinates
-        c_p = img.transfo_pix2phys([[c.x, c.y, c.z]])[0]
-        phys_coord.append(CoordinateValue([c_p[0], c_p[1], c_p[2], c.value]))
-
-    return phys_coord
-
-
-def get_coordinates_in_destination(img: Image, dst: Image, tp: str = 'discrete') -> Sequence[CoordinateValue]:
-    """
-    This function calculates the position of labels in the pixelar space of a destination image
-    :param img: source Image
-    :param dst: Object Image
-    :param type: 'discrete' or 'continuous'
-    :returns: a list of CoordinateValue, in the pixelar (image) space of the destination image
-    """
-    phys_coord = _get_physical_coordinates(img)
-    dest_coord = []
-    for c in phys_coord:
-        if tp == 'discrete':
-            c_p = dst.transfo_phys2pix([[c.x, c.y, c.y]])[0]
-        elif tp == 'continuous':
-            c_p = dst.transfo_phys2pix([[c.x, c.y, c.y]], real=False)[0]
-        else:
-            raise ValueError("The value of 'type' should either be 'discrete' or 'continuous'!")
-        dest_coord.append(CoordinateValue([c_p[0], c_p[1], c_p[2], c.value]))
-
-    return dest_coord
-
-
 def continuous_vertebral_levels(img: Image) -> Image:
     """
     This function transforms the vertebral levels file from the template into a continuous file.

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -449,7 +449,7 @@ def continuous_vertebral_levels(img: Image) -> Image:
     return out
 
 
-def remove_labels_from_image(img: Image, labels: Sequence[Coordinate]) -> Image:
+def remove_labels_from_image(img: Image, labels: Sequence[int]) -> Image:
     """
     Remove specified labels (set to 0) from an image.
     :param img: source image
@@ -457,20 +457,19 @@ def remove_labels_from_image(img: Image, labels: Sequence[Coordinate]) -> Image:
     :returns: image with labels specified removed
     """
     out = img.copy()
-    coordinates = img.getNonZeroCoordinates()
 
-    for x in labels:
-        for coord in coordinates:
-            if x == coord:
-                out.data[int(coord.x), int(coord.y), int(coord.z)] = 0.0
+    for l in labels:
+        for x, y, z, v in img.getNonZeroCoordinates():
+            if l == v:
+                out.data[x,y,z] = 0.0
                 break
         else:
-            logger.warning(f"Label {x} not found in input image!")
+            logger.warning(f"Label {l} not found in input image!")
 
     return out
 
 
-def remove_other_labels_from_image(img: Image, labels: Sequence[Coordinate]) -> Image:
+def remove_other_labels_from_image(img: Image, labels: Sequence[int]) -> Image:
     """
     Remove labels other than specified from an image
     :param img: source image
@@ -478,14 +477,14 @@ def remove_other_labels_from_image(img: Image, labels: Sequence[Coordinate]) -> 
     :returns: image with labels specified kept only
     """
     out = zeros_like(img)
-    coordinates = img.getNonZeroCoordinates()
 
-    for x in labels:
-        for coord in coordinates:
-            if x == coord:
-                out.data[int(coord.x), int(coord.y), int(coord.z)] = coord.value
+    for l in labels:
+        for x, y, z, v in img.getNonZeroCoordinates():
+            if l == v:
+                out.data[x,y,z] = v
                 break
         else:
-            logger.warning(f"Label {x} not found in input image!")
+            logger.warning(f"Label {l} not found in input image!")
 
+    logger.debug(f"{out.data}")
     return out

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -156,6 +156,7 @@ def create_labels_along_segmentation(img: Image, labels: Sequence[Tuple[int, int
 
     if out.orientation != og_orientation:
         out.change_orientation(og_orientation)
+        img.change_orientation(og_orientation)
 
     return out
 
@@ -221,6 +222,7 @@ def increment_z_inverse(img: Image) -> Image:
 
     if out.orientation != og_orientation:
         out.change_orientation(og_orientation)
+        img.change_orientation(og_orientation)
 
     return out
 
@@ -279,6 +281,7 @@ def label_vertebrae(img: Image, vertebral_levels: Sequence[int] = None) -> Image
 
     if out.orientation != og_orientation:
         out.change_orientation(og_orientation)
+        img.change_orientation(og_orientation)
 
     return out
 
@@ -483,6 +486,7 @@ def continuous_vertebral_levels(img: Image) -> Image:
 
     if out.orientation != og_orientation:
         out.change_orientation(og_orientation)
+        img.change_orientation(og_orientation)
 
     return out
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -312,15 +312,14 @@ def remove_missing_labels(img: Image, ref: Image):
     :param ref: reference image
     :returns: image with labels missing from reference removed
     """
-    out = zeros_like(img)
+    out = img.copy()
 
     input_coords = img.getNonZeroCoordinates(coordValue=True)
     ref_coords = ref.getNonZeroCoordinates(coordValue=True)
 
-    coord_intersection = [c for c in input_coords if list(filter(lambda x: x.value == c.value, ref_coords))]
-
-    for x, y, z, v in coord_intersection:
-        out.data[int(x), int(y), int(z)] = int(np.round(v))
+    for c in input_coords:
+        if c not in ref_coords:
+            out.data[int(c.x), int(c.y), int(c.z)] = 0
 
     return out
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -329,15 +329,11 @@ def remove_missing_labels(img: Image, ref: Image) -> Image:
     :returns: image with labels missing from reference removed
     """
 
-    out = zeros_like(img)
+    out = img.copy()
 
-    coord_input = img.getNonZeroCoordinates(coordValue=True)
-    coord_ref = ref.getNonZeroCoordinates(coordValue=True)
-
-    coord_intersection = list(set(coord_input).intersection(set(coord_ref)))
-
-    for coord in coord_intersection:
-        out.data[int(coord.x), int(coord.y), int(coord.z)] = int(np.round(coord.value))
+    for x, y, z, v in img.getNonZeroCoordinates():
+        if ref.data[x,y,z] != v:
+            out.data[x,y,z] = 0
 
     return out
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -24,8 +24,6 @@ logger = logging.getLogger(__name__)
 
 # TODO: for vert-disc: make it faster! currently the module display-voxel is very long (esp. when ran on PAM50). We can find an alternative approach by sweeping through centerline voxels.
 # TODO: label_disc: for top vertebrae, make label at the center of the cord (currently it's at the tip)
-# TODO: check if use specified several processes.
-# TODO: currently it seems like cross_radius is given in pixel instead of mm
 
 
 def add(img: Image, value: int) -> Image:

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -243,10 +243,10 @@ def labelize_from_disks(img: Image, ref: Image) -> Image:
     coordinates_ref = ref.getNonZeroCoordinates(sorting='value')
 
     # for all points in input, find the value that has to be set up, depending on the vertebral level
-    for coord in coordinates_input:
-        for j in range(0, len(coordinates_ref) - 1):
-            if coordinates_ref[j + 1].z < coord.z <= coordinates_ref[j].z:
-                out.data[int(coord.x), int(coord.y), int(coord.z)] = coordinates_ref[j].value
+    for x, y, z, v in coordinates_input:
+        for j in range(len(coordinates_ref) - 1):
+            if coordinates_ref[j + 1].z < z <= coordinates_ref[j].z:
+                out.data[x, y, z] = coordinates_ref[j].value
 
     return out
 
@@ -286,6 +286,7 @@ def label_vertebrae(img: Image, vertebral_levels: Sequence[int] = None) -> Image
     return out
 
 
+# FIXME [AJ]: this is slow on large images
 def compute_mean_squared_error(img: Image, ref: Image) -> float:
     """
     Compute the Mean Squared Distance Error between two sets of labels (input and ref).
@@ -332,8 +333,8 @@ def remove_missing_labels(img: Image, ref: Image) -> Image:
     out = img.copy()
 
     for x, y, z, v in img.getNonZeroCoordinates():
-        if ref.data[x,y,z] != v:
-            out.data[x,y,z] = 0
+        if ref.data[x, y, z] != v:
+            out.data[x, y, z] = 0
 
     return out
 
@@ -461,7 +462,7 @@ def remove_labels_from_image(img: Image, labels: Sequence[int]) -> Image:
     for l in labels:
         for x, y, z, v in img.getNonZeroCoordinates():
             if l == v:
-                out.data[x,y,z] = 0.0
+                out.data[x, y, z] = 0.0
                 break
         else:
             logger.warning(f"Label {l} not found in input image!")
@@ -481,10 +482,9 @@ def remove_other_labels_from_image(img: Image, labels: Sequence[int]) -> Image:
     for l in labels:
         for x, y, z, v in img.getNonZeroCoordinates():
             if l == v:
-                out.data[x,y,z] = v
+                out.data[x, y, z] = v
                 break
         else:
             logger.warning(f"Label {l} not found in input image!")
 
-    logger.debug(f"{out.data}")
     return out

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -502,13 +502,10 @@ def remove_labels_from_image(img: Image, labels: Sequence[Coordinate]) -> Image:
     coordinates = img.getNonZeroCoordinates()
 
     for x in labels:
-        exists = False
         for coord in coordinates:
-            if x == coord.value:
-                new_coord = coord
-                exists = True
-        if exists:
-            out.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = 0.0
+            if x == coord:
+                out.data[int(coord.x), int(coord.y), int(coord.z)] = 0.0
+                break
         else:
             logger.warning(f"Label {x} not found in input image!")
 
@@ -526,13 +523,10 @@ def remove_other_labels_from_image(img: Image, labels: Sequence[Coordinate]) -> 
     coordinates = img.getNonZeroCoordinates()
 
     for x in labels:
-        exists = False
         for coord in coordinates:
-            if x == coord.value:
-                new_coord = coord
-                exists = True
-        if exists:
-            out.data[int(new_coord.x), int(new_coord.y), int(new_coord.z)] = new_coord.value
+            if x == coord:
+                out.data[int(coord.x), int(coord.y), int(coord.z)] = coord.value
+                break
         else:
             logger.warning(f"Label {x} not found in input image!")
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -104,7 +104,7 @@ def _add_labels(img: Image, coordinates: Sequence[Coordinate]) -> Image:
         else:
             raise ValueError(f"Data should be 2D or 3D. Current shape is: {img.data.shape}")
 
-        logger.info(f"Label #{i}: {coord.x}, {coord.y}, {coord.z} --> {coord.value}")
+        logger.debug(f"Label #{i}: {coord.x}, {coord.y}, {coord.z} --> {coord.value}")
 
     return img
 
@@ -144,7 +144,7 @@ def create_labels_along_segmentation(img: Image, labels: Sequence[Tuple[int, int
         x, y = int(np.round(x)), int(np.round(y))
 
         # display info
-        logger.info(f"Label # {idx_label}: {x}, {y}. {z_rpi} --> {value}")
+        logger.debug(f"Label # {idx_label}: {x}, {y}. {z_rpi} --> {value}")
 
         if len(out.data.shape) == 3:
             out.data[x, y, z_rpi] = value
@@ -193,7 +193,7 @@ def cubic_to_point(img: Image) -> Image:
     # 3. Compute the center of mass of each group of voxels and write them into the output image
     for _, list_coord in groups.items():
         center_of_mass = sum(list_coord) / float(len(list_coord))
-        logger.info(f"Value = {center_of_mass.value} : ({center_of_mass.x},\
+        logger.debug(f"Value = {center_of_mass.value} : ({center_of_mass.x},\
          {center_of_mass.y}, {center_of_mass.z}) --> ({np.round(center_of_mass.x)}, \
          {np.round(center_of_mass.y)}, {np.round(center_of_mass.z)})")
 

--- a/spinalcordtoolbox/labels.py
+++ b/spinalcordtoolbox/labels.py
@@ -160,7 +160,6 @@ def create_labels_along_segmentation(img: Image, labels: Sequence[Tuple[int, int
     return out
 
 
-
 def cubic_to_point(img: Image) -> Image:
     """
     Calculate the center of mass of each group of labels and returns a file of same size with only a
@@ -205,9 +204,9 @@ def cubic_to_point(img: Image) -> Image:
 def increment_z_inverse(img: Image) -> Image:
     """
     Take all non-zero values, sort them along the inverse z direction, and attributes the values 1,
-    2, 3, etc. This function assumes RPI orientation.
+    2, 3, etc.
     :param img: source image
-    :returns: image with non-zero balue sorted along inverse z
+    :returns: image with non-zero values sorted along inverse z
     """
     og_orientation = img.orientation
     if og_orientation != "RPI":
@@ -288,7 +287,6 @@ def compute_mean_squared_error(img: Image, ref: Image) -> float:
     """
     Compute the Mean Squared Distance Error between two sets of labels (input and ref).
     Moreover, a warning is generated for each label mismatch.
-    If the MSE is above the threshold provided (by default = 0mm), a log is reported with the filenames considered here.
     :param img: source image
     :param ref: reference image
     :returns: computed MSE

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -89,6 +89,9 @@ class Coordinate(Point):
         except ValueError:
             raise TypeError("All coordinates must be int and the value can be a float or a int. x=" + str(self.x) + ", y=" + str(self.y) + ", z=" + str(self.z) + ", value=" + str(self.value))
 
+    def __iter__(self):
+        return iter((self.x, self.y, self.z, self.value))
+
     def __repr__(self):
         return "(" + str(self.x) + ", " + str(self.y) + ", " + str(self.z) + ", " + str(self.value) + ")"
 

--- a/spinalcordtoolbox/types.py
+++ b/spinalcordtoolbox/types.py
@@ -90,6 +90,7 @@ class Coordinate(Point):
             raise TypeError("All coordinates must be int and the value can be a float or a int. x=" + str(self.x) + ", y=" + str(self.y) + ", z=" + str(self.z) + ", value=" + str(self.value))
 
     def __iter__(self):
+        # Allows for this usage: "for x, y, z, v in [list of Coordinate]"
         return iter((self.x, self.y, self.z, self.value))
 
     def __repr__(self):

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -77,10 +77,9 @@ def test_create_labels_along_segmentation():
     a = Image(src_seg)
     labels = [(5, 1), (14, 2), (23, 3)]
 
-    og_orientation = a.orientation
     b = sct_labels.create_labels_along_segmentation(a, labels)
 
-    assert b.orientation == og_orientation
+    assert b.orientation == a.orientation
 
     # TODO [AJ] how to validate labels?
 

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -104,11 +104,11 @@ def test_increment_z_inverse(test_image):
 
 
 @pytest.mark.parametrize("test_seg,test_labels", [(seg_img, labels_img)])
-def test_labelize_from_disks(test_seg, test_labels):
+def test_labelize_from_discs(test_seg, test_labels):
     seg = test_seg.copy()
     ref = test_labels.copy()
 
-    sct_labels.labelize_from_disks(seg, ref)
+    sct_labels.labelize_from_discs(seg, ref)
     # TODO [AJ] implement test
 
 

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -130,18 +130,17 @@ def test_label_vertebrae(test_image):
     # TODO [AJ] implement test
 
 
-@pytest.mark.parametrize("test_image", test_images)
-def test_compute_mean_squared_error(test_image):
-    src = test_image.copy()
-    ref = test_image.copy()
 
-    for z in range(3):
-        for y in range(2):
-            for x in range(1):
-                ref.data[x, y, z] *= 10
+def test_compute_mean_squared_error():
+    src = fake_3dimage_sct()
+    ref = src.copy()
 
-    sct_labels.compute_mean_squared_error(src, ref)
-    # TODO [AJ] implement test
+    for x, y, z, _ in src.getNonZeroCoordinates():
+        if z < 5:
+            ref.data[x, y, z+2] = src.data[x, y, z]
+
+    mse = sct_labels.compute_mean_squared_error(src, ref)
+    assert mse == 1.1547005383792515
 
 
 @pytest.mark.skip(reason="Too long to run on large image!")

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -52,28 +52,6 @@ def fake_3dimage_sct():
 test_images = [fake_3dimage_sct(), fake_3dimage_sct2(), t2_img]
 
 
-# AJ remove test if we keep add_faster + refactor caller
-@pytest.mark.parametrize("test_image", test_images)
-def test_add(test_image):
-    a = test_image.copy()
-    val = 4
-
-    t1 = time()
-    sct_added = sct_labels.add(a, val)
-    t2 = time()
-    np_added = sct_labels.add_faster(a, val)
-    t3 = time()
-
-    c = sct_added.data == np_added.data
-    assert c.all()
-
-    l1 = t2 - t1
-    l2 = t3 - t2
-    logger.debug(f"time to run sct_labels.add() -> {l1}")
-    logger.debug(f"time to run np add -> {l2}")
-    logger.debug(f"speed x improvement -> {l1/l2}")
-
-
 @pytest.mark.parametrize("test_image", test_images)
 def test_create_labels_empty(test_image):
     a = test_image.copy()

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -178,3 +178,15 @@ def test_labels_diff(test_image):
     assert missing_from_ref[0] == Coordinate([0, 0, 0, src.data[0][0][0]])
     assert missing_from_ref[1] == Coordinate([0, 1, 2, src.data[0][1][2]])
     assert missing_from_src[0] == Coordinate([0, 1, 1, ref.data[0][1][1]])
+
+
+@pytest.mark.parametrize("test_image", test_images)
+def test_continuous_vertebral_levels(test_image):
+    a = test_image.copy()
+    b = sct_labels.continuous_vertebral_levels(a)
+
+    # check that orientation is maintained
+    assert b.orientation == a.orientation
+
+    # TODO [AJ] implement test
+

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -95,12 +95,22 @@ def test_cubic_to_point(test_image):
     sct_labels.cubic_to_point(a)
     # TODO [AJ] implement test
 
-
 @pytest.mark.parametrize("test_image", test_images)
 def test_increment_z_inverse(test_image):
-    a = test_image.copy()
-    sct_labels.increment_z_inverse(a)
-    # TODO [AJ] implement test
+    a = zeros_like(test_image.copy())
+    a.data[0, 1, 0] = 1
+    a.data[0, 1, 1] = 5
+    a.data[0, 1, 2] = 2
+
+    expected = a.copy()
+    expected.data[0, 1, 0] = 3
+    expected.data[0, 1, 1] = 2
+    expected.data[0, 1, 2] = 1
+
+    b = sct_labels.increment_z_inverse(a)
+
+    diff = b.data == expected.data
+    assert diff.all()
 
 
 @pytest.mark.parametrize("test_seg,test_labels", [(seg_img, labels_img)])

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -80,8 +80,8 @@ def test_create_labels_empty(test_image):
     expected = zeros_like(a)
 
     labels = [Coordinate(l) for l in [[0, 0, 0, 7], [0, 1, 2, 5]]]
-    expected.data[0,0,0] = 7
-    expected.data[0,1,2] = 5
+    expected.data[0, 0, 0] = 7
+    expected.data[0, 1, 2] = 5
 
     b = sct_labels.create_labels_empty(a, labels)
 
@@ -96,8 +96,8 @@ def test_create_labels(test_image):
 
     b = sct_labels.create_labels(a, labels)
 
-    assert b.data[0,1,0] == 99
-    assert b.data[0,1,2] == 5
+    assert b.data[0, 1, 0] == 99
+    assert b.data[0, 1, 2] == 5
 
 
 @pytest.mark.parametrize("test_seg", [seg_img])
@@ -164,22 +164,17 @@ def test_remove_missing_labels(test_image):
     expected = test_image.copy()
 
     # change 2 labels in ref
-    src.data[0,0,0] = 99
-    src.data[0,1,2] = 99
+    src.data[0, 0, 0] = 99
+    src.data[0, 1, 2] = 99
 
     # manually set expected
-    expected.data[0,0,0] = 0
-    expected.data[0,1,2] = 0
+    expected.data[0, 0, 0] = 0
+    expected.data[0, 1, 2] = 0
 
     res = sct_labels.remove_missing_labels(src, ref)
     diff = res.data == expected.data
 
     assert diff.all()
-
-
-@pytest.mark.skip(reason="To be implemented")
-def test_get_coordinates_in_destination():
-    raise NotImplementedError()
 
 
 @pytest.mark.parametrize("test_image", test_images)
@@ -199,13 +194,13 @@ def test_remove_labels_from_image(test_image):
 
     labels = [1, 2]
 
-    img.data[0,0,0] = 1
-    img.data[0,1,0] = 2
+    img.data[0, 0, 0] = 1
+    img.data[0, 1, 0] = 2
 
     res = sct_labels.remove_labels_from_image(img, labels)
 
-    expected.data[0,0,0] = 0
-    expected.data[0,1,0] = 0
+    expected.data[0, 0, 0] = 0
+    expected.data[0, 1, 0] = 0
 
     diff = res.data == expected.data
     assert diff.all()
@@ -218,13 +213,13 @@ def test_remove_other_labels_from_image(test_image):
 
     labels = [5, 6]
 
-    img.data[0,0,0] = 5
-    img.data[0,1,0] = 6
+    img.data[0, 0, 0] = 5
+    img.data[0, 1, 0] = 6
 
     res = sct_labels.remove_other_labels_from_image(img, labels)
 
-    expected.data[0,0,0] = 5
-    expected.data[0,1,0] = 6
+    expected.data[0, 0, 0] = 5
+    expected.data[0, 1, 0] = 6
 
     diff = res.data == expected.data
 

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -15,6 +15,7 @@ from spinalcordtoolbox.types import Coordinate
 logger = logging.getLogger(__name__)
 
 src_img = sct_test_path('t2', 't2.nii.gz')
+src_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
 
 
 # AJ remove test if we keep add_faster + refactor caller
@@ -60,3 +61,14 @@ def test_create_labels():
 
     assert b.data[1][2][3] == 99
     assert b.data[14][28][33] == 5
+
+
+def test_create_labels_along_segmentation():
+    a = Image(src_seg)
+    labels = [(5, 1), (14, 2), (23, 3)]
+
+    og_orientation = a.orientation
+    b = sct_labels.create_labels_along_segmentation(a, labels)
+
+    if b.orientation != og_orientation:
+        raise ValueError("Image orientation not maintained")

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -183,24 +183,6 @@ def test_get_coordinates_in_destination():
 
 
 @pytest.mark.parametrize("test_image", test_images)
-def test_labels_diff(test_image):
-    src = test_image.copy()
-    ref = test_image.copy()
-
-    # change some labels
-    ref.data[0][0][0] = 99
-    ref.data[0][1][2] = 99
-
-    src.data[0][1][1] = 99
-
-    # check that changes appear in diff
-    missing_from_ref, missing_from_src = sct_labels.labels_diff(src, ref)
-    assert missing_from_ref[0] == Coordinate([0, 0, 0, src.data[0][0][0]])
-    assert missing_from_ref[1] == Coordinate([0, 1, 2, src.data[0][1][2]])
-    assert missing_from_src[0] == Coordinate([0, 1, 1, ref.data[0][1][1]])
-
-
-@pytest.mark.parametrize("test_image", test_images)
 def test_continuous_vertebral_levels(test_image):
     a = test_image.copy()
     b = sct_labels.continuous_vertebral_levels(a)

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -80,8 +80,8 @@ def test_create_labels_empty(test_image):
     expected = zeros_like(a)
 
     labels = [Coordinate(l) for l in [[0, 0, 0, 7], [0, 1, 2, 5]]]
-    expected.data[0][0][0] = 7
-    expected.data[0][1][2] = 5
+    expected.data[0,0,0] = 7
+    expected.data[0,1,2] = 5
 
     b = sct_labels.create_labels_empty(a, labels)
 
@@ -96,8 +96,8 @@ def test_create_labels(test_image):
 
     b = sct_labels.create_labels(a, labels)
 
-    assert b.data[0][1][0] == 99
-    assert b.data[0][1][2] == 5
+    assert b.data[0,1,0] == 99
+    assert b.data[0,1,2] == 5
 
 
 @pytest.mark.parametrize("test_seg", [seg_img])
@@ -196,12 +196,16 @@ def test_continuous_vertebral_levels(test_image):
 def test_remove_labels_from_image(test_image):
     img = test_image.copy()
     expected = test_image.copy()
-    labels = [Coordinate(l) for l in [[0, 0, 0, 7], [0, 1, 2, 5]]]
+
+    labels = [1, 2]
+
+    img.data[0,0,0] = 1
+    img.data[0,1,0] = 2
 
     res = sct_labels.remove_labels_from_image(img, labels)
 
-    expected.data[0][0][0] = 0
-    expected.data[0][1][2] = 0
+    expected.data[0,0,0] = 0
+    expected.data[0,1,0] = 0
 
     diff = res.data == expected.data
     assert diff.all()
@@ -212,11 +216,15 @@ def test_remove_other_labels_from_image(test_image):
     img = test_image.copy()
     expected = zeros_like(test_image)
 
-    labels = [Coordinate(l) for l in [[0, 0, 0, 7], [0, 1, 2, 5]]]
+    labels = [5, 6]
+
+    img.data[0,0,0] = 5
+    img.data[0,1,0] = 6
+
     res = sct_labels.remove_other_labels_from_image(img, labels)
 
-    expected.data[0][0][0] = img.data[0][0][0]
-    expected.data[0][1][2] = img.data[0][1][2]
+    expected.data[0,0,0] = 5
+    expected.data[0,1,0] = 6
 
     diff = res.data == expected.data
 

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -134,6 +134,7 @@ def test_compute_mean_squared_error(test_image):
     # TODO [AJ] implement test
 
 
+@pytest.mark.skip(reason="Too long to run on large image!")
 @pytest.mark.parametrize("test_image", test_images)
 def test_remove_missing_labels(test_image):
     src = test_image.copy()
@@ -141,9 +142,12 @@ def test_remove_missing_labels(test_image):
 
     expected = test_image.copy()
 
-    # change 2 labels in ref
+    # introduce 2 discrepancies
     src.data[0, 0, 0] = 99
     src.data[0, 1, 2] = 99
+
+    ref.data[0, 0, 0] = 1
+    ref.data[0, 1, 2] = 1
 
     # manually set expected
     expected.data[0, 0, 0] = 0

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -108,3 +108,22 @@ def test_label_vertebrae():
 @pytest.mark.skip(reason="To be implemented")
 def test_compute_mean_squared_error():
     raise NotImplementedError()
+
+
+def test_remove_missing_labels():
+    src = fake_image()
+    ref = fake_image()
+
+    # change 2 labels in ref
+    ref.data[1][2][3] = 99
+    ref.data[3][2][1] = 99
+
+    res = sct_labels.remove_missing_labels(src, ref)
+
+    # check that missing labels have been removed
+    assert res.data[1][2][3] == 0
+    assert res.data[3][2][1] == 0
+
+    # random spot check
+    assert src.data[1][1][1] == res.data[1][1][1]
+    assert src.data[2][2][2] == res.data[2][2][2]

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -122,13 +122,14 @@ def test_labelize_from_discs(test_seg, test_labels):
     # TODO [AJ] implement test
 
 
-@pytest.mark.parametrize("test_image", test_images)
-def test_label_vertebrae(test_image):
-    a = test_image.copy()
-    sct_labels.label_vertebrae(a)
-    sct_labels.label_vertebrae(a, [1, 2, 3, 4])
-    # TODO [AJ] implement test
+def test_label_vertebrae():
+    a = fake_3dimage_sct2()
+    expected = zeros_like(a)
+    expected.data[0, 0, 0] = 111
+    b = sct_labels.label_vertebrae(a, [111])
 
+    diff = b.data == expected.data
+    assert diff.all()
 
 
 def test_compute_mean_squared_error():

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -6,21 +6,31 @@ import logging
 from time import time
 
 import numpy as np
+import pytest
 
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.utils import sct_test_path
 from spinalcordtoolbox.types import Coordinate
+from test_image import fake_3dimage
 
 logger = logging.getLogger(__name__)
 
-src_img = sct_test_path('t2', 't2.nii.gz')
 src_seg = sct_test_path('t2', 't2_seg-manual.nii.gz')
+
+
+def fake_image():
+    i = fake_3dimage()
+    img = Image(i.get_data(), hdr=i.header,
+                orientation="RPI",
+                dim=i.header.get_data_shape(),
+                )
+    return img
 
 
 # AJ remove test if we keep add_faster + refactor caller
 def test_add():
-    a = Image(src_img)
+    a = fake_image()
     val = 4
 
     t1 = time()
@@ -40,12 +50,12 @@ def test_add():
 
 
 def test_create_labels_empty():
-    a = Image(src_img)
+    a = fake_image()
     ref = zeros_like(a)
 
-    labels = [Coordinate(l) for l in [[12, 24, 32, 7], [15, 35, 33, 5]]]
-    ref.data[12][24][32] = 7
-    ref.data[15][35][33] = 5
+    labels = [Coordinate(l) for l in [[1, 2, 3, 7], [4, 5, 6, 5]]]
+    ref.data[1][2][3] = 7
+    ref.data[4][5][6] = 5
 
     b = sct_labels.create_labels_empty(a, labels)
 
@@ -54,13 +64,13 @@ def test_create_labels_empty():
 
 
 def test_create_labels():
-    a = Image(src_img)
-    labels = [Coordinate(l) for l in [[1, 2, 3, 99], [14, 28, 33, 5]]]
+    a = fake_image()
+    labels = [Coordinate(l) for l in [[1, 2, 3, 99], [4, 5, 6, 5]]]
 
     b = sct_labels.create_labels(a, labels)
 
     assert b.data[1][2][3] == 99
-    assert b.data[14][28][33] == 5
+    assert b.data[4][5][6] == 5
 
 
 def test_create_labels_along_segmentation():
@@ -70,5 +80,31 @@ def test_create_labels_along_segmentation():
     og_orientation = a.orientation
     b = sct_labels.create_labels_along_segmentation(a, labels)
 
-    if b.orientation != og_orientation:
-        raise ValueError("Image orientation not maintained")
+    assert b.orientation == og_orientation
+
+    # TODO [AJ] how to validate labels?
+
+
+@pytest.mark.skip(reason="To be implemented")
+def test_cubic_to_point():
+    raise NotImplementedError()
+
+
+@pytest.mark.skip(reason="To be implemented")
+def test_increment_z_inverse():
+    raise NotImplementedError()
+
+
+@pytest.mark.skip(reason="To be implemented")
+def test_labelize_from_disks():
+    raise NotImplementedError()
+
+
+@pytest.mark.skip(reason="To be implemented")
+def test_label_vertebrae():
+    raise NotImplementedError()
+
+
+@pytest.mark.skip(reason="To be implemented")
+def test_compute_mean_squared_error():
+    raise NotImplementedError()

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -164,12 +164,12 @@ def test_remove_missing_labels(test_image):
     expected = test_image.copy()
 
     # change 2 labels in ref
-    ref.data[0][0][0] = 99
-    ref.data[0][1][2] = 99
+    src.data[0,0,0] = 99
+    src.data[0,1,2] = 99
 
     # manually set expected
-    expected.data[0][0][0] = 0
-    expected.data[0][1][2] = 0
+    expected.data[0,0,0] = 0
+    expected.data[0,1,2] = 0
 
     res = sct_labels.remove_missing_labels(src, ref)
     diff = res.data == expected.data

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -10,12 +10,14 @@ import numpy as np
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.types import Coordinate
 
 logger = logging.getLogger(__name__)
 
 src_img = sct_test_path('t2', 't2.nii.gz')
 
 
+# AJ remove test if we keep add_faster + refactor caller
 def test_add():
     a = Image(src_img)
     val = 4
@@ -34,3 +36,27 @@ def test_add():
     logger.debug(f"time to run sct_labels.add() -> {l1}")
     logger.debug(f"time to run np add -> {l2}")
     logger.debug(f"speed x improvement -> {l1/l2}")
+
+
+def test_create_labels_empty():
+    a = Image(src_img)
+    ref = zeros_like(a)
+
+    labels = [Coordinate(l) for l in [[12, 24, 32, 7], [15, 35, 33, 5]]]
+    ref.data[12][24][32] = 7
+    ref.data[15][35][33] = 5
+
+    b = sct_labels.create_labels_empty(a, labels)
+
+    c = b.data == ref.data
+    assert c.all()
+
+
+def test_create_labels():
+    a = Image(src_img)
+    labels = [Coordinate(l) for l in [[1, 2, 3, 99], [14, 28, 33, 5]]]
+
+    b = sct_labels.create_labels(a, labels)
+
+    assert b.data[1][2][3] == 99
+    assert b.data[14][28][33] == 5

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -190,3 +190,33 @@ def test_continuous_vertebral_levels(test_image):
 
     # TODO [AJ] implement test
 
+
+@pytest.mark.parametrize("test_image", test_images)
+def test_remove_labels_from_image(test_image):
+    img = test_image.copy()
+    expected = test_image.copy()
+    labels = [Coordinate(l) for l in [[0, 0, 0, 7], [0, 1, 2, 5]]]
+
+    res = sct_labels.remove_labels_from_image(img, labels)
+
+    expected.data[0][0][0] = 0
+    expected.data[0][1][2] = 0
+
+    diff = res.data == expected.data
+    assert diff.all()
+
+
+@pytest.mark.parametrize("test_image", test_images)
+def test_remove_other_labels_from_image(test_image):
+    img = test_image.copy()
+    expected = zeros_like(test_image)
+
+    labels = [Coordinate(l) for l in [[0, 0, 0, 7], [0, 1, 2, 5]]]
+    res = sct_labels.remove_other_labels_from_image(img, labels)
+
+    expected.data[0][0][0] = img.data[0][0][0]
+    expected.data[0][1][2] = img.data[0][1][2]
+
+    diff = res.data == expected.data
+
+    assert diff.all()

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 seg_img = Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
 t2_img = Image(sct_test_path('t2', 't2.nii.gz'))
+labels_img = Image(sct_test_path('t2', 'labels.nii.gz'))
 
 
 # TODO [AJ] investigate how to parametrize fixtures from test_image.py
@@ -107,33 +108,52 @@ def test_create_labels_along_segmentation(test_seg):
     b = sct_labels.create_labels_along_segmentation(a, labels)
 
     assert b.orientation == a.orientation
-
     # TODO [AJ] implement test
 
 
-@pytest.mark.skip(reason="To be implemented")
-def test_cubic_to_point():
-    raise NotImplementedError()
+@pytest.mark.parametrize("test_image", test_images)
+def test_cubic_to_point(test_image):
+    a = test_image.copy()
+    sct_labels.cubic_to_point(a)
+    # TODO [AJ] implement test
 
 
-@pytest.mark.skip(reason="To be implemented")
-def test_increment_z_inverse():
-    raise NotImplementedError()
+@pytest.mark.parametrize("test_image", test_images)
+def test_increment_z_inverse(test_image):
+    a = test_image.copy()
+    sct_labels.increment_z_inverse(a)
+    # TODO [AJ] implement test
 
 
-@pytest.mark.skip(reason="To be implemented")
-def test_labelize_from_disks():
-    raise NotImplementedError()
+@pytest.mark.parametrize("test_seg,test_labels", [(seg_img, labels_img)])
+def test_labelize_from_disks(test_seg, test_labels):
+    seg = test_seg.copy()
+    ref = test_labels.copy()
+
+    sct_labels.labelize_from_disks(seg, ref)
+    # TODO [AJ] implement test
 
 
-@pytest.mark.skip(reason="To be implemented")
-def test_label_vertebrae():
-    raise NotImplementedError()
+@pytest.mark.parametrize("test_image", test_images)
+def test_label_vertebrae(test_image):
+    a = test_image.copy()
+    sct_labels.label_vertebrae(a)
+    sct_labels.label_vertebrae(a, [1, 2, 3, 4])
+    # TODO [AJ] implement test
 
 
-@pytest.mark.skip(reason="To be implemented")
-def test_compute_mean_squared_error():
-    raise NotImplementedError()
+@pytest.mark.parametrize("test_image", test_images)
+def test_compute_mean_squared_error(test_image):
+    src = test_image.copy()
+    ref = test_image.copy()
+
+    for z in range(3):
+        for y in range(2):
+            for x in range(1):
+                ref.data[x, y, z] *= 10
+
+    sct_labels.compute_mean_squared_error(src, ref)
+    # TODO [AJ] implement test
 
 
 @pytest.mark.parametrize("test_image", test_images)
@@ -187,7 +207,6 @@ def test_continuous_vertebral_levels(test_image):
 
     # check that orientation is maintained
     assert b.orientation == a.orientation
-
     # TODO [AJ] implement test
 
 

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -127,3 +127,25 @@ def test_remove_missing_labels():
     # random spot check
     assert src.data[1][1][1] == res.data[1][1][1]
     assert src.data[2][2][2] == res.data[2][2][2]
+
+
+@pytest.mark.skip(reason="To be implemented")
+def test_get_coordinates_in_destination():
+    raise NotImplementedError()
+
+
+def test_labels_diff():
+    src = fake_image()
+    ref = fake_image()
+
+    # change some labels
+    ref.data[1][2][3] = 99
+    ref.data[3][2][1] = 99
+
+    src.data[4][5][6] = 99
+
+    # check that changes appear in diff
+    missing_from_ref, missing_from_src = sct_labels.labels_diff(src, ref)
+    assert missing_from_ref[0] == Coordinate([1, 2, 3, src.data[1][2][3]])
+    assert missing_from_ref[1] == Coordinate([3, 2, 1, src.data[3][2][1]])
+    assert missing_from_src[0] == Coordinate([4, 5, 6, ref.data[4][5][6]])


### PR DESCRIPTION
Closes #2870 
Closes #2905 
Needed by #2873 
After #2842 
After #2903 

batch_processing results
```
Version:         git-aj/2870-refactor_sct_label_utils-144f6950224434a98a474f719c63950064f55ec4*
Ran on:          Linux drupad-p1 5.4.64-1-MANJARO                                                                                                              
Duration:        0hrs 13min 53sec                                 
---
t2/CSA:          73.87711295363036
mt/MTR(WM):      54.420871701809666
t2s/CSA_GM:      12.487834828856178
t2s/CSA_WM:      64.93830702088246
dmri/FA(CST_r):  0.7756557364086285
dmri/FA(CST_l):  0.7801552138489745
```