### PR TITLE
Update CLI argparse verbosity to use `-v` instead of `-v 0/1/2`

### DIFF
--- a/dev/atlas/validate_atlas/validate_atlas.py
+++ b/dev/atlas/validate_atlas/validate_atlas.py
@@ -200,7 +200,7 @@ def validate_atlas(folder_cropped_atlas, nb_bootstraps, std_noise, range_tract, 
                             index_manual = int(list_methods[i_method][list_methods[i_method].find('man')+3])
                             fname_mask = mask_folder[index_manual] + mask_prefix + list_tracts_txt[i_tract] + mask_ext
                             # manual extraction
-                            status, output = sct.run('sct_average_data_within_mask -i ' + fname_phantom_noise + ' -m ' + fname_mask + ' -v 0')
+                            status, output = sct.run('sct_average_data_within_mask -i ' + fname_phantom_noise + ' -m ' + fname_mask)
                             x_estim_i = float(output)
                         else:
                             # automatic extraction

--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -94,12 +94,10 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -548,7 +546,7 @@ def main(args=None):
 
     # Verbosity
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # create the Lesion constructor
     lesion_obj = AnalyzeLeion(fname_mask=fname_mask,

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -104,12 +104,10 @@ def get_parser():
         choices=(0, 1),
         default=int(Param().rm_tmp))
     optional.add_argument(
-        "-v",
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended.",
-        required=False,
-        type=int,
-        choices=(0, 1, 2),
-        default=Param().verbose)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -351,7 +349,7 @@ def main(args=None):
     if arguments.r is not None:
         param.rm_tmp = bool(arguments.r)
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # create the GLCM constructor
     glcm = ExtractGLCM(param=param, param_glcm=param_glcm)

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -107,12 +107,10 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
-        help="Verbose: 0: nothing, 1: classic, 2: expended.",
-        required=False,
-        type=int,
-        default=1,
-        choices=(0, 1, 2))
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -369,7 +367,7 @@ def main(args=None):
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = arguments.v
-    sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if transform.verbose else 1, update=True)
 
     transform.apply()
 

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -124,12 +124,10 @@ def get_parser():
         metavar=Metavar.str,
         default="ernst_angle.png")
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended (graph)",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -156,7 +154,7 @@ def main():
     if arguments.tr is not None:
         input_tr = arguments.tr
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     graph = ErnstAngle(input_t1, tr=input_tr, fname_output=input_fname_output)
     if input_tr is not None:

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -172,7 +172,7 @@ def main():
         except:
             sct.printv('\nERROR: Cannot open file'+fname_output_file, '1', 'error')
 
-    if verbose == 2:
+    if verbose:
         graph.draw(input_tr_min, input_tr_max)
 
 

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -484,12 +484,10 @@ def get_parser():
         required=False,
         default='hausdorff_distance.txt')
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -522,7 +520,7 @@ if __name__ == "__main__":
         if arguments.o is not None:
             output_fname = arguments.o
         param.verbose = arguments.v
-        sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+        sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
         tmp_dir = sct.tmp_create()
         im1_name = "im1.nii.gz"

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -264,7 +264,7 @@ class ComputeDistances:
         sct.printv('-----------------------------------------------------------------------------\n' +
                    self.res, self.param.verbose, 'normal')
 
-        if self.param.verbose == 2:
+        if self.param.verbose:
             self.show_results()
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -60,11 +60,9 @@ def get_parser():
         )
     optional.add_argument(
         '-v',
-        type=int,
-        choices=(0, 1, 2),
-        help='Verbose: 0 = nothing, 1 = classic, 2 = expended',
-        default=1
-        )
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
     optional.add_argument(
         '-o',
         help='Path to output file.',

--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -117,11 +117,10 @@ def get_parser(argv):
         help="Output file for T1map. Default is t1map.nii.gz",
         default=None)
     optional.add_argument(
-        "-v",
-        help="Verbose: 0 = no verbosity, 1 = verbose (default).",
-        type=int,
-        choices=(0, 1),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -168,7 +167,7 @@ def main(argv):
     parser = get_parser(argv)
     args = parser.parse_args(argv if argv else ['--help'])
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     sct.printv('Load data...', verbose)
     nii_mt = Image(args.mt)

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -82,10 +82,9 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         '-v',
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        type=int,
-        choices=(0, 1, 2),
-        default=1)
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -121,7 +120,7 @@ def main():
     else:
         index_vol_user = ''
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Check parameters
     if method == 'diff':

--- a/scripts/sct_concat_transfo.py
+++ b/scripts/sct_concat_transfo.py
@@ -54,7 +54,7 @@ def main(args=None):
     if arguments.o is not None:
         fname_warp_final = arguments.o
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Parse list of warping fields
     sct.printv('\nParse list of warping fields...', verbose)
