### PR TITLE
test skimage compilation fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,11 +104,11 @@ matrix:
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode11.2
     - name: "OSX 10.13 (High Sierra)"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
     - name: "OSX 10.12 (Sierra)"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: osx
       osx_image: xcode9.2
     - name: "Windows Server, 1809"

--- a/install_sct
+++ b/install_sct
@@ -529,11 +529,6 @@ conda activate venv_sct
 
 # Install Python dependencies
 print info "Installing Python dependencies..."
-# numpy is an undeclared build dependency: https://github.com/scikit-image/scikit-image/issues/4919
-# so explicitly install it as a workaround; note that in releases with requirements-freeze.txt
-# this can cause a strange double-install: https://github.com/neuropoly/spinalcordtoolbox/issues/2750
-# but we can live with that until https://github.com/scikit-image/scikit-image/pull/4920 is merged.
-pip install numpy
 # Check if a frozen version of the requirements exist (for release only)
 if [[ -f "requirements-freeze.txt" ]]; then
   print info "Using requirements-freeze.txt (release installation)"


### PR DESCRIPTION
skimage finally merged https://github.com/scikit-image/scikit-image/pull/4920, so remove the hack of pre-installing numpy.

I'm not sure this has been published yet on their end.

I hacked travis.yml to test the case that was failing (OS X sierra); don't merge this without undoing that.