### PR TITLE
Update verbose arguments and usage to be integer 0/1 instead of string 0/1/2

### DIFF
--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -94,12 +94,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -548,7 +549,7 @@ def main(args=None):
 
     # Verbosity
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # create the Lesion constructor
     lesion_obj = AnalyzeLeion(fname_mask=fname_mask,

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -104,12 +104,13 @@ def get_parser():
         choices=(0, 1),
         default=int(Param().rm_tmp))
     optional.add_argument(
-        "-v",
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended.",
-        required=False,
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1, 2),
-        default=Param().verbose)
+        choices=(0, 1),
+        default=Param().verbose,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -351,7 +352,7 @@ def main(args=None):
     if arguments.r is not None:
         param.rm_tmp = bool(arguments.r)
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # create the GLCM constructor
     glcm = ExtractGLCM(param=param, param_glcm=param_glcm)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -107,12 +107,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
-        help="Verbose: 0: nothing, 1: classic, 2: expended.",
-        required=False,
+        '-v',
+        metavar=Metavar.int,
         type=int,
+        choices=(0, 1),
         default=1,
-        choices=(0, 1, 2))
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -369,7 +370,7 @@ def main(args=None):
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = arguments.v
-    sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if transform.verbose else 1, update=True)
 
     transform.apply()
 

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -124,12 +124,13 @@ def get_parser():
         metavar=Metavar.str,
         default="ernst_angle.png")
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended (graph)",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -156,7 +157,7 @@ def main():
     if arguments.tr is not None:
         input_tr = arguments.tr
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     graph = ErnstAngle(input_t1, tr=input_tr, fname_output=input_fname_output)
     if input_tr is not None:

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -175,7 +175,7 @@ def main():
         except:
             sct.printv('\nERROR: Cannot open file'+fname_output_file, '1', 'error')
 
-    if verbose == 2:
+    if verbose:
         graph.draw(input_tr_min, input_tr_max)
 
 

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -484,12 +484,13 @@ def get_parser():
         required=False,
         default='hausdorff_distance.txt')
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -522,7 +523,7 @@ if __name__ == "__main__":
         if arguments.o is not None:
             output_fname = arguments.o
         param.verbose = arguments.v
-        sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+        sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
         tmp_dir = sct.tmp_create()
         im1_name = "im1.nii.gz"

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -60,11 +60,12 @@ def get_parser():
         )
     optional.add_argument(
         '-v',
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1, 2),
-        help='Verbose: 0 = nothing, 1 = classic, 2 = expended',
-        default=1
-        )
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
     optional.add_argument(
         '-o',
         help='Path to output file.',

--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -117,11 +117,13 @@ def get_parser(argv):
         help="Output file for T1map. Default is t1map.nii.gz",
         default=None)
     optional.add_argument(
-        "-v",
-        help="Verbose: 0 = no verbosity, 1 = verbose (default).",
+        '-v',
+        metavar=Metavar.int,
         type=int,
         choices=(0, 1),
-        default=1)
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -168,7 +170,7 @@ def main(argv):
     parser = get_parser(argv)
     args = parser.parse_args(argv if argv else ['--help'])
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     sct.printv('Load data...', verbose)
     nii_mt = Image(args.mt)

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -82,10 +82,12 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         '-v',
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -121,7 +123,7 @@ def main():
     else:
         index_vol_user = ''
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Check parameters
     if method == 'diff':

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -54,7 +54,7 @@ def main(args=None):
     if arguments.o is not None:
         fname_warp_final = arguments.o
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Parse list of warping fields
     sct.printv('\nParse list of warping fields...', verbose)
@@ -170,12 +170,13 @@ def get_parser():
         metavar=Metavar.str,
         required = False)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -112,12 +112,13 @@ def get_parser():
         default = 1,
         choices = (0, 1))
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended ",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -151,7 +152,7 @@ def main(args=None):
         param.remove_temp_files = arguments.r
 
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # run main program
     create_mask(param)

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -129,11 +129,12 @@ def get_parser():
         metavar=Metavar.int,
         )
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="0: Verbose off | 1: Verbose on",
         choices=(0, 1),
