### PR TITLE
sct_register_to_template: Fix '%' in argparse iCloud help links

### DIFF
--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -119,7 +119,7 @@ def get_parser():
             "the parameter '-ref subject'.\n"
             "\n"
             "More information about label creation can be found at "
-            "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%5FCourse%5F20200121 (p47)"
+            "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%%5FCourse%%5F20200121 (p47)"
         ),
         formatter_class=SmartFormatter,
         add_help=None,
@@ -153,7 +153,7 @@ def get_parser():
         help="R|One or two labels (preferred) located at the center of the spinal cord, on the mid-vertebral slice. "
              "Example: anat_labels.nii.gz\n"
              "For more information about label creation, please see: "
-             "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%5FCourse%5F20200121 (p47)"
+             "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%%5FCourse%%5F20200121 (p47)"
     )
     optional.add_argument(
         '-ldisc',
@@ -162,7 +162,7 @@ def get_parser():
              "If you are using more than 2 labels, all disc covering the region of interest should be provided. "
              "(E.g., if you are interested in levels C2 to C7, then you should provide disc labels 2,3,4,5,6,7.) "
              "For more information about label creation, please refer to "
-             "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%5FCourse%5F20200121 (p47)"
+             "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%%5FCourse%%5F20200121 (p47)"
     )
     optional.add_argument(
         '-lspinal',


### PR DESCRIPTION
### Related PRs/Issues

Fixes #2927. 

### Description

Argparses uses `%` for format specification. To display `%` as a regular character, `%%` must be used instead. 

This PR fixes incorrect `%` usage in iCloud links in argparse help descriptions.