### PR TITLE
Fix issue with outdated Homebrew in older macOS TravisCI images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
         homebrew:
           packages:
             - libomp  # Needed for onnxruntime Python package, see issue #2930
+          update: true  # Fixes issue w/outdated Homebrew in older MacOS images
       osx_image: xcode9.4
     - name: "OSX 10.12 (Sierra)"
       if: branch = release or type = cron
@@ -123,6 +124,7 @@ matrix:
         homebrew:
           packages:
             - libomp  # Needed for onnxruntime Python package, see issue #2930
+          update: true  # Fixes issue w/outdated Homebrew in older MacOS images
     - name: "Windows Server, 1809"
       # runs on all branches
       language: bash


### PR DESCRIPTION
### Related PR/Issues

Fixes #2930. Follows PRs #2931 and #2932. 

### Description

Recap of what's happened so far:
* `onnxruntime` got a version bump, causing the macOS Travis builds to fail due to a missing  `libomp` dependency.
* Travis's Homebrew addon can be used to install `libomp`, which worked for macOS 10.14.
* The version of Homebrew that ships with Travis's macOS 10.12 and 10.13 images [is out of date](https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/14), causing issues with installation.

By supplying `update: true`, this should _hopefully_ be the final change needed to fix the macOS builds. (But, it is hard to say conclusively as 10.12 and 10.13 builds currently only run on merge.)