### PR TITLE
Replace onnxruntime==1.4.0 version pinning with libomp install for macOS CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
       addons:
         homebrew:
           packages:
-            - libomp
+            - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.13 (High Sierra)"
       if: branch = release or type = cron
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,11 +110,19 @@ matrix:
     - name: "OSX 10.13 (High Sierra)"
       if: branch = release or type = cron
       os: osx
+      addons:
+        homebrew:
+          packages:
+            - libomp  # Needed for onnxruntime Python package, see issue #2930
       osx_image: xcode9.4
     - name: "OSX 10.12 (Sierra)"
       if: branch = release or type = cron
       os: osx
       osx_image: xcode9.2
+      addons:
+        homebrew:
+          packages:
+            - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "Windows Server, 1809"
       # runs on all branches
       language: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,10 @@ matrix:
       # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode11.2
+      addons:
+        homebrew:
+          packages:
+            - libomp
     - name: "OSX 10.13 (High Sierra)"
       if: branch = release or type = cron
       os: osx

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,6 @@ Keras==2.1.5
 matplotlib
 nibabel
 numpy
-# Note: If a newer version (1.5.1) is installed, Mojave CI jobs will fail
-# This is temporary until a better upstream fix can be determined. (See #2930)
-onnxruntime==1.4.0; sys_platform == "darwin"
 pandas
 psutil
 pyqt5==5.11.3


### PR DESCRIPTION
Potentially a better fix for #2930. See https://github.com/microsoft/onnxruntime/issues/5344#issuecomment-702124166.