### PR TITLE
sct_compute_mtsat.py: more sane defaults

### DIFF
--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -109,13 +109,13 @@ def get_parser(argv):
     optional.add_argument(
         "-omtsat",
         metavar=Metavar.str,
-        help="Output file for MTsat. Default is mtsat.nii.gz",
-        default=None)
+        help="Output file for MTsat",
+        default="mtsat.nii.gz")
     optional.add_argument(
         "-ot1map",
         metavar=Metavar.str,
-        help="Output file for T1map. Default is t1map.nii.gz",
-        default=None)
+        help="Output file for T1map",
+        default="t1map.nii.gz")
     optional.add_argument(
         "-v",
         help="Verbose: 0 = no verbosity, 1 = verbose (default).",
@@ -199,20 +199,11 @@ def main(argv):
                                          nii_b1map=nii_b1map)
 
     # Output MTsat and T1 maps
-    # by default, output in the same directory as the input images
     sct.printv('Generate output files...', verbose)
-    if args.omtsat is None:
-        fname_mtsat = os.path.join(os.path.dirname(nii_mt.absolutepath), "mtsat.nii.gz")
-    else:
-        fname_mtsat = args.omtsat
-    nii_mtsat.save(fname_mtsat)
-    if args.ot1map is None:
-        fname_t1map = os.path.join(os.path.dirname(nii_mt.absolutepath), "t1map.nii.gz")
-    else:
-        fname_t1map = args.ot1map
-    nii_t1map.save(fname_t1map)
+    nii_mtsat.save(args.omtsat)
+    nii_t1map.save(args.ot1map)
 
-    sct.display_viewer_syntax([fname_mtsat, fname_t1map],
+    sct.display_viewer_syntax([args.omtsat, args.ot1map],
                               colormaps=['gray', 'gray'],
                               minmax=['-10,10', '0, 3'],
                               opacities=['1', '1'],

--- a/unit_testing/test_sct_compute_mtsat.py
+++ b/unit_testing/test_sct_compute_mtsat.py
@@ -9,14 +9,20 @@ from spinalcordtoolbox.utils import sct_test_path
 
 import sct_compute_mtsat
 
+out_mstat = "out_mtsat.nii.gz"
+out_t1map = "out_t1map.nii.gz"
 
 INPUT_PARAMS = [
     ['-mt', sct_test_path('mt', 'mt1.nii.gz'),
      '-pd', sct_test_path('mt', 'mt0.nii.gz'),
-     '-t1', sct_test_path('mt', 't1w.nii.gz')],
+     '-t1', sct_test_path('mt', 't1w.nii.gz'),
+     '-omtsat', out_mstat,
+     '-ot1map', out_t1map],
     ['-mt', sct_test_path('mt', 'mt1.nii.gz'),
      '-pd', sct_test_path('mt', 'mt0.nii.gz'),
      '-t1', sct_test_path('mt', 't1w.nii.gz'),
+     '-omtsat', out_mstat,
+     '-ot1map', out_t1map,
      '-trmt', '51', '-trpd', '52', '-trt1', '10', '-famt', '4', '-fapd', '5', '-fat1', '14'],
     ]
 
@@ -24,5 +30,7 @@ INPUT_PARAMS = [
 @pytest.mark.parametrize('input_params', INPUT_PARAMS)
 def test_with_json_sidecar(input_params):
     sct_compute_mtsat.main(input_params)
-    # Check if output file exists
-    assert os.path.isfile(sct_test_path('mt', 'mtsat.nii.gz'))
+    # Check if output files exist
+    for f in [out_mstat, out_t1map]:
+        assert os.path.isfile(f)
+        os.remove(f)


### PR DESCRIPTION
Closes #2908 

- When a help entry says `-omtsat <str>  Output file for MTsat. Default is mtsat.nii.gz` -> it is misleading to save the output file in the same folder as the input file (when `-omtsat` is not provided). Instead use the current working directory which better reflects the default.

- Unit test should not save in `sct_testing_data`. For lack of a better place use the current working directory instead.