-        default=1
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on."
     )
 
     return parser
@@ -154,7 +155,7 @@ def main(args=None):
     # initialize ImageCropper
     cropper = ImageCropper(Image(arguments.i))
     cropper.verbose = arguments.v
-    sct.init_sct(log_level=cropper.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if cropper.verbose else 1)
 
     # Switch across cropping methods
     if arguments.g:

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -101,11 +101,12 @@ def get_parser():
 
     misc = parser.add_argument_group('\nMISC')
     misc.add_argument(
-        "-v",
+        '-v',
         type=int,
-        help="Verbose: 0 = no verbosity, 1 = verbose.",
         choices=(0, 1),
-        default=1)
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
     misc.add_argument(
         "-h",
         "--help",

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -85,11 +85,13 @@ def get_parser():
              "provides non-deterministic results.",
         metavar='')
     misc.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = no verbosity, 1 = verbose.",
         choices=(0, 1),
-        default=1)
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -107,7 +109,7 @@ def run_main():
     model_name = arguments.m
     threshold = arguments.thr
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     if threshold > 1.0 or threshold < 0.0:
         raise RuntimeError("Threshold should be between 0.0 and 1.0.")

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -166,7 +166,7 @@ def main():
                                                sct.extract_fname(fname_image)[2]))
         im_labels_viewer.save(fname_labels)
 