@@ -170,12 +170,10 @@ def get_parser():
         metavar=Metavar.str,
         required = False)
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -112,12 +112,10 @@ def get_parser():
         default = 1,
         choices = (0, 1))
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended ",
-        required=False,
-        choices=(0, 1, 2),
-        default = 1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -151,7 +149,7 @@ def main(args=None):
         param.remove_temp_files = arguments.r
 
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # run main program
     create_mask(param)

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -213,7 +213,7 @@ def create_mask(param):
         # extract coordinate of point
         sct.printv('\nExtract coordinate of point...', param.verbose)
         # TODO: change this way to remove dependence to sct.run. ProcessLabels.display_voxel returns list of coordinates
-        status, output = sct.run(['sct_label_utils', '-i', 'point_RPI.nii', '-display'], verbose=param.verbose)
+        status, output = sct.run(['sct_label_utils', '-i', 'point_RPI.nii', '-display', '-v'], verbose=param.verbose)
         # parse to get coordinate
         # TODO fixup... this is quite magic
         coord = output[output.find('Position=') + 10:-17].split(',')

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -129,11 +129,9 @@ def get_parser():
         metavar=Metavar.int,
         )
     optional.add_argument(
-        "-v",
-        type=int,
-        help="0: Verbose off | 1: Verbose on",
-        choices=(0, 1),
-        default=1
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -154,7 +152,7 @@ def main(args=None):
     # initialize ImageCropper
     cropper = ImageCropper(Image(arguments.i))
     cropper.verbose = arguments.v
-    sct.init_sct(log_level=cropper.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if cropper.verbose else 1)
 
     # Switch across cropping methods
     if arguments.g:

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -101,11 +101,10 @@ def get_parser():
 
     misc = parser.add_argument_group('\nMISC')
     misc.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = no verbosity, 1 = verbose.",
-        choices=(0, 1),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
     misc.add_argument(
         "-h",
         "--help",

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -85,11 +85,10 @@ def get_parser():
              "provides non-deterministic results.",
         metavar='')
     misc.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = no verbosity, 1 = verbose.",
-        choices=(0, 1),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -107,7 +106,7 @@ def run_main():
     model_name = arguments.m
     threshold = arguments.thr
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     if threshold > 1.0 or threshold < 0.0:
         raise RuntimeError("Threshold should be between 0.0 and 1.0.")

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -97,11 +97,10 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
-        type=int,
-        help="1: Display on (default), 0: Display off, 2: Extended",
-        choices=(0, 1, 2),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
     optional.add_argument(
         '-igt',
         metavar=Metavar.str,
@@ -139,7 +138,7 @@ def main():
 
     remove_temp_files = args.r
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     algo_config_stg = '\nMethod:'
     algo_config_stg += '\n\tCenterline algorithm: ' + str(ctr_algo)

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -163,7 +163,7 @@ def main():
                                                sct.extract_fname(fname_image)[2]))
         im_labels_viewer.save(fname_labels)
 
