### PR TITLE
Pin onnxruntime version to fix "ImportError: cannot import name 'get_all_providers'" for macOS in CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Keras==2.1.5
 matplotlib
 nibabel
 numpy
+onnxruntime==1.4.0
 pandas
 psutil
 pyqt5==5.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ nibabel
 numpy
 # Note: If a newer version (1.5.1) is installed, Mojave CI jobs will fail
 # This is temporary until a better upstream fix can be determined. (See #2930)
-onnxruntime; sys_platform != "darwin"
 onnxruntime==1.4.0; sys_platform == "darwin"
 pandas
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,10 @@ Keras==2.1.5
 matplotlib
 nibabel
 numpy
-onnxruntime==1.4.0
+# Note: If a newer version (1.5.1) is installed, Mojave CI jobs will fail
+# This is temporary until a better upstream fix can be determined. (See #2930)
+onnxruntime; sys_platform != "darwin"
+onnxruntime==1.4.0; sys_platform == "darwin"
 pandas
 psutil
 pyqt5==5.11.3


### PR DESCRIPTION
### Related PRs/Issues

Fixes #2930.

### Description

SCT installs `onnxruntime` as it's an IVADOMED dependency. Recently, it's pypi version was bumped from 1.4.0 to 1.5.1. This change breaks our TravisCI job for macOS Mojave. The underlying reason is unclear, but in the meantime, this PR applies a temporary fix to restore the CI job.

This should be followed up on after conferring with the `onnxruntime` project devs.