-    if verbose == 2:
+    if verbose:
         # Save ctr
         fname_ctr = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_centerline' +
                                                sct.extract_fname(fname_image)[2]))

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -97,11 +97,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="1: Display on (default), 0: Display off, 2: Extended",
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
     optional.add_argument(
         '-igt',
         metavar=Metavar.str,
@@ -139,7 +141,7 @@ def main():
 
     remove_temp_files = args.r
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     algo_config_stg = '\nMethod:'
     algo_config_stg += '\n\tCenterline algorithm: ' + str(ctr_algo)

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -98,11 +98,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="1: display on (default), 0: display off, 2: extended",
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
     optional.add_argument(
         '-qc',
         metavar=Metavar.str,
@@ -169,7 +171,7 @@ def main():
 
     remove_temp_files = args.r
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     path_qc = args.qc
     qc_dataset = args.qc_dataset

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -82,11 +82,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
+        '-v',
+        metavar=Metavar.int,
         type=int,
+        choices=(0, 1),
         default=1,
-        choices=(0, 1, 2))
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -187,7 +189,7 @@ if __name__ == "__main__":
     remove_temp_files = arguments.r
     noise_threshold = arguments.d
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     file_to_denoise = arguments.i
     output_file_name = arguments.o

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -92,12 +92,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -293,7 +294,7 @@ def main():
     rm_tmp = bool(arguments.r)
 
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Initialize DetectPMJ
     detector = DetectPMJ(fname_im=fname_in,

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -93,11 +93,12 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         '-v',
+        metavar=Metavar.int,
         type=int,
-        help='Verbose.',
-        required=False,
+        choices=(0, 1),
         default=1,
-        choices=(0, 1))
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -110,7 +111,7 @@ if __name__ == "__main__":
     fname_input2 = arguments.d
 
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     tmp_dir = sct.tmp_create(verbose=verbose)  # create tmp directory
     tmp_dir = os.path.abspath(tmp_dir)

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -86,12 +86,13 @@ def get_parser():
         required=False,
         default='dti_')
     optional.add_argument(
-        "-v",
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        required=False,
+        choices=(0, 1),
         default=param.verbose,
-        choices=(0, 1, 2))
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -114,7 +115,7 @@ def main(args=None):
     if arguments.m is not None:
         file_mask = arguments.m
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # compute DTI
     if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -135,11 +135,14 @@ def get_parser():
         help="Remove temporary files. 0 = no, 1 = yes"
     )
     optional.add_argument(
-        "-v",
-        choices=('0', '1', '2'),
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expanded",
+        '-v',
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
+
     return parser
 
 
@@ -162,10 +165,10 @@ def main():
     param.remove_temp_files = arguments.r
     if arguments.param is not None:
         param.update(arguments.param)
-    param.verbose = int(arguments.v)
+    param.verbose = arguments.v
 
     # Update log level
-    sct.init_sct(log_level=param.verbose, update=True)
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # run moco
     moco_wrapper(param)

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -105,9 +105,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=('0', '1'),
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
         default=param_default.verbose,
-        help='Verbose. 0 = nothing, 1 = expanded',
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     return parser
 
@@ -127,8 +129,8 @@ def main(args=None):
     fname_data = arguments.i
     fname_bvecs = arguments.bvec
     average = arguments.a
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     remove_temp_files = arguments.r
     path_out = arguments.ofolder
 

--- a/scripts/sct_dmri_transpose_bvecs.py
+++ b/scripts/sct_dmri_transpose_bvecs.py
@@ -66,9 +66,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = basic, 2 = extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -86,8 +88,8 @@ def main(args=None):
 
     fname_in = arguments.bvec
     fname_out = arguments.o
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # get bvecs in proper orientation
     from dipy.io import read_bvals_bvecs

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -57,9 +57,11 @@ def get_parser(dict_url):
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -153,8 +155,8 @@ def main(args=None):
         arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     data_name = arguments.d
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     if arguments.o is not None:
         dest_folder = arguments.o
     else:

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -204,9 +204,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=("0", "1"),
-        default="1",
-        help="Verbose. 0 = nothing, 1 = expanded"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     advanced = parser.add_argument_group("\nFOR ADVANCED USERS")
@@ -410,8 +412,8 @@ if __name__ == "__main__":
     fname_output_metric_map = arguments.output_map  # TODO: Not used. Why?
     fname_mask_weight = arguments.mask_weighted  # TODO: Not used. Why?
     discard_negative_values = int(arguments.discard_neg_val)  # TODO: Not used. Why?
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # call main function
     main(fname_data=fname_data, path_label=path_label, method=method, slices=parse_num_list(slices_of_interest),

--- a/scripts/sct_flatten_sagittal.py
+++ b/scripts/sct_flatten_sagittal.py
@@ -137,9 +137,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default=str(param_default.verbose),
-        help="Verbosity. 0: no verbose (default), 1: min verbose, 2: verbose + figures"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=param_default.verbose,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -155,8 +157,8 @@ if __name__ == "__main__":
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     fname_anat = arguments.i
     fname_centerline = arguments.s
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # call main function
     main(fname_anat, fname_centerline, verbose)

--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -91,9 +91,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbosity. 0: None, 1: Verbose"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     optional.add_argument(
         '-o',
@@ -118,8 +120,8 @@ def main(args=None):
     else:
         fname_dst = sct.add_suffix(fname_src, "_tsnr")
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # call main function
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -111,9 +111,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = basic, 2 = extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -137,10 +139,10 @@ def main():
         param.fname_mask = arguments.m
     if arguments.param is not None:
         param.update(arguments.param)
-    param.verbose = int(arguments.v)
+    param.verbose = arguments.v
 
     # Update log level
-    sct.init_sct(log_level=param.verbose, update=True)
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # run moco
     moco_wrapper(param)

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -95,10 +95,12 @@ def get_parser():
         help="File name of ground-truth centerline or segmentation (binary nifti)."
     )
     optional.add_argument(
-        "-v",
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 1: display on, 0: display off (default)"
+        '-v',
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     optional.add_argument(
         "-qc",
@@ -154,8 +156,8 @@ def run_main():
         path_data, file_data, ext_data = sct.extract_fname(fname_data)
         file_output = os.path.join(path_data, file_data + '_centerline')
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     if method == 'viewer':
         # Manual labeling of cord centerline

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -152,11 +152,12 @@ def get_parser():
     misc = parser.add_argument_group('Misc')
     misc.add_argument(
         '-v',
+        metavar=Metavar.int,
         type=int,
-        help='Verbose. 0: nothing. 1: basic. 2: extended.',
-        required=False,
+        choices=(0, 1),
         default=1,
-        choices=(0, 1, 2))
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -179,7 +180,7 @@ def main(args=None):
     fname_in = arguments.i
     n_in = len(fname_in)
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     if arguments.o is not None:
         fname_out = arguments.o

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -41,7 +41,7 @@ class Param:
         self.fname_label_output = 'labels.nii.gz'
         self.labels = []
         self.cross_size = 5  # cross size in mm
-        self.verbose = '1'
+        self.verbose = 1
 
 
 class ProcessLabels(object):
@@ -817,9 +817,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
         default=param_default.verbose,
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     optional.add_argument(
         '-qc',
@@ -919,8 +921,8 @@ def main(args=None):
         input_fname_previous = arguments.ilabel
     else:
         input_fname_previous = None
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     processor = ProcessLabels(input_filename, fname_output=input_fname_output, fname_ref=input_fname_ref,
                               cross_radius=input_cross_radius, dilate=input_dilate, coordinates=input_coordinates,

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -196,9 +196,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     optional.add_argument(
         '-qc',
@@ -267,8 +269,8 @@ def main(args=None):
         fname_initlabel = os.path.abspath(arguments.initlabel)
     if arguments.param is not None:
         param.update(arguments.param[0])
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     remove_temp_files = int(arguments.r)
     denoise = int(arguments.denoise)
     laplacian = int(arguments.laplacian)

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -495,7 +495,7 @@ def compute_similarity(img1: Image, img2: Image, fname_out: str, metric: str, me
 
     res, data1_1d, data2_1d = sct_math.compute_similarity(img1.data, img2.data, metric=metric)
 
-    if verbose > 1:
+    if verbose:
         matplotlib.use('Agg')
         plt.plot(data1_1d, 'b')
         plt.plot(data2_1d, 'r')

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -224,12 +224,13 @@ def get_parser():
         choices=('uint8', 'int16', 'int32', 'float32', 'complex64', 'float64', 'int8', 'uint16', 'uint32', 'int64',
                  'uint64'))
     misc.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
-        required=False,
+        choices=(0, 1),
         default=1,
-        choices=(0, 1, 2))
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -252,7 +253,7 @@ def main(args=None):
     fname_in = arguments.i
     fname_out = arguments.o
     verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=2 if verbose else 1, update=True)
     if '-type' in arguments:
         output_type = arguments.type
     else:

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -102,12 +102,13 @@ def get_parser():
         default = Param().rm_tmp,
         choices = (0, 1))
     misc.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default = str(Param().verbose))
+        choices=(0, 1),
+        default=Param().verbose,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -212,7 +213,7 @@ def main():
     if arguments.r is not None:
         param.rm_tmp = arguments.r
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # check if list of input files and warping fields have same length
     assert len(list_fname_src) == len(list_fname_warp), "ERROR: list of files are not of the same length"

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -172,9 +172,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbosity. 1: display on, 0: display off (default)"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -312,8 +314,8 @@ def main(args=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # update fields
     metrics_agg = {}

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -450,7 +450,7 @@ def propseg(img_input, options_dict):
     verbose = arguments.v
     sct.init_sct(log_level=2 if verbose else 1, update=True)
     # Update for propseg binary
-    if verbose > 0:
+    if verbose:
         cmd += ["-verbose"]
 
     # Output options

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -222,9 +222,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 1: display on, 0: display off (default)"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     optional.add_argument(
         '-mesh',
@@ -445,8 +447,8 @@ def propseg(img_input, options_dict):
     if arguments.r is not None:
         remove_temp_files = int(arguments.r)
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     # Update for propseg binary
     if verbose > 0:
         cmd += ["-verbose"]

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -58,8 +58,12 @@ def get_parser():
                              'was run on',
                         required=False)
     parser.add_argument('-v',
-                        action='store_true',
-                        help="Verbose")
+                        metavar='INT',
+                        type=int,
+                        choices=(0, 1),
+                        default=1,
+                        help="Enable verbose output. 0 = off, 1 = on.",
+                        required=False)
     return parser
 
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -238,9 +238,11 @@ def get_parser(paramregmulti=None):
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing, 1: basic, 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
     return parser
 
