### PR TITLE
sct_maths: Convert usage of convert_list_str to use list_type

### DIFF
--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -183,7 +183,7 @@ def get_parser():
         type=list_type(',', float),
         help='Gaussian smoothing filtering. Supply values for standard deviations in mm. If a single value is provided, '
              'it will be applied to each axis of the image. If multiple values are provided, there must be one value '
-             'per image axis. (Examples: "-smooth 2,3,2" (3D image), "-smooth 2" (any-D image)).',
+             'per image axis. (Examples: "-smooth 2.0,3.0,2.0" (3D image), "-smooth 2.0" (any-D image)).',
         required=False)
     filtering.add_argument(
         '-laplacian',
@@ -191,7 +191,7 @@ def get_parser():
         type=list_type(',', float),
         help='Laplacian filtering. Supply values for standard deviations in mm. If a single value is provided, it will '
              'be applied to each axis of the image. If multiple values are provided, there must be one value per '
-             'image axis. (Examples: "-laplacian 2,3,2" (3D image), "-laplacian 2" (any-D image)).',
+             'image axis. (Examples: "-laplacian 2.0,3.0,2.0" (3D image), "-laplacian 2.0" (any-D image)).',
         required=False)
     filtering.add_argument(
         '-denoise',

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -179,14 +179,17 @@ def get_parser():
         "-smooth",
         metavar=Metavar.list,
         type=list_type(',', float),
-        help='Gaussian smoothing filter with specified standard deviations in mm for each axis (Example: 2,2,1) or '
-             'single value for all axis (Example: 2).',
+        help='Gaussian smoothing filtering. Supply values for standard deviations in mm. If a single value is provided, '
+             'it will be applied to each axis of the image. If multiple values are provided, there must be one value '
+             'per image axis. (Examples: "-smooth 2,3,2" (3D image), "-smooth 2" (any-D image)).',
         required=False)
     filtering.add_argument(
         '-laplacian',
         metavar=Metavar.list,
         type=list_type(',', float),
-        help='Laplacian filtering with specified standard deviations in mm for all axes (Example: 2).',
+        help='Laplacian filtering. Supply values for standard deviations in mm. If a single value is provided, it will '
+             'be applied to each axis of the image. If multiple values are provided, there must be one value per '
+             'image axis. (Examples: "-laplacian 2,3,2" (3D image), "-laplacian 2" (any-D image)).',
         required=False)
     filtering.add_argument(
         '-denoise',

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -115,9 +115,12 @@ def get_parser():
         "-adap",
         metavar=Metavar.list,
         type=list_type(',', int),
-        help="R|Threshold image using Adaptive algorithm (from skimage). Separate following arguments with ',':"
-             "\n Block size: Odd size of pixel neighborhood which is used to calculate the threshold value (e.g. 3, 7, 21, ...)"
-             "\n Offset: Constant subtracted from weighted mean of neighborhood to calculate the local threshold value. Suggested offset is 0.",
+        help="R|Threshold image using Adaptive algorithm (from skimage). Provide 2 values separated by ',' that "
+             "correspond to the parameters below. For example, '-adap 7,0' corresponds to a block size of 7 and an "
+             "offset of 0.\n"
+             "  - Block size: Odd size of pixel neighborhood which is used to calculate the threshold value. \n"
+             "  - Offset: Constant subtracted from weighted mean of neighborhood to calculate the local threshold "
+             "value. Suggested offset is 0.",
         required=False)
     thresholding.add_argument(
         "-otsu-median",

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -126,9 +126,11 @@ def get_parser():
         "-otsu-median",
         metavar=Metavar.list,
         type=list_type(',', int),
-        help="R|Threshold image using Median Otsu algorithm. Separate following arguments with ',':"
-             "\n Size of the median filter (e.g. 2, 3)"
-             "\n Number of iterations (e.g. 3, 4, 5)\n",
+        help="R|Threshold image using Median Otsu algorithm (from dipy). Provide 2 values separated by ',' that "
+             "correspond to the parameters below. For example, '-otsu-median 3,5' corresponds to a filter size of 3 "
+             "repeated over 5 iterations.\n"
+             "  - Size: Radius (in voxels) of the applied median filter.\n"
+             "  - Iterations: Number of passes of the median filter.",
         required=False)
     thresholding.add_argument(
         '-percent',


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2844.

### Description

A factory function (`list_type`) was written as part of #2819 to parse typed lists in arguments. 

`list_type` is more general than the `convert_list_str` function in sct_maths, which was created for a similar purpose. So, this PR replaces the 4 instances of `convert_list_str`.