-    if verbose == 2:
+    if verbose:
         # Save ctr
         fname_ctr = os.path.abspath(os.path.join(output_folder, sct.extract_fname(fname_image)[1] + '_centerline' +
                                                sct.extract_fname(fname_image)[2]))

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -98,11 +98,10 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
-        type=int,
-        help="1: display on (default), 0: display off, 2: extended",
-        choices=(0, 1, 2),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
     optional.add_argument(
         '-qc',
         metavar=Metavar.str,
@@ -169,7 +168,7 @@ def main():
 
     remove_temp_files = args.r
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     path_qc = args.qc
     qc_dataset = args.qc_dataset

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -145,7 +145,7 @@ def main(file_to_denoise, param, output_file_name) :
     if arguments.std is None:
         difference[~mask[:, :, axial_middle].T] = 0
 
-    if param.verbose == 2:
+    if param.verbose:
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots(1, 3)
         ax[0].imshow(before, cmap='gray', origin='lower')

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -82,11 +82,10 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
-        type=int,
-        default=1,
-        choices=(0, 1, 2))
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -187,7 +186,7 @@ if __name__ == "__main__":
     remove_temp_files = arguments.r
     noise_threshold = arguments.d
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     file_to_denoise = arguments.i
     output_file_name = arguments.o

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -92,12 +92,10 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -293,7 +291,7 @@ def main():
     rm_tmp = bool(arguments.r)
 
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Initialize DetectPMJ
     detector = DetectPMJ(fname_im=fname_in,

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -93,11 +93,9 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         '-v',
-        type=int,
-        help='Verbose.',
-        required=False,
-        default=1,
-        choices=(0, 1))
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -110,7 +108,7 @@ if __name__ == "__main__":
     fname_input2 = arguments.d
 
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     tmp_dir = sct.tmp_create(verbose=verbose)  # create tmp directory
     tmp_dir = os.path.abspath(tmp_dir)

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -86,12 +86,10 @@ def get_parser():
         required=False,
         default='dti_')
     optional.add_argument(
-        "-v",
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
-        type=int,
-        required=False,
-        default=param.verbose,
-        choices=(0, 1, 2))
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -114,7 +112,7 @@ def main(args=None):
     if arguments.m is not None:
         file_mask = arguments.m
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # compute DTI
     if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -135,11 +135,11 @@ def get_parser():
         help="Remove temporary files. 0 = no, 1 = yes"
     )
     optional.add_argument(
-        "-v",
-        choices=('0', '1', '2'),
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expanded",
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
+
     return parser
 
 
@@ -162,10 +162,10 @@ def main():
     param.remove_temp_files = arguments.r
     if arguments.param is not None:
         param.update(arguments.param)
-    param.verbose = int(arguments.v)
+    param.verbose = arguments.v
 
     # Update log level
-    sct.init_sct(log_level=param.verbose, update=True)
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # run moco
     moco_wrapper(param)

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -105,9 +105,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=('0', '1'),
-        default=param_default.verbose,
-        help='Verbose. 0 = nothing, 1 = expanded',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     return parser
 
@@ -127,8 +126,8 @@ def main(args=None):
     fname_data = arguments.i
     fname_bvecs = arguments.bvec
     average = arguments.a
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     remove_temp_files = arguments.r
     path_out = arguments.ofolder
 

--- a/scripts/sct_dmri_transpose_bvecs.py
+++ b/scripts/sct_dmri_transpose_bvecs.py
@@ -66,9 +66,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = basic, 2 = extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -86,8 +85,8 @@ def main(args=None):
 
     fname_in = arguments.bvec
     fname_out = arguments.o
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # get bvecs in proper orientation
     from dipy.io import read_bvals_bvecs

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -57,9 +57,8 @@ def get_parser(dict_url):
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -153,8 +152,8 @@ def main(args=None):
         arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     data_name = arguments.d
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     if arguments.o is not None:
         dest_folder = arguments.o
     else:

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -204,9 +204,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=("0", "1"),
-        default="1",
-        help="Verbose. 0 = nothing, 1 = expanded"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     advanced = parser.add_argument_group("\nFOR ADVANCED USERS")
@@ -410,8 +409,8 @@ if __name__ == "__main__":
     fname_output_metric_map = arguments.output_map  # TODO: Not used. Why?
     fname_mask_weight = arguments.mask_weighted  # TODO: Not used. Why?
     discard_negative_values = int(arguments.discard_neg_val)  # TODO: Not used. Why?
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # call main function
     main(fname_data=fname_data, path_label=path_label, method=method, slices=parse_num_list(slices_of_interest),

--- a/scripts/sct_flatten_sagittal.py
+++ b/scripts/sct_flatten_sagittal.py
@@ -137,9 +137,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default=str(param_default.verbose),
-        help="Verbosity. 0: no verbose (default), 1: min verbose, 2: verbose + figures"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -155,8 +154,8 @@ if __name__ == "__main__":
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     fname_anat = arguments.i
     fname_centerline = arguments.s
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # call main function
     main(fname_anat, fname_centerline, verbose)

--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -91,9 +91,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbosity. 0: None, 1: Verbose"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     optional.add_argument(
         '-o',
@@ -118,8 +117,8 @@ def main(args=None):
     else:
         fname_dst = sct.add_suffix(fname_src, "_tsnr")
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # call main function
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -111,9 +111,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = basic, 2 = extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -137,10 +136,10 @@ def main():
         param.fname_mask = arguments.m
     if arguments.param is not None:
         param.update(arguments.param)
-    param.verbose = int(arguments.v)
+    param.verbose = arguments.v
 
     # Update log level
-    sct.init_sct(log_level=param.verbose, update=True)
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # run moco
     moco_wrapper(param)

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -95,10 +95,9 @@ def get_parser():
         help="File name of ground-truth centerline or segmentation (binary nifti)."
     )
     optional.add_argument(
-        "-v",
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 1: display on, 0: display off (default)"
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     optional.add_argument(
         "-qc",
@@ -154,8 +153,8 @@ def run_main():
         path_data, file_data, ext_data = sct.extract_fname(fname_data)
         file_output = os.path.join(path_data, file_data + '_centerline')
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     if method == 'viewer':
         # Manual labeling of cord centerline

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -152,11 +152,9 @@ def get_parser():
     misc = parser.add_argument_group('Misc')
     misc.add_argument(
         '-v',
-        type=int,
-        help='Verbose. 0: nothing. 1: basic. 2: extended.',
-        required=False,
-        default=1,
-        choices=(0, 1, 2))
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -179,7 +177,7 @@ def main(args=None):
     fname_in = arguments.i
     n_in = len(fname_in)
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     if arguments.o is not None:
         fname_out = arguments.o

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -817,9 +817,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default=param_default.verbose,
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     optional.add_argument(
         '-qc',
@@ -919,8 +918,8 @@ def main(args=None):
         input_fname_previous = arguments.ilabel
     else:
         input_fname_previous = None
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     processor = ProcessLabels(input_filename, fname_output=input_fname_output, fname_ref=input_fname_ref,
                               cross_radius=input_cross_radius, dilate=input_dilate, coordinates=input_coordinates,

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -196,9 +196,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     optional.add_argument(
         '-qc',
@@ -267,8 +266,8 @@ def main(args=None):
         fname_initlabel = os.path.abspath(arguments.initlabel)
     if arguments.param is not None:
         param.update(arguments.param[0])
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     remove_temp_files = int(arguments.r)
     denoise = int(arguments.denoise)
     laplacian = int(arguments.laplacian)

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -299,12 +299,14 @@ def main(args=None):
         # apply straightening
         s, o = sct.run(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
     else:
-        sct_straighten_spinalcord.main(args=[
+        args = [
             '-i', 'data.nii',
             '-s', 'segmentation.nii',
             '-r', str(remove_temp_files),
-            '-v', str(verbose),
-        ])
+        ]
+        if verbose:
+            args.append('-v')
+        sct_straighten_spinalcord.main(args)
         sct.cache_save(cachefile, cache_sig)
 
     # resample to 0.5mm isotropic to match template resolution

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -224,12 +224,10 @@ def get_parser():
         choices=('uint8', 'int16', 'int32', 'float32', 'complex64', 'float64', 'int8', 'uint16', 'uint32', 'int64',
                  'uint64'))
     misc.add_argument(
-        "-v",
-        type=int,
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
-        required=False,
-        default=1,
-        choices=(0, 1, 2))
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -252,7 +250,7 @@ def main(args=None):
     fname_in = arguments.i
     fname_out = arguments.o
     verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=2 if verbose else 1, update=True)
     if '-type' in arguments:
         output_type = arguments.type
     else:

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -492,7 +492,7 @@ def compute_similarity(img1: Image, img2: Image, fname_out: str, metric: str, me
 
     res, data1_1d, data2_1d = sct_math.compute_similarity(img1.data, img2.data, metric=metric)
 
-    if verbose > 1:
+    if verbose:
         matplotlib.use('Agg')
         plt.plot(data1_1d, 'b')
         plt.plot(data2_1d, 'r')

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -102,12 +102,10 @@ def get_parser():
         default = Param().rm_tmp,
         choices = (0, 1))
     misc.add_argument(
-        "-v",
-        type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default = str(Param().verbose))
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -212,7 +210,7 @@ def main():
     if arguments.r is not None:
         param.rm_tmp = arguments.r
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     # check if list of input files and warping fields have same length
     assert len(list_fname_src) == len(list_fname_warp), "ERROR: list of files are not of the same length"

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -148,13 +148,16 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
     for fname_src in list_fname_src:
 
         # apply transformation src --> dest
-        sct_apply_transfo.main(args=[
+        args = [
             '-i', fname_src,
             '-d', fname_dest,
             '-w', list_fname_warp[i_file],
             '-x', param.interp,
             '-o', 'src_' + str(i_file) + '_template.nii.gz',
-            '-v', str(param.verbose)])
+        ]
+        if param.verbose:
+            args.append('-v')
+        sct_apply_transfo.main(args)
         # create binary mask from input file by assigning one to all non-null voxels
         sct_maths.main(args=[
             '-i', fname_src,

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -172,9 +172,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbosity. 1: display on, 0: display off (default)"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -312,8 +311,8 @@ def main(args=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # update fields
     metrics_agg = {}

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -447,7 +447,7 @@ def propseg(img_input, options_dict):
     verbose = arguments.v
     sct.init_sct(log_level=2 if verbose else 1, update=True)
     # Update for propseg binary
-    if verbose > 0:
+    if verbose:
         cmd += ["-verbose"]
 
     # Output options

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -60,8 +60,8 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_
     im_input = Image('tmp.segmentation.nii.gz')
     image_input_orientation = im_input.orientation
 
-    sct_image.main("-i tmp.segmentation.nii.gz -setorient RPI -o tmp.segmentation_RPI.nii.gz -v 0".split())
-    sct_image.main("-i tmp.centerline.nii.gz -setorient RPI -o tmp.centerline_RPI.nii.gz -v 0".split())
+    sct_image.main("-i tmp.segmentation.nii.gz -setorient RPI -o tmp.segmentation_RPI.nii.gz".split())
+    sct_image.main("-i tmp.centerline.nii.gz -setorient RPI -o tmp.centerline_RPI.nii.gz".split())
 
     # go through segmentation image, and compare with centerline from propseg
     im_seg = Image('tmp.segmentation_RPI.nii.gz')
@@ -132,7 +132,7 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_
     im_seg.save('tmp.segmentation_RPI_c.nii.gz')
 
     # replacing old segmentation with the corrected one
-    sct_image.main('-i tmp.segmentation_RPI_c.nii.gz -setorient {} -o {} -v 0'.
+    sct_image.main('-i tmp.segmentation_RPI_c.nii.gz -setorient {} -o {}'.
                    format(image_input_orientation, fname_seg_absolute).split())
 
     os.chdir(curdir)

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -222,9 +222,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 1: display on, 0: display off (default)"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     optional.add_argument(
         '-mesh',
@@ -445,8 +444,8 @@ def propseg(img_input, options_dict):
     if arguments.r is not None:
         remove_temp_files = int(arguments.r)
 
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     # Update for propseg binary
     if verbose > 0:
         cmd += ["-verbose"]

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -57,9 +57,11 @@ def get_parser():
                         help='If provided, this string will be mentioned in the QC report as the subject the process '
                              'was run on',
                         required=False)
-    parser.add_argument('-v',
-                        action='store_true',
-                        help="Verbose")
+    parser.add_argument(
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
     return parser
 
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -238,9 +238,8 @@ def get_parser(paramregmulti=None):
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing, 1: basic, 2: extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
     return parser
 
@@ -331,8 +330,8 @@ def main(args=None):
     identity = int(arguments.identity)
     interp = arguments.x
     remove_temp_files = int(arguments.r)
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # sct.printv(arguments)
     sct.printv('\nInput parameters:')

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -849,7 +849,7 @@ def resample_labels(fname_labels, fname_dest, fname_output):
         label_new_list.append(','.join(label_sub_new))
     label_new_list = ':'.join(label_new_list)
     # create new labels
-    sct.run(['sct_label_utils', '-i', fname_dest, '-create', label_new_list, '-v', '1', '-o', fname_output])
+    sct.run(['sct_label_utils', '-i', fname_dest, '-create', label_new_list, '-o', fname_output])
 
 
 def check_labels(fname_landmarks, label_type='body'):

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -274,9 +274,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default=param.verbose,
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -321,8 +320,8 @@ def main(args=None):
     contrast_template = arguments.c
     ref = arguments.ref
     param.remove_temp_files = int(arguments.r)
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both
     param_centerline = ParamCenterline(
         algo_fitting=arguments.centerline_algo,

--- a/scripts/sct_resample.py
+++ b/scripts/sct_resample.py
@@ -104,9 +104,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended."
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -145,8 +144,8 @@ def run_main():
             param.interpolation = int(arguments.x)
         else:
             param.interpolation = arguments.x
-    param.verbose = int(arguments.v)
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    param.verbose = arguments.v
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
                                                param.interpolation, param.verbose, fname_ref=param.ref)

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -214,8 +214,7 @@ def main(args=None):
     sigma_smooth = ",".join([str(i) for i in sigma])
     sct_maths.main(args=['-i', 'anat_rpi_straight.nii',
                          '-smooth', sigma_smooth,
-                         '-o', 'anat_rpi_straight_smooth.nii',
-                         '-v', '0'])
+                         '-o', 'anat_rpi_straight_smooth.nii'])
     # Apply the reversed warping field to get back the curved spinal cord
     sct.printv('\nApply the reversed warping field to get back the curved spinal cord...')
     sct.run(['sct_apply_transfo', '-i', 'anat_rpi_straight_smooth.nii', '-o', 'anat_rpi_straight_smooth_curved.nii', '-d', 'anat.nii', '-w', 'warp_straight2curve.nii.gz', '-x', 'spline'], verbose)

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -107,9 +107,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -133,8 +132,8 @@ def main(args=None):
         sigma = arguments.smooth
     if arguments.r is not None:
         remove_temp_files = int(arguments.r)
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
 
     # Display arguments
     sct.printv('\nCheck input arguments...')

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -184,12 +184,10 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
-        type=int,
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        '-v',
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
+    )
 
     return parser
 
@@ -236,7 +234,7 @@ def main(args=None):
     sc_straight.path_output = arguments.ofolder
     path_qc = arguments.qc
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     sc_straight.verbose = verbose
 
     # if "-cpu-nb" in arguments:

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -224,7 +224,7 @@ def main(args=None):
     jobs = arguments.jobs
 
     param.verbose = arguments.verbose
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    sct.init_sct(log_level=2 if param.verbose else 1, update=True)
 
     start_time = time.time()
 

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -242,7 +242,7 @@ def which_sct_binaries():
 
 
 def run(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_binary=False):
-    # if verbose == 2:
+    # if verbose:
     #     printv(sys._getframe().f_back.f_code.co_name, 1, 'process')
 
     if cwd is None:
@@ -296,7 +296,7 @@ def run(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_binary=
         if output == '' and process.poll() is not None:
             break
         if output:
-            if verbose == 2:
+            if verbose:
                 printv(output.strip())
             output_final += output.strip() + '\n'
 

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -212,9 +212,8 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic"
+        action="store_true",
+        help="Increase verbosity. Setting this option will enable showing DEBUG messages.",
     )
 
     return parser
@@ -232,8 +231,8 @@ def main(args=None):
     warp_spinal_levels = int(arguments.s)
     folder_out = arguments.ofolder
     path_template = arguments.t
-    verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    verbose = arguments.v
+    sct.init_sct(log_level=2 if verbose else 1, update=True)
     path_qc = arguments.qc
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject

--- a/spinalcordtoolbox/centerline/core.py
+++ b/spinalcordtoolbox/centerline/core.py
@@ -205,7 +205,7 @@ def get_centerline(im_seg, param=ParamCenterline(), verbose=1):
     fit_results.param = param
 
     # Display fig of fitted curves
-    if verbose == 2:
+    if verbose:
         from datetime import datetime
         import matplotlib
         matplotlib.use('Agg')  # prevent display figure

--- a/spinalcordtoolbox/centerline/nurbs.py
+++ b/spinalcordtoolbox/centerline/nurbs.py
@@ -1091,7 +1091,7 @@ def b_spline_nurbs(x, y, z, fname_centerline=None, degree=3, point_number=3000, 
     y_deriv = x_fit[::-1]
     z_deriv = x_fit[::-1]"""
 
-    if verbose == 2:
+    if verbose:
         # TODO qc
         PC = nurbs.getControle()
         PC_x = [p[0] for p in PC]

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -236,7 +236,7 @@ def deep_segmentation_MSlesion(im_image, contrast_type, ctr_algo='svm', ctr_file
     else:
         im_viewer = None
 
-    if verbose == 2:
+    if verbose:
         fname_res_ctr = sct.add_suffix(fname_orient, '_ctr')
         resampling.resample_file(fname_res_ctr, fname_res_ctr, initial_resolution,
                                                            'mm', 'linear', verbose=0)

--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -375,7 +375,7 @@ def moco_wrapper(param):
     # Average across time
     if param.is_diffusion:
         # generate b0_moco_mean and dwi_moco_mean
-        args = ['-i', im_moco.absolutepath, '-bvec', param.fname_bvecs, '-a', '1', '-v', '0']
+        args = ['-i', im_moco.absolutepath, '-bvec', param.fname_bvecs, '-a', '1']
         if not param.fname_bvals == '':
             # if bvals file is provided
             args += ['-bval', param.fname_bvals]
@@ -754,8 +754,7 @@ def register(param, file_src, file_dest, file_mat, file_out, im_mask=None):
                                      '-d', file_dest,
                                      '-w', file_mat + param.suffix_mat,
                                      '-o', file_out_concat,
-                                     '-x', param.interp,
-                                     '-v', '0'])
+                                     '-x', param.interp])
 
     # check if output file exists
     # Note (from JCA): In the past, i've tried to catch non-zero output from ANTs function (via the 'status' variable),

--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -747,7 +747,7 @@ def register(param, file_src, file_dest, file_mat, file_out, im_mask=None):
             kw.update(dict(is_sct_binary=True))
             # reducing the number of CPU used for moco (see issue #201 and #2642)
             env = {**os.environ, **{"ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS": "1"}}
-            status, output = sct.run(cmd, verbose=1 if param.verbose == 2 else 0, env=env, **kw)
+            status, output = sct.run(cmd, param.verbose, env=env, **kw)
 
     elif param.todo == 'apply':
         sct_apply_transfo.main(args=['-i', file_src,

--- a/spinalcordtoolbox/registration/landmarks.py
+++ b/spinalcordtoolbox/registration/landmarks.py
@@ -255,7 +255,7 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
     logger.info(f"Center:\n {points_src_barycenter}")
     logger.info(f"Translation:\n {translation_array}")
 
-    if verbose == 2 and path_qc is not None:
+    if verbose and path_qc is not None:
         create_folder(path_qc)
 
         import matplotlib

--- a/spinalcordtoolbox/registration/register.py
+++ b/spinalcordtoolbox/registration/register.py
@@ -441,7 +441,7 @@ def register2d_centermassrot(fname_src, fname_dest, paramreg=None, fname_warp='w
     """
     # TODO: no need to split the src or dest if it is the template (we know its centerline and orientation already)
 
-    if verbose == 2:
+    if verbose:
         import matplotlib
         matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
@@ -580,7 +580,7 @@ def register2d_centermassrot(fname_src, fname_dest, paramreg=None, fname_warp='w
     if not filter_size == 0 and (rot_method in ['pca', 'hog', 'pcahog']):
         # Filtering the angles by gaussian filter
         angle_src_dest_regularized = ndimage.filters.gaussian_filter1d(angle_src_dest[z_nonzero], filter_size)
-        if verbose == 2:
+        if verbose:
             plt.plot(180 * angle_src_dest[z_nonzero] / np.pi, 'ob')
             plt.plot(180 * angle_src_dest_regularized / np.pi, 'r', linewidth=2)
             plt.grid()
@@ -619,7 +619,7 @@ def register2d_centermassrot(fname_src, fname_dest, paramreg=None, fname_warp='w
         # apply inverse transformation (in physical space)
         coord_inverse_phy = np.array(np.dot((coord_init_phy - np.transpose(centermass_src_phy)), R3d.T) + np.transpose(centermass_dest_phy))
         # display rotations
-        if verbose == 2 and not angle_src_dest[iz] == 0 and not rot_method == 'hog':
+        if verbose and not angle_src_dest[iz] == 0 and not rot_method == 'hog':
             # compute new coordinates
             coord_src_rot = coord_src[iz] * R
             coord_dest_rot = coord_dest[iz] * R.T
@@ -698,7 +698,7 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
     th_nonzero = 0.5  # values below are considered zero
 
     # for display stuff
-    if verbose == 2:
+    if verbose:
         import matplotlib
         matplotlib.use('Agg')  # prevent display figure
         import matplotlib.pyplot as plt
@@ -866,7 +866,7 @@ def register2d_columnwise(fname_src, fname_dest, fname_warp='warp_forward.nii.gz
             coord_init_pix_scaleY[:, 1] = col_scaleYsmooth.ravel()
             coord_init_pix_scaleYinv[:, 1] = col_scaleYinvsmooth.ravel()
             # display
-            if verbose == 2:
+            if verbose:
                 # FIG 1
                 plt.figure(figsize=(15, 3))
                 # plot #1

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -350,7 +350,7 @@ class SpinalCordStraightener(object):
             time_centerlines = time.time() - time_centerlines
             logger.info('Time to generate centerline: {} ms'.format(np.round(time_centerlines * 1000.0)))
 
-        if verbose == 2:
+        if verbose:
             # TODO: use OO
             import matplotlib.pyplot as plt
             from datetime import datetime

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -114,7 +114,7 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     sct.printv('Distances between discs (in voxel): ' + str(list_distance_template), verbose)
 
     # display init disc
-    if verbose == 2:
+    if verbose:
         from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
         from matplotlib.figure import Figure
         fig_disc = Figure()
@@ -164,7 +164,7 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
                                         zrange=zrange, verbose=verbose, save_suffix='_disc' + str(current_disc), gaussian_std=999, path_output=path_output)
 
         # display new disc
-        if verbose == 2:
+        if verbose:
             ax_disc.scatter(yc + param.shift_AP_visu, current_z, c='yellow', s=10)
             ax_disc.text(yc + param.shift_AP_visu + 4, current_z, str(current_disc) + '/' + str(current_disc + 1),
                     verticalalignment='center', horizontalalignment='left', color='yellow', fontsize=7)
@@ -225,7 +225,7 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
         if current_z <= 0:
             search_next_disc = False
 
-    if verbose == 2:
+    if verbose:
         fig_disc.savefig('fig_label_discs.png')
 
     # if upper disc is not 1, add disc above top disc based on mean_distance_adjusted
@@ -425,7 +425,7 @@ def compute_corr_3d(src, target, x, xshift, xsize, y, yshift, ysize, z, zshift, 
         ind_peak = zrange.index(0)  # approx_distance_to_next_disc
 
     # display patterns and correlation
-    if verbose == 2:
+    if verbose:
         from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
         from matplotlib.figure import Figure
         fig = Figure(figsize=(15, 7))
@@ -495,7 +495,7 @@ def label_segmentation(fname_seg, list_disc_z, list_disc_value, verbose=1):
         # get voxels in mask
         ind_nonzero = np.nonzero(seg.data[:, :, iz])
         seg.data[ind_nonzero[0], ind_nonzero[1], iz] = vertebral_level
-        # if verbose == 2:
+        # if verbose:
         #     # move to OO. No time to finish... (JCA)
         #     from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
         #     from matplotlib.figure import Figure

--- a/testing/sct_dmri_separate_b0_and_dwi/test_sct_dmri_separate_b0_and_dwi.sh
+++ b/testing/sct_dmri_separate_b0_and_dwi/test_sct_dmri_separate_b0_and_dwi.sh
@@ -38,7 +38,6 @@ for subject in $SUBJECT_LIST; do
         -b ../../data/${subject}/${contrast}/${file2}
         -a 1
 		-o ./
-        -v 1
         -r 0"
     echo ==============================================================================================
     echo "$cmd"

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -54,8 +54,7 @@ def test_integrity(param_test):
         '-d', param_test.file_seg,
         '-w', 'warp_template2anat.nii.gz',
         '-o', 'test_template2anat.nii.gz',
-        '-x', 'nn',
-        '-v', '0'])
+        '-x', 'nn'])
 
     # apply transformation to binary mask: anat --> template
     sct_apply_transfo.main(args=[
@@ -63,8 +62,7 @@ def test_integrity(param_test):
         '-d', param_test.fname_gt[index_args],
         '-w', 'warp_anat2template.nii.gz',
         '-o', 'test_anat2template.nii.gz',
-        '-x', 'nn',
-        '-v', '0'])
+        '-x', 'nn'])
 
     # compute dice coefficient between template segmentation warped to anat and segmentation from anat
     im_seg = Image(param_test.file_seg)

--- a/testing/test_sct_resample.py
+++ b/testing/test_sct_resample.py
@@ -25,9 +25,9 @@ def init(param_test):
     Initialize class: param_test
     """
     # initialization
-    default_args = ['-i dmri/dmri.nii.gz -f 0.5x0.5x1 -v 1 -o resampled.nii.gz',  # 4D, factor
-                    '-i t2/t2.nii.gz -mm 0.97x1.14x1.2 -v 1 -o resampled.nii.gz',  # 3D, mm
-                    '-i t2/t2.nii.gz -vox 120x110x26 -v 1 -o resampled.nii.gz'  # 3D, vox
+    default_args = ['-i dmri/dmri.nii.gz -f 0.5x0.5x1 -o resampled.nii.gz',  # 4D, factor
+                    '-i t2/t2.nii.gz -mm 0.97x1.14x1.2 -o resampled.nii.gz',  # 3D, mm
+                    '-i t2/t2.nii.gz -vox 120x110x26 -o resampled.nii.gz'  # 3D, vox
                     ]
 
     param_test.results_dims = [(20, 21, 5, 7, 1.6826923, 1.6826923, 17.5, 2.2),  # 4D, factor


### PR DESCRIPTION
### Related PRs/Issues

Fixes #2676 .

### Description

The `-v / -verbose` argument is currently handled inconsistently:
* In some scripts, the options are `0/1/2` (`WARNING/INFO/DEBUG`) with `default=1` (or `INFO`).
* In other scripts, the options are `0/1` (`WARNING/INFO`) with `default=1` (or `INFO`).

This PR changes all CLI scripts to use `action="store_true"` instead. This effect of this is:
* Verbosity is `False` (`INFO`) by default
* Verbosity is `True` (`DEBUG`) when `-v` is passed. 

The justification for this is:
* Using `-v` (without a value) is more conventional usage for UNIX CLI scripts.
* The lesser verbosity level (`WARNING`) might not be necessary for users, considering we use `INFO` by default.

### Remaining work

This PR preserves existing behavior wherever `sct.init_sct` is used to set the logging level:

https://github.com/neuropoly/spinalcordtoolbox/blob/ec2d01c1b0e31c63e8ffaad792b66ffbcf2139f0/scripts/sct_qc.py#L87

However, verbosity is _also_ used as-is in some places. (e.g. `param.verbose = arguments.v` then later `if param.verbose:`) This results in some nuanced behavior because the old way (0/1/2) doesn't map cleanly to the new way (False/True).

**For example:** Because the default was `1`, `if verbose:` would always be True. Now, the default is `False`, which causes issues in `sct.printv`, because `printv` doesn't use `sct.init_sct` and logging levels like everything else.

https://github.com/neuropoly/spinalcordtoolbox/blob/ec2d01c1b0e31c63e8ffaad792b66ffbcf2139f0/scripts/sct_utils.py#L798-L817

To fix this, there would need to be a more involved change.