@@ -331,8 +333,8 @@ def main(args=None):
     identity = int(arguments.identity)
     interp = arguments.x
     remove_temp_files = int(arguments.r)
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # sct.printv(arguments)
     sct.printv('\nInput parameters:')

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -274,9 +274,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
         default=param.verbose,
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -321,8 +323,8 @@ def main(args=None):
     contrast_template = arguments.c
     ref = arguments.ref
     param.remove_temp_files = int(arguments.r)
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both
     param_centerline = ParamCenterline(
         algo_fitting=arguments.centerline_algo,

--- a/scripts/sct_resample.py
+++ b/scripts/sct_resample.py
@@ -104,9 +104,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended."
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -145,8 +147,8 @@ def run_main():
             param.interpolation = int(arguments.x)
         else:
             param.interpolation = arguments.x
-    param.verbose = int(arguments.v)
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    param.verbose = arguments.v
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
                                                param.interpolation, param.verbose, fname_ref=param.ref)

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -107,9 +107,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -133,8 +135,8 @@ def main(args=None):
         sigma = arguments.smooth
     if arguments.r is not None:
         remove_temp_files = int(arguments.r)
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Display arguments
     sct.printv('\nCheck input arguments...')
@@ -216,7 +218,7 @@ def main(args=None):
     sct_maths.main(args=['-i', 'anat_rpi_straight.nii',
                          '-smooth', sigma_smooth,
                          '-o', 'anat_rpi_straight_smooth.nii',
-                         '-v', '0'])
+                         '-v', 0])
     # Apply the reversed warping field to get back the curved spinal cord
     sct.printv('\nApply the reversed warping field to get back the curved spinal cord...')
     sct.run(['sct_apply_transfo', '-i', 'anat_rpi_straight_smooth.nii', '-o', 'anat_rpi_straight_smooth_curved.nii', '-d', 'anat.nii', '-w', 'warp_straight2curve.nii.gz', '-x', 'spline'], verbose)

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -184,12 +184,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
+    )
 
     return parser
 
