### PR TITLE
Fix incorrect checking of input arguments

### DIFF
--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -35,6 +35,7 @@ def get_parser():
     input_output = parser.add_argument_group("\nINPUT/OUTPUT")
     input_output.add_argument(
         "-i",
+        required=True,
         help="Image to segment.",
         metavar=sct.utils.Metavar.file)
     input_output.add_argument(
@@ -118,41 +119,38 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-    args = {k: v for k, v in vars(args).items() if v is not None}
 
     # Deal with model
-    if args['list_models']:
+    if args.list_models is not None:
         sct.deepseg.models.display_list_models()
 
     # Deal with task
-    if args['list_tasks']:
+    if args.list_tasks is not None:
         sct.deepseg.models.display_list_tasks()
 
-    if 'install_model' in args:
-        sct.deepseg.models.install_model(args['install_model'])
+    if args.install_model is not None:
+        sct.deepseg.models.install_model(args.install_model)
         exit(0)
 
-    if 'install_task' in args:
-        for name_model in sct.deepseg.models.TASKS[args['install_task']]['models']:
+    if args.install_task is not None:
+        for name_model in sct.deepseg.models.TASKS[args.install_task]['models']:
             sct.deepseg.models.install_model(name_model)
         exit(0)
 
     # Deal with input/output
-    if 'i' not in args:
-        parser.error("The following arguments is required: -i")
-    if not os.path.isfile(args['i']):
-        parser.error("This file does not exist: {}".format(args['i']))
+    if not os.path.isfile(args.i):
+        parser.error("This file does not exist: {}".format(args.i))
 
     # Check if at least a model or task has been specified
-    if 'model' not in args and 'task' not in args:
+    if args.model is None and args.task is None:
         parser.error("You need to specify a model or a task.")
 
     # Get pipeline model names
-    if 'task' in args:
-        name_models = sct.deepseg.models.TASKS[args['task']]['models']
+    if args.task is not None:
+        name_models = sct.deepseg.models.TASKS[args.task]['models']
 
-    if 'model' in args:
-        name_models = args['model']
+    if args.model is not None:
+        name_models = args.model
 
     # Run pipeline by iterating through the models
     fname_prior = None
@@ -171,11 +169,11 @@ def main():
                 parser.error("The input model is invalid: {}".format(path_model))
 
         # Call segment_nifti
-        fname_seg = sct.deepseg.core.segment_nifti(args['i'], path_model, fname_prior, args)
+        fname_seg = sct.deepseg.core.segment_nifti(args.i, path_model, fname_prior, args)
         # Use the result of the current model as additional input of the next model
         fname_prior = fname_seg
 
-    display_viewer_syntax([args['i'], fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
+    display_viewer_syntax([args.i, fname_seg], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
 if __name__ == '__main__':

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
     curdir = os.getcwd()
     os.chdir(tmp_dir) # go to tmp directory
 
-    if '-bin' in arguments:
+    if arguments.bin is not None:
         fname_input1_bin = sct.add_suffix(fname_input1, '_bin')
         sct.run(['sct_maths', '-i', fname_input1, '-bin', '0', '-o', fname_input1_bin])
         fname_input1 = fname_input1_bin

--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -113,7 +113,7 @@ def main(args=None):
 
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     fname_src = arguments.i
-    if "-o" in arguments:
+    if arguments.o is not None:
         fname_dst = arguments.o
     else:
         fname_dst = sct.add_suffix(fname_src, "_tsnr")

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -319,7 +319,7 @@ def main(args=None):
     if im_out is not None:
         sct.printv('Generate output files...', verbose)
         # if only one output
-        if len(im_out) == 1 and not '-split' in arguments:
+        if len(im_out) == 1 and arguments.split is None:
             im_out[0].save(fname_out, dtype=output_type, verbose=verbose)
             sct.display_viewer_syntax([fname_out], verbose=verbose)
         if arguments.mcs:

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -254,10 +254,7 @@ def main(args=None):
     fname_out = arguments.o
     verbose = arguments.v
     init_sct(log_level=verbose, update=True)  # Update log level
-    if '-type' in arguments:
-        output_type = arguments.type
-    else:
-        output_type = None
+    output_type = arguments.type
 
     # Open file(s)
     im = Image(fname_in)
@@ -406,13 +403,13 @@ def main(args=None):
     #     for im_in, d_out, fn_out in zip(nii, data_out, fname_out):
     #         im_in.data = d_out
     #         im_in.absolutepath = fn_out
-    #         if "-w" in arguments:
+    #         if arguments.w is not None:
     #             im_in.hdr.set_intent('vector', (), '')
     #         im_in.save()
     # elif n_out == 1:
     #     nii[0].data = data_out[0]
     #     nii[0].absolutepath = fname_out[0]
-    #     if "-w" in arguments:
+    #     if arguments.w is not None:
     #             nii[0].hdr.set_intent('vector', (), '')
     #     nii[0].save()
     # elif n_out > n_in:
@@ -420,7 +417,7 @@ def main(args=None):
     #         im_out = nii[0].copy()
     #         im_out.data = dat_out
     #         im_out.absolutepath = name_out
-    #         if "-w" in arguments:
+    #         if arguments.w is not None:
     #             im_out.hdr.set_intent('vector', (), '')
     #         im_out.save()
     # else:

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -205,7 +205,7 @@ def main():
     list_fname_warp = arguments.w
     param.fname_out = arguments.o
 
-    # if '-ofolder' in arguments:
+    # if arguments.ofolder is not None
     #     path_results = arguments.ofolder
     if arguments.x is not None:
         param.interp = arguments.x

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -239,7 +239,7 @@ def main(args=None):
     sct.init_sct(log_level=verbose, update=True)  # Update log level
     sc_straight.verbose = verbose
 
-    # if "-cpu-nb" in arguments:
+    # if arguments.cpu_nb is not None:
     #     sc_straight.cpu_number = arguments.cpu-nb)
     if arguments.disable_straight2curved:
         sc_straight.straight2curved = False


### PR DESCRIPTION
### Related PRs/issues

Fixes #2926. 

### Description

Replaces the following behaviors with `if arguments.arg is not None`:

* `if '-arg' in arguments`
* `if arguments['arg']`

This PR also fixes a check for a required arg (`if '-i' not in args`) by simply making the argument itself required.