### PR TITLE
Migrate sct_testing tests to use pytest directly

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ sys.path.append(sct_dir_local_path('scripts'))
 
 import pytest
 import sct_download_data as downloader
+from scripts.sct_testing import Param
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -28,3 +29,9 @@ def download_data(request):
     with capmanager.global_and_fixture_disabled():
         print('\nDownloading sct testing data.')
         downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+
+
+@pytest.fixture()
+def param_test():
+    param = Param()
+    return param

--- a/testing/test_sct_deepseg_gm.py
+++ b/testing/test_sct_deepseg_gm.py
@@ -12,9 +12,17 @@
 
 from __future__ import absolute_import
 
+import os
+
+import pytest
+import logging
+
 from spinalcordtoolbox.image import Image, compute_dice
 
+logger = logging.getLogger(__name__)
 
+
+@pytest.fixture
 def init(param_test):
     """
     Initialize class: param_test
@@ -31,10 +39,24 @@ def init(param_test):
     return param_test
 
 
-def test_integrity(param_test):
+@pytest.mark.script_launch_mode('subprocess')
+def test_integrity(init, script_runner):
     """
     Test integrity of function
     """
+    # Quirk from using init() directly as a fixture
+    param_test = init
+
+    os.chdir(param_test.path_data)
+
+    args = param_test.args[0].split(" ")
+    ret = script_runner.run('sct_deepseg_gm', *args)
+    logger.debug(f"{ret.stdout}")
+    logger.debug(f"{ret.stderr}")
+    assert ret.success
+    assert ret.returncode == 0
+    assert ret.stderr == ''
+
     # open output segmentation
     im_seg = Image(param_test.file_seg)
     # open ground truth
@@ -45,12 +67,4 @@ def test_integrity(param_test):
     param_test.output += 'Computed dice: '+str(dice_segmentation)
     param_test.output += '\nDice threshold (if computed Dice smaller: fail): '+str(param_test.dice_threshold)
 
-    if dice_segmentation < param_test.dice_threshold:
-        param_test.status = 99
-        param_test.output += '\n--> FAILED'
-    else:
-        param_test.output += '\n--> PASSED'
-
-    # update Panda structure
-    param_test.results['dice'] = dice_segmentation
-    return param_test
+    assert dice_segmentation > param_test.dice_threshold


### PR DESCRIPTION
This PR demonstrates an alternative approach to #2917, using `test_sct_deepseg_gm` to demonstrate.

* Turns `Param()` into a fixture
* Turns `init` into a fixture
* Adds `script_runner.run` to `test_integrity()` which calls the CLI script without `sct_testing`
* Slightly modifies the success/failure condition of the test.

You can test this by running `python -m pytest -v -o log_cli=True --log-level=DEBUG testing/test_sct_deepseg_gm.py`

Console output:

```bash
(venv_sct) joshua@pop-os:~/Repos/spinalcordtoolbox$ python -m pytest -v -o log_cli=True --log-level=DEBUG testing/test_sct_deepseg_gm.py
=============================================== test session starts ===============================================
platform linux -- Python 3.6.10, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /home/joshua/Repos/spinalcordtoolbox/python/envs/venv_sct/bin/python
cachedir: .pytest_cache
rootdir: /home/joshua/Repos/spinalcordtoolbox, configfile: setup.cfg
plugins: console-scripts-0.2.0, cov-2.10.0
collected 1 item                                                                                                  

testing/test_sct_deepseg_gm.py::test_integrity[subprocess] 
Downloading sct testing data.

------------------------------------------------- live log setup --------------------------------------------------
WARNING  spinalcordtoolbox.download:download.py:142 Removing existing destination folder “sct_testing_data”
INFO     spinalcordtoolbox.download:download.py:42 Trying URL: https://github.com/sct-data/sct_testing_data/releases/download/r20200904/sct_testing_data-r20200904.zip
INFO     spinalcordtoolbox.download:download.py:63 Downloading: sct_testing_data-r20200904.zip
INFO     spinalcordtoolbox.utils:utils.py:330 Creating temporary folder (/tmp/sct-20200925174510.758966-sa5b7p0a)
INFO     spinalcordtoolbox.download:download.py:89 Unzip data to: /tmp/sct-20200925174510.758966-sa5b7p0a
INFO     spinalcordtoolbox.download:download.py:202 Removing temporary folders...
-------------------------------------------------- live log call --------------------------------------------------
DEBUG    test_sct_deepseg_gm:test_sct_deepseg_gm.py:54 
--
Spinal Cord Toolbox (git-jn/2916-port_functional_tests_to_pytest-019eedd7c82bd68b3c1e46e379ce28866af64069)


 4/11 [=========>....................] - ETA: 8s
 8/11 [====================>.........] - ETA: 3s
11/11 [==============================] - 13s 1s/step

*** Generate Quality Control (QC) html report ***
Resample images to 0.6x0.6 mm
QcImage: layout with Axial slice
Compute center of mass at each slice
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/css/bootstrap.min.css.map /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/css
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/css/bootstrap-theme.min.css /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/css
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/css/select2.min.css /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/css
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/css/bootstrap.min.css /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/css
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/css/bootstrap-table.min.css /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/css
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/css/style.css /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/css
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/js/bootstrap-table.min.js /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/js
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/js/jquery-3.1.0.min.js /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/js
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/js/bootstrap.min.js /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/js
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/js/animation.js /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/js
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/js/main.js /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/js
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/js/select2.min.js /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/js
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/imgs/axial.png /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/imgs
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/imgs/sct_logo.png /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/imgs
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/imgs/sagittal.png /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/imgs
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/fonts/glyphicons-halflings-regular.svg /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/fonts
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/fonts/glyphicons-halflings-regular.ttf /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/fonts
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/fonts/glyphicons-halflings-regular.woff /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/fonts
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/fonts/glyphicons-halflings-regular.eot /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/fonts
cp /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/reports/assets/_assets/fonts/glyphicons-halflings-regular.woff2 /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_assets/fonts
Successfully generated the QC results in /home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/_json/qc_2020_09_25_174528.513793.json
Use the following command to see the results in a browser:
xdg-open "/home/joshua/Repos/spinalcordtoolbox/sct_testing_data/testing-qc/index.html"

DEBUG    test_sct_deepseg_gm:test_sct_deepseg_gm.py:55 
DEBUG    spinalcordtoolbox.image:image.py:347 Loaded output.nii.gz (/home/joshua/Repos/spinalcordtoolbox/sct_testing_data/output.nii.gz) orientation RPI shape (320, 320, 11)
DEBUG    spinalcordtoolbox.image:image.py:347 Loaded t2s/t2s_uncropped_gmseg_manual.nii.gz (/home/joshua/Repos/spinalcordtoolbox/sct_testing_data/t2s/t2s_uncropped_gmseg_manual.nii.gz) orientation RPI shape (320, 320, 11)
PASSED                                                                                                      [100%]

================================================ warnings summary =================================================
testing/test_sct_deepseg_gm.py::test_integrity[subprocess]
testing/test_sct_deepseg_gm.py::test_integrity[subprocess]
  /home/joshua/Repos/spinalcordtoolbox/spinalcordtoolbox/image.py:343: DeprecationWarning: get_data() is deprecated in favor of get_fdata(), which has a more predictable return type. To obtain get_data() behavior going forward, use numpy.asanyarray(img.dataobj).
  
  * deprecated from version: 3.0
  * Will raise <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 5.0
    self.data = self.im_file.get_data()

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================= 1 passed, 2 warnings in 21.80s ==========================================
```