@@ -236,7 +237,7 @@ def main(args=None):
     sc_straight.path_output = arguments.ofolder
     path_qc = arguments.qc
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     sc_straight.verbose = verbose
 
     # if "-cpu-nb" in arguments:

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -224,7 +224,7 @@ def main(args=None):
     jobs = arguments.jobs
 
     param.verbose = arguments.verbose
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     start_time = time.time()
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -242,7 +242,7 @@ def which_sct_binaries():
 
 
 def run(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_binary=False):
-    # if verbose == 2:
+    # if verbose:
     #     printv(sys._getframe().f_back.f_code.co_name, 1, 'process')
 
     if cwd is None:
@@ -296,7 +296,7 @@ def run(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_binary=
         if output == '' and process.poll() is not None:
             break
         if output:
-            if verbose == 2:
+            if verbose:
                 printv(output.strip())
             output_final += output.strip() + '\n'
 

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -212,9 +212,11 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic"
+        metavar=Metavar.int,
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Enable verbose output. 0 = off, 1 = on.",
     )
 
     return parser
@@ -232,8 +234,8 @@ def main(args=None):
     warp_spinal_levels = int(arguments.s)
     folder_out = arguments.ofolder
     path_template = arguments.t
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     path_qc = arguments.qc
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject


### PR DESCRIPTION
### Related PRs/issues

Fixes #2676.

### Description

* Standardizes `-v` options to use integer 0/1 which switches between INFO/DEBUG (instead of string 0/1/2 as was before)
* Corrects usage of verbose in sct.run/main() calls
* Combines numerical checks for verbose=1/2, e.g. `if verbose == "2"`, `if verbose > 1`, etc. become `if verbose:`