### PR TITLE
Convert argparse '0'/'1' options to be typed as ints rather than strings

### DIFF
--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -105,8 +105,10 @@ def get_parser():
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Remove temporary files. O = no, 1 = yes"
     )
     optional.add_argument(
@@ -129,7 +131,7 @@ def main():
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     param.fname_data = arguments.i
     param.path_out = arguments.ofolder
-    param.remove_temp_files = int(arguments.r)
+    param.remove_temp_files = arguments.r
     param.interp = arguments.x
     if arguments.g is not None:
         param.group_size = arguments.g

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -154,15 +154,19 @@ def get_parser():
     )
     optional.add_argument(
         '-denoise',
-        choices=['0', '1'],
-        default='0',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=0,
         help="Apply denoising filter (non-local means adaptative denoising) to the data. Sometimes denoising is too "
              "aggressive, so use with care."
     )
     optional.add_argument(
         '-laplacian',
-        choices=['0', '1'],
-        default='0',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=0,
         help="Apply Laplacian filtering. More accurate but could mistake disc depending on anatomy."
     )
     optional.add_argument(
@@ -190,8 +194,10 @@ def get_parser():
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Remove temporary files."
     )
     optional.add_argument(
@@ -269,9 +275,9 @@ def main(args=None):
         param.update(arguments.param[0])
     verbose = int(arguments.v)
     sct.init_sct(log_level=verbose, update=True)  # Update log level
-    remove_temp_files = int(arguments.r)
-    denoise = int(arguments.denoise)
-    laplacian = int(arguments.laplacian)
+    remove_temp_files = arguments.r
+    denoise = arguments.denoise
+    laplacian = arguments.laplacian
 
     path_tmp = sct.tmp_create(basename="label_vertebrae", verbose=verbose)
 

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -128,14 +128,18 @@ def get_parser():
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Removes temporary folder used for the algorithm at the end of execution."
     )
     optional.add_argument(
         '-angle-corr',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Angle correction for computing morphometric measures. When angle correction is used, the cord within "
              "the slice is stretched/expanded by a factor corresponding to the cosine of the angle between the "
              "centerline and the axial plane. If the cord is already quasi-orthogonal to the slab, you can set "
@@ -278,15 +282,14 @@ def main(args=None):
     else:
         file_out = ''
     if arguments.append is not None:
-        append = int(arguments.append)
+        append = arguments.append
     else:
         append = 0
     if arguments.vert is not None:
         vert_levels = arguments.vert
     else:
         vert_levels = ''
-    if arguments.r is not None:
-        remove_temp_files = arguments.r
+    remove_temp_files = arguments.r
     if arguments.vertfile is not None:
         fname_vert_levels = arguments.vertfile
     if arguments.perlevel is not None:
@@ -299,11 +302,7 @@ def main(args=None):
         perslice = arguments.perslice
     else:
         perslice = None
-    if arguments.angle_corr is not None:
-        if arguments.angle_corr == '1':
-            angle_correction = True
-        elif arguments.angle_corr == '0':
-            angle_correction = False
+    angle_correction = arguments.angle_corr
     param_centerline = ParamCenterline(
         algo_fitting=arguments.centerline_algo,
         smooth=arguments.centerline_smooth,

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -216,8 +216,10 @@ def get_parser():
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Whether to remove temporary files. 0 = no, 1 = yes"
     )
     optional.add_argument(
@@ -370,8 +372,10 @@ def get_parser():
     )
     optional.add_argument(
         '-correct-seg',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Enable (1) or disable (0) the algorithm that checks and correct the output segmentation. More "
              "specifically, the algorithm checks if the segmentation is consistent with the centerline provided by "
              "isct_propseg."
@@ -441,9 +445,7 @@ def propseg(img_input, options_dict):
     if arguments.up is not None:
         cmd += ["-up", str(arguments.up)]
 
-    remove_temp_files = 1
-    if arguments.r is not None:
-        remove_temp_files = int(arguments.r)
+    remove_temp_files = arguments.r
 
     verbose = int(arguments.v)
     sct.init_sct(log_level=verbose, update=True)  # Update log level
@@ -628,7 +630,7 @@ def propseg(img_input, options_dict):
             fname_labels_viewer = fname_labels_viewer_new
 
     # check consistency of segmentation
-    if arguments.correct_seg == "1":
+    if arguments.correct_seg:
         check_and_correct_segmentation(fname_seg, fname_centerline, folder_output=folder_output, threshold_distance=3.0,
                                        remove_temp_files=remove_temp_files, verbose=verbose)
 

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -191,8 +191,10 @@ def get_parser(paramregmulti=None):
     )
     optional.add_argument(
         '-identity',
-        choices=['0', '1'],
-        default='0',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=0,
         help="Just put source into destination (no optimization)."
     )
     optional.add_argument(
@@ -232,8 +234,10 @@ def get_parser(paramregmulti=None):
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Whether to remove temporary files. 0 = no, 1 = yes"
     )
     optional.add_argument(
@@ -328,9 +332,9 @@ def main(args=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
 
-    identity = int(arguments.identity)
+    identity = arguments.identity
     interp = arguments.x
-    remove_temp_files = int(arguments.r)
+    remove_temp_files = arguments.r
     verbose = int(arguments.v)
     sct.init_sct(log_level=verbose, update=True)  # Update log level
 

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -268,7 +268,9 @@ def get_parser():
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
         default=param.remove_temp_files,
         help="Whether to remove temporary files. 0 = no, 1 = yes"
     )
@@ -320,7 +322,7 @@ def main(args=None):
     path_template = arguments.t
     contrast_template = arguments.c
     ref = arguments.ref
-    param.remove_temp_files = int(arguments.r)
+    param.remove_temp_files = arguments.r
     verbose = int(arguments.v)
     sct.init_sct(log_level=verbose, update=True)  # Update log level
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -101,8 +101,8 @@ def get_parser():
     )
     optional.add_argument(
         '-r',
-        choices=['0', '1'],
-        default='1',
+        choices=[0, 1],
+        default=1,
         help="Whether to remove temporary files. 0 = no, 1 = yes"
     )
     optional.add_argument(
@@ -131,8 +131,7 @@ def main(args=None):
     param.algo_fitting = arguments.algo_fitting
     if arguments.smooth is not None:
         sigma = arguments.smooth
-    if arguments.r is not None:
-        remove_temp_files = int(arguments.r)
+    remove_temp_files = arguments.r
     verbose = int(arguments.v)
     sct.init_sct(log_level=verbose, update=True)  # Update log level
 

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -170,14 +170,18 @@ def get_parser():
     )
     optional.add_argument(
         '-a',
-        choices=['0', '1'],
-        default=str(param_default.warp_atlas),
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=param_default.warp_atlas,
         help="Warp atlas of white matter."
     )
     optional.add_argument(
         '-s',
-        choices=['0', '1'],
-        default=str(param_default.warp_spinal_levels),
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=param_default.warp_spinal_levels,
         help="Warp spinal levels."
     )
     optional.add_argument(
@@ -228,8 +232,8 @@ def main(args=None):
 
     fname_src = arguments.d
     fname_transfo = arguments.w
-    warp_atlas = int(arguments.a)
-    warp_spinal_levels = int(arguments.s)
+    warp_atlas = arguments.a
+    warp_spinal_levels = arguments.s
     folder_out = arguments.ofolder
     path_template = arguments.t
     verbose = int(arguments.v)


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2843.

### Description

Updates remaining binary options to be typed as integers (rather than using string values). Also updates usage so that `arg == "1"` or `int(arg)` are no longer used.

I've also created a new dev Wiki page called [Argparse in CLI Scripts](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming:-Argparse-in-CLI-scripts) that includes a section for this change called [Integer (0/1) options vs. action="store_true"](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming:-Argparse-in-CLI-scripts#integer-01-options-vs-actionstore_true). (It also combines information from a few other recent discussions.)