### PR TITLE
Move init_sct to spinalcordtoolbox.utils

### DIFF
--- a/dev/scripts/isct_warpmovie_generator.py
+++ b/dev/scripts/isct_warpmovie_generator.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division
 
 from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.utils import init_sct
 from scipy.misc import toimage
 
 import sct_utils as sct
@@ -42,7 +43,7 @@ class WarpingField(Image):
             raise StopIteration()
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
 
     # TODO: Convert to argparse when fixing this script
     # from msct_parser import Parser

--- a/scripts/isct_check_detection.py
+++ b/scripts/isct_check_detection.py
@@ -17,7 +17,9 @@ import getopt
 
 import nibabel
 import numpy as np
+
 from spinalcordtoolbox import sct_test_path
+from spinalcordtoolbox.utils import init_sct
 
 import sct_utils as sct
 
@@ -116,7 +118,7 @@ def usage():
 # Start program
 #=======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # initialize parameters
     param = Param()
     # call main function

--- a/scripts/isct_convert_binary_to_trilinear.py
+++ b/scripts/isct_convert_binary_to_trilinear.py
@@ -22,8 +22,10 @@ import time
 
 import numpy as np
 
-import sct_utils as sct
 from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.utils import init_sct
+
+import sct_utils as sct
 
 
 class Param:
@@ -177,9 +179,9 @@ def usage():
         '  -s                sigma of the smoothing Gaussian kernel (in voxel). Default=' + str(param_default.smoothing_sigma) + '\n'
         '  -r {0,1}          remove temporary files. Default=' + str(param_default.remove_temp_files) + '\n'
         '  -v {0,1}          verbose. Default=' + str(param_default.verbose) + '\n'
-        '  -h                help. Show this message\n' 
+        '  -h                help. Show this message\n'
         '\n'
-        'EXAMPLE\n' 
+        'EXAMPLE\n'
         '  ' + os.path.basename(__file__) + ' -i segmentation.nii \n')
 
     # exit program
@@ -190,7 +192,7 @@ def usage():
 # Start program
 #=======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # initialize parameters
     param = Param()
     param_default = Param()

--- a/scripts/isct_test_ants.py
+++ b/scripts/isct_test_ants.py
@@ -19,8 +19,9 @@ import getopt
 import os
 
 import numpy as np
-
 import nibabel as nib
+
+from spinalcordtoolbox.utils import init_sct
 
 import sct_utils as sct
 
@@ -169,6 +170,6 @@ def usage():
 # Start program
 #=======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_analyze_lesion.py
+++ b/scripts/sct_analyze_lesion.py
@@ -20,6 +20,7 @@ from skimage.measure import label
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import init_sct
 
 import sct_utils as sct
 from sct_utils import extract_fname, printv, tmp_create
@@ -548,7 +549,7 @@ def main(args=None):
 
     # Verbosity
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # create the Lesion constructor
     lesion_obj = AnalyzeLeion(fname_mask=fname_mask,
@@ -573,5 +574,5 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -22,7 +22,7 @@ from skimage.feature import greycomatrix, greycoprops
 import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, sct_progress_bar
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, sct_progress_bar, init_sct
 
 def get_parser():
     # Initialize the parser
@@ -351,7 +351,7 @@ def main(args=None):
     if arguments.r is not None:
         param.rm_tmp = bool(arguments.r)
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # create the GLCM constructor
     glcm = ExtractGLCM(param=param, param_glcm=param_glcm)
@@ -366,5 +366,5 @@ def main(args=None):
     sct.printv('fsleyes ' + arguments.i + ' ' + ' -cm red-yellow -a 70.0 '.join(fname_out_lst) + ' -cm Red-Yellow -a 70.0 & \n', param.verbose, 'info')
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -19,7 +19,7 @@ from __future__ import division, absolute_import
 import sys, io, os, time, functools
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
@@ -368,7 +368,7 @@ def main(args=None):
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
     transform.verbose = arguments.v
-    sct.init_sct(log_level=transform.verbose, update=True)  # Update log level
+    init_sct(log_level=transform.verbose, update=True)  # Update log level
 
     transform.apply()
 
@@ -376,6 +376,6 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -31,7 +31,7 @@ import warnings
 import requirements
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import SmartFormatter, sct_dir_local_path
+from spinalcordtoolbox.utils import SmartFormatter, sct_dir_local_path, init_sct
 
 
 # DEFAULT PARAMETERS
@@ -367,7 +367,7 @@ def main():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # initialize parameters
     param = Param()
     # call main function

--- a/scripts/sct_compute_ernst_angle.py
+++ b/scripts/sct_compute_ernst_angle.py
@@ -18,7 +18,7 @@ import os
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 # DEFAULT PARAMETERS
@@ -156,7 +156,7 @@ def main():
     if arguments.tr is not None:
         input_tr = arguments.tr
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     graph = ErnstAngle(input_t1, tr=input_tr, fname_output=input_fname_output)
     if input_tr is not None:
@@ -182,5 +182,5 @@ def main():
 # Start program
 #=======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -19,7 +19,7 @@ import numpy as np
 import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 # TODO: display results ==> not only max : with a violin plot of h1 and h2 distribution ? see dev/straightening --> seaborn.violinplot
 # TODO: add the option Hyberbolic Hausdorff's distance : see  choi and seidel paper
@@ -499,7 +499,7 @@ def get_parser():
 ########################################################################################################################
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     param = Param()
     input_fname = None
     if param.debug:
@@ -522,7 +522,7 @@ if __name__ == "__main__":
         if arguments.o is not None:
             output_fname = arguments.o
         param.verbose = arguments.v
-        sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+        init_sct(log_level=param.verbose, update=True)  # Update log level
 
         tmp_dir = sct.tmp_create()
         im1_name = "im1.nii.gz"

--- a/scripts/sct_compute_mscc.py
+++ b/scripts/sct_compute_mscc.py
@@ -18,7 +18,7 @@ import argparse
 
 import sct_utils as sct
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 # PARSER
@@ -94,6 +94,6 @@ def main():
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_compute_mtr.py
+++ b/scripts/sct_compute_mtr.py
@@ -18,7 +18,7 @@ import os
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.qmri.mt import compute_mtr
 
@@ -48,7 +48,7 @@ def get_parser():
     optional.add_argument(
         "-thr",
         type=float,
-        help="Threshold to clip MTR output values in case of division by small number. This implies that the output image" 
+        help="Threshold to clip MTR output values in case of division by small number. This implies that the output image"
              "range will be [-thr, +thr]. Default: 100.",
         default=100
         )
@@ -92,5 +92,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_compute_mtsat.py
+++ b/scripts/sct_compute_mtsat.py
@@ -21,7 +21,7 @@ import os
 import argparse
 import json
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, splitext
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, splitext, init_sct
 from spinalcordtoolbox.qmri.mt import compute_mtsat
 from spinalcordtoolbox.image import Image
 
@@ -168,7 +168,7 @@ def main(argv):
     parser = get_parser(argv)
     args = parser.parse_args(argv if argv else ['--help'])
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     sct.printv('Load data...', verbose)
     nii_mt = Image(args.mt)

--- a/scripts/sct_compute_snr.py
+++ b/scripts/sct_compute_snr.py
@@ -19,9 +19,8 @@ import numpy as np
 import os
 import argparse
 from spinalcordtoolbox.image import Image, empty_like
-from spinalcordtoolbox.utils import parse_num_list
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, parse_num_list, init_sct
 
 
 # PARAMETERS
@@ -121,7 +120,7 @@ def main():
     else:
         index_vol_user = ''
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # Check parameters
     if method == 'diff':
@@ -192,6 +191,6 @@ def main():
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_convert.py
+++ b/scripts/sct_convert.py
@@ -20,8 +20,8 @@ import argparse
 
 import numpy as np
 
-from sct_utils import init_sct, printv
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from sct_utils import printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 import spinalcordtoolbox.image as image
 
 

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -29,7 +29,7 @@ import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from sct_image import concat_data
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate
 
@@ -153,7 +153,7 @@ def main(args=None):
         param.remove_temp_files = arguments.r
 
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # run main program
     create_mask(param)
@@ -355,5 +355,5 @@ def create_mask2d(param, center, shape, size, im_data):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_crop_image.py
+++ b/scripts/sct_crop_image.py
@@ -15,7 +15,7 @@ import argparse
 
 from spinalcordtoolbox.cropping import ImageCropper, BoundingBox
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 import sct_utils as sct
 
 
@@ -154,7 +154,7 @@ def main(args=None):
     # initialize ImageCropper
     cropper = ImageCropper(Image(arguments.i))
     cropper.verbose = arguments.v
-    sct.init_sct(log_level=cropper.verbose, update=True)  # Update log level
+    init_sct(log_level=cropper.verbose, update=True)  # Update log level
 
     # Switch across cropping methods
     if arguments.g:
@@ -184,5 +184,5 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -18,18 +18,16 @@ import argparse
 import os
 import sys
 
-import spinalcordtoolbox as sct
-import spinalcordtoolbox.deepseg.core
-import spinalcordtoolbox.deepseg.models
-import spinalcordtoolbox.utils
-from sct_utils import init_sct, printv, display_viewer_syntax
+import spinalcordtoolbox.deepseg as deepseg
+from spinalcordtoolbox.utils import SmartFormatter, Metavar, init_sct
+from sct_utils import printv, display_viewer_syntax,
 
 
 def get_parser():
     parser = argparse.ArgumentParser(
         description="Segment an anatomical structure or pathologies according to the specified deep learning model.",
         add_help=None,
-        formatter_class=sct.utils.SmartFormatter,
+        formatter_class=SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"))
 
     input_output = parser.add_argument_group("\nINPUT/OUTPUT")
@@ -37,19 +35,19 @@ def get_parser():
         "-i",
         required=True,
         help="Image to segment.",
-        metavar=sct.utils.Metavar.file)
+        metavar=Metavar.file)
     input_output.add_argument(
         "-o",
         help="Output file name. In case of multi-class segmentation, class-specific suffixes will be added. By default,"
              "suffix '_seg' will be added and output extension will be .nii.gz.",
-        metavar=sct.utils.Metavar.str)
+        metavar=Metavar.str)
 
     seg = parser.add_argument_group('\nTASKS')
     seg.add_argument(
         "-task",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: sct_deepseg -list-tasks",
-        metavar=sct.utils.Metavar.str)
+        metavar=Metavar.str)
     seg.add_argument(
         "-list-tasks",
         action='store_true',
@@ -57,7 +55,7 @@ def get_parser():
     seg.add_argument(
         "-install-task",
         help="Install models that are required for specified task.",
-        choices=list(sct.deepseg.models.TASKS.keys()))
+        choices=list(deepseg.models.TASKS.keys()))
 
     seg = parser.add_argument_group('\nMODELS')
     seg.add_argument(
@@ -68,7 +66,7 @@ def get_parser():
              "-model my_models/model. To list official models, run: sct_deepseg -list-models."
              "To build your own model, follow instructions at: https://github.com/neuropoly/ivado-medical-imaging",
         nargs='+',
-        metavar=sct.utils.Metavar.str)
+        metavar=Metavar.str)
     seg.add_argument(
         "-list-models",
         action='store_true',
@@ -76,7 +74,7 @@ def get_parser():
     seg.add_argument(
         "-install-model",
         help="Install specified model.",
-        choices=list(sct.deepseg.models.MODELS.keys()))
+        choices=list(deepseg.models.MODELS.keys()))
 
     misc = parser.add_argument_group('\nPARAMETERS')
     misc.add_argument(
@@ -85,20 +83,20 @@ def get_parser():
         help="Binarize segmentation with specified threshold. Set to 0 for no thresholding (i.e., soft segmentation). "
              "Default value is model-specific and was set during optimization "
              "(more info at https://github.com/sct-pipeline/deepseg-threshold).",
-        metavar=sct.utils.Metavar.float,
-        default=sct.deepseg.core.DEFAULTS['thr'])
+        metavar=Metavar.float,
+        default=deepseg.core.DEFAULTS['thr'])
     misc.add_argument(
         "-largest",
         type=int,
         help="Keep the largest connected-objects from the output segmentation. Specify the number of objects to keep."
              "To keep all objects, set to 0",
-        default=sct.deepseg.core.DEFAULTS['largest'])
+        default=deepseg.core.DEFAULTS['largest'])
     misc.add_argument(
         "-fill-holes",
         type=int,
         help="Fill small holes in the segmentation.",
         choices=(0, 1),
-        default=sct.deepseg.core.DEFAULTS['fill_holes'])
+        default=deepseg.core.DEFAULTS['fill_holes'])
 
     misc = parser.add_argument_group('\nMISC')
     misc.add_argument(
@@ -122,19 +120,19 @@ def main():
 
     # Deal with model
     if args.list_models is not None:
-        sct.deepseg.models.display_list_models()
+        deepseg.models.display_list_models()
 
     # Deal with task
     if args.list_tasks is not None:
-        sct.deepseg.models.display_list_tasks()
+        deepseg.models.display_list_tasks()
 
     if args.install_model is not None:
-        sct.deepseg.models.install_model(args.install_model)
+        deepseg.models.install_model(args.install_model)
         exit(0)
 
     if args.install_task is not None:
-        for name_model in sct.deepseg.models.TASKS[args.install_task]['models']:
-            sct.deepseg.models.install_model(name_model)
+        for name_model in deepseg.models.TASKS[args.install_task]['models']:
+            deepseg.models.install_model(name_model)
         exit(0)
 
     # Deal with input/output
@@ -147,7 +145,7 @@ def main():
 
     # Get pipeline model names
     if args.task is not None:
-        name_models = sct.deepseg.models.TASKS[args.task]['models']
+        name_models = deepseg.models.TASKS[args.task]['models']
 
     if args.model is not None:
         name_models = args.model
@@ -156,7 +154,7 @@ def main():
     fname_prior = None
     for name_model in name_models:
         # Check if this is an official model
-        if name_model in list(sct.deepseg.models.MODELS.keys()):
+        if name_model in list(deepseg.models.MODELS.keys()):
             # If it is, check if it is installed
             path_model = spinalcordtoolbox.deepseg.models.folder(name_model)
             if not spinalcordtoolbox.deepseg.models.is_valid(path_model):
@@ -165,11 +163,11 @@ def main():
         # If it is not, check if this is a path to a valid model
         else:
             path_model = os.path.abspath(name_model)
-            if not sct.deepseg.models.is_valid(path_model):
+            if not deepseg.models.is_valid(path_model):
                 parser.error("The input model is invalid: {}".format(path_model))
 
         # Call segment_nifti
-        fname_seg = sct.deepseg.core.segment_nifti(args.i, path_model, fname_prior, args)
+        fname_seg = deepseg.core.segment_nifti(args.i, path_model, fname_prior, args)
         # Use the result of the current model as additional input of the next model
         fname_prior = fname_seg
 

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -20,7 +20,7 @@ import sys
 
 import spinalcordtoolbox.deepseg as deepseg
 from spinalcordtoolbox.utils import SmartFormatter, Metavar, init_sct
-from sct_utils import printv, display_viewer_syntax,
+from sct_utils import printv, display_viewer_syntax
 
 
 def get_parser():

--- a/scripts/sct_deepseg_gm.py
+++ b/scripts/sct_deepseg_gm.py
@@ -15,7 +15,7 @@ import os
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -107,7 +107,7 @@ def run_main():
     model_name = arguments.m
     threshold = arguments.thr
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     if threshold > 1.0 or threshold < 0.0:
         raise RuntimeError("Threshold should be between 0.0 and 1.0.")
@@ -137,5 +137,5 @@ def run_main():
 
 
 if __name__ == '__main__':
-    sct.init_sct()
+    init_sct()
     run_main()

--- a/scripts/sct_deepseg_lesion.py
+++ b/scripts/sct_deepseg_lesion.py
@@ -18,7 +18,7 @@ import os
 import sys
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 
 import sct_utils as sct
 
@@ -139,7 +139,7 @@ def main():
 
     remove_temp_files = args.r
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     algo_config_stg = '\nMethod:'
     algo_config_stg += '\n\tCenterline algorithm: ' + str(ctr_algo)
@@ -174,5 +174,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_deepseg_sc.py
+++ b/scripts/sct_deepseg_sc.py
@@ -18,7 +18,7 @@ import sys
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 
 
 def get_parser():
@@ -169,7 +169,7 @@ def main():
 
     remove_temp_files = args.r
     verbose = args.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     path_qc = args.qc
     qc_dataset = args.qc_dataset
@@ -204,5 +204,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_denoising_onlm.py
+++ b/scripts/sct_denoising_onlm.py
@@ -9,7 +9,7 @@ from time import time
 import nibabel as nib
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 # DEFAULT PARAMETERS
@@ -178,7 +178,7 @@ def main(file_to_denoise, param, output_file_name) :
 # Start program
 # =======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     parser = get_parser()
     # initialize parameters
     arguments = parser.parse_args(args = None if sys.argv[1:] else ['--help'])
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     remove_temp_files = arguments.r
     noise_threshold = arguments.d
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     file_to_denoise = arguments.i
     output_file_name = arguments.o

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -23,7 +23,7 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 
 
 def get_parser():
@@ -293,7 +293,7 @@ def main():
     rm_tmp = bool(arguments.r)
 
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # Initialize DetectPMJ
     detector = DetectPMJ(fname_im=fname_in,
@@ -319,5 +319,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -17,7 +17,7 @@ import os
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 def get_parser():
@@ -102,7 +102,7 @@ def get_parser():
     return parser
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     parser = get_parser()
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     fname_input2 = arguments.d
 
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     tmp_dir = sct.tmp_create(verbose=verbose)  # create tmp directory
     tmp_dir = os.path.abspath(tmp_dir)

--- a/scripts/sct_dmri_compute_bvalue.py
+++ b/scripts/sct_dmri_compute_bvalue.py
@@ -21,7 +21,7 @@ import math
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 # main
 # =======================================================================================================================
@@ -97,6 +97,6 @@ def get_parser():
 # Start program
 #=======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_dmri_compute_dti.py
+++ b/scripts/sct_dmri_compute_dti.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import os, sys, argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 class Param:
@@ -114,7 +114,7 @@ def main(args=None):
     if arguments.m is not None:
         file_mask = arguments.m
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # compute DTI
     if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):
@@ -201,7 +201,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # initialize parameters
     param = Param()
     # call main function

--- a/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -16,7 +16,7 @@ import argparse
 import numpy as np
 
 from dipy.data.fetcher import read_bvals_bvecs
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 from spinalcordtoolbox.image import Image, concat_data
 
 import sct_utils as sct
@@ -153,6 +153,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_dmri_concat_bvals.py
+++ b/scripts/sct_dmri_concat_bvals.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import os, sys, argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 # PARSER
 # ==========================================================================================
@@ -88,6 +88,6 @@ def main():
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_dmri_concat_bvecs.py
+++ b/scripts/sct_dmri_concat_bvecs.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import sys, os, argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 # PARSER
@@ -111,6 +111,6 @@ def main():
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_dmri_display_bvecs.py
+++ b/scripts/sct_dmri_display_bvecs.py
@@ -19,7 +19,7 @@ from mpl_toolkits.mplot3d import Axes3D
 from dipy.data.fetcher import read_bvals_bvecs
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 import argparse
 import os
 
@@ -140,6 +140,6 @@ def main():
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_dmri_moco.py
+++ b/scripts/sct_dmri_moco.py
@@ -32,7 +32,7 @@ from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 
 import sct_utils as sct
 import argparse
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 
 
 def get_parser():
@@ -165,12 +165,12 @@ def main():
     param.verbose = int(arguments.v)
 
     # Update log level
-    sct.init_sct(log_level=param.verbose, update=True)
+    init_sct(log_level=param.verbose, update=True)
 
     # run moco
     moco_wrapper(param)
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -26,7 +26,7 @@ from spinalcordtoolbox.image import Image
 from sct_image import split_data
 from sct_convert import convert
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 import argparse
 
 
@@ -128,7 +128,7 @@ def main(args=None):
     fname_bvecs = arguments.bvec
     average = arguments.a
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     remove_temp_files = arguments.r
     path_out = arguments.ofolder
 
@@ -314,5 +314,5 @@ def identify_b0(fname_bvecs, fname_bvals, bval_min, verbose):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_dmri_transpose_bvecs.py
+++ b/scripts/sct_dmri_transpose_bvecs.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division
 import os
 import sys
 import argparse
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 from sct_utils import extract_fname, printv
 import sct_utils as sct
@@ -87,7 +87,7 @@ def main(args=None):
     fname_in = arguments.bvec
     fname_out = arguments.o
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # get bvecs in proper orientation
     from dipy.io import read_bvals_bvecs
@@ -114,6 +114,6 @@ def main(args=None):
 # Start program
 #=======================================================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -17,7 +17,7 @@ import sys
 import argparse
 
 from spinalcordtoolbox.download import install_data
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 import sct_utils as sct
 
 
@@ -154,7 +154,7 @@ def main(args=None):
 
     data_name = arguments.d
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     if arguments.o is not None:
         dest_folder = arguments.o
     else:
@@ -168,6 +168,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     res = main()
     raise SystemExit(res)

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -27,11 +27,10 @@ import argparse
 import numpy as np
 
 from spinalcordtoolbox.metadata import read_label_file
-from spinalcordtoolbox.utils import parse_num_list
 from spinalcordtoolbox.aggregate_slicewise import check_labels, extract_metric, save_as_csv, Metric, LabelStruc
 import sct_utils as sct
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type, parse_num_list, init_sct
 
 # get path of the script and the toolbox
 # TODO: is that useful??
@@ -117,7 +116,7 @@ def get_parser():
         '-l',
         metavar=Metavar.str,
         default='',
-        help="Label IDs to extract the metric from. Default = all labels. Separate labels with ','. To select a group " 
+        help="Label IDs to extract the metric from. Default = all labels. Separate labels with ','. To select a group "
              "of consecutive labels use ':'. Example: 1:3 is equivalent to 1,2,3. Maximum Likelihood (or MAP) is "
              "computed using all tracts, but only values of the selected tracts are reported."
     )
@@ -127,7 +126,7 @@ def get_parser():
         default=param_default.method,
         help="R|Method to extract metrics.\n"
              "  - ml: maximum likelihood (only use with well-defined regions and low noise)\n"
-             "    N.B. ONLY USE THIS METHOD WITH THE WHITE MATTER ATLAS! The sum of all tracts should be 1 in " 
+             "    N.B. ONLY USE THIS METHOD WITH THE WHITE MATTER ATLAS! The sum of all tracts should be 1 in "
              "all voxels (the algorithm doesn't normalize the atlas).\n"
              "  - map: maximum a posteriori. Mean priors are estimated by maximum likelihood within three clusters "
              "(white matter, gray matter and CSF). Tract and noise variance are set with flag -p.\n"
@@ -383,7 +382,7 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
 
 if __name__ == "__main__":
 
-    sct.init_sct()
+    init_sct()
 
     param_default = Param()
 
@@ -411,7 +410,7 @@ if __name__ == "__main__":
     fname_mask_weight = arguments.mask_weighted  # TODO: Not used. Why?
     discard_negative_values = int(arguments.discard_neg_val)  # TODO: Not used. Why?
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
     main(fname_data=fname_data, path_label=path_label, method=method, slices=parse_num_list(slices_of_interest),

--- a/scripts/sct_flatten_sagittal.py
+++ b/scripts/sct_flatten_sagittal.py
@@ -24,7 +24,7 @@ import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 # Default parameters
@@ -146,7 +146,7 @@ def get_parser():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # initialize parameters
     param = Param()
     param_default = Param()
@@ -156,7 +156,7 @@ if __name__ == "__main__":
     fname_anat = arguments.i
     fname_centerline = arguments.s
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
     main(fname_anat, fname_centerline, verbose)

--- a/scripts/sct_fmri_compute_tsnr.py
+++ b/scripts/sct_fmri_compute_tsnr.py
@@ -22,7 +22,7 @@ import numpy as np
 
 import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 from spinalcordtoolbox.image import Image
 
 
@@ -119,7 +119,7 @@ def main(args=None):
         fname_dst = sct.add_suffix(fname_src, "_tsnr")
 
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # call main function
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)
@@ -129,6 +129,6 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     param = Param()
     main()

--- a/scripts/sct_fmri_moco.py
+++ b/scripts/sct_fmri_moco.py
@@ -18,7 +18,7 @@ import argparse
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 
 
 def get_parser():
@@ -142,12 +142,12 @@ def main():
     param.verbose = int(arguments.v)
 
     # Update log level
-    sct.init_sct(log_level=param.verbose, update=True)
+    init_sct(log_level=param.verbose, update=True)
 
     # run moco
     moco_wrapper(param)
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_get_centerline.py
+++ b/scripts/sct_get_centerline.py
@@ -9,7 +9,7 @@ import argparse
 import numpy as np
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 from spinalcordtoolbox.reports.qc import generate_qc
@@ -120,7 +120,7 @@ def get_parser():
 
 
 def run_main():
-    sct.init_sct()
+    init_sct()
     parser = get_parser()
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
@@ -155,7 +155,7 @@ def run_main():
         file_output = os.path.join(path_data, file_data + '_centerline')
 
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     if method == 'viewer':
         # Manual labeling of cord centerline
@@ -182,7 +182,7 @@ def run_main():
     np.savetxt(file_output + '.csv', arr_centerline.transpose(), delimiter=",")
 
     sct.display_viewer_syntax([fname_input_data, file_output+'.nii.gz'], colormaps=['gray', 'red'], opacities=['', '1'])
-    
+
     path_qc = arguments.qc
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -19,9 +19,9 @@ import numpy as np
 
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image, concat_data
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
-from nibabel                 import Nifti1Image
-from nibabel.processing      import resample_from_to
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
+from nibabel import Nifti1Image
+from nibabel.processing import resample_from_to
 
 
 import sct_utils as sct
@@ -179,7 +179,7 @@ def main(args=None):
     fname_in = arguments.i
     n_in = len(fname_in)
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     if arguments.o is not None:
         fname_out = arguments.o
@@ -587,5 +587,5 @@ def visualize_warp(fname_warp, fname_grid=None, step=3, rm_tmp=True):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -31,7 +31,7 @@ from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
 import spinalcordtoolbox.labels as sct_labels
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 import sct_utils as sct
 
 logger = logging.getLogger(__name__)
@@ -232,7 +232,7 @@ def main(args=None):
         arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     verbosity = arguments.v
-    sct.init_sct(log_level=verbosity, update=True)  # Update log level
+    init_sct(log_level=verbosity, update=True)  # Update log level
 
     input_filename = arguments.i
     output_fname = arguments.o
@@ -391,6 +391,6 @@ def launch_manual_label_gui(img: Image, input_labels_img: Image, labels: Sequenc
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -26,7 +26,7 @@ from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import create_labels_along_segmentation
 
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 import sct_utils as sct
 import sct_straighten_spinalcord
 
@@ -274,7 +274,7 @@ def main(args=None):
     if arguments.param is not None:
         param.update(arguments.param[0])
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     remove_temp_files = arguments.r
     denoise = arguments.denoise
     laplacian = arguments.laplacian
@@ -469,6 +469,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_maths.py
+++ b/scripts/sct_maths.py
@@ -23,10 +23,10 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type, init_sct
 import spinalcordtoolbox.math as sct_math
 
-from sct_utils import printv, extract_fname, display_viewer_syntax, init_sct
+from sct_utils import printv, extract_fname, display_viewer_syntax
 
 
 def get_parser():

--- a/scripts/sct_merge_images.py
+++ b/scripts/sct_merge_images.py
@@ -27,7 +27,7 @@ import sct_utils as sct
 import sct_apply_transfo
 import spinalcordtoolbox.image as msct_image
 import sct_maths
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 
 
 class Param:
@@ -212,7 +212,7 @@ def main():
     if arguments.r is not None:
         param.rm_tmp = arguments.r
     param.verbose = arguments.v
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # check if list of input files and warping fields have same length
     assert len(list_fname_src) == len(list_fname_warp), "ERROR: list of files are not of the same length"
@@ -227,5 +227,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -26,11 +26,9 @@ from matplotlib.ticker import MaxNLocator
 
 import sct_utils as sct
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, parse_num_list, init_sct
 from spinalcordtoolbox import process_seg
-from spinalcordtoolbox.aggregate_slicewise import aggregate_per_slice_or_level, save_as_csv, func_wa, func_std, \
-    func_sum, _merge_dict
-from spinalcordtoolbox.utils import parse_num_list
+from spinalcordtoolbox.aggregate_slicewise import *
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -312,7 +310,7 @@ def main(args=None):
     qc_subject = arguments.qc_subject
 
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # update fields
     metrics_agg = {}
@@ -336,7 +334,7 @@ def main(args=None):
                                                             levels=parse_num_list(vert_levels), perslice=perslice,
                                                             perlevel=perlevel, vert_level=fname_vert_levels,
                                                             group_funcs=group_funcs)
-    metrics_agg_merged = _merge_dict(metrics_agg)
+    metrics_agg_merged = merge_dict(metrics_agg)
     save_as_csv(metrics_agg_merged, file_out, fname_in=fname_segmentation, append=append)
 
     # QC report (only show CSA for clarity)
@@ -349,6 +347,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main(sys.argv[1:])

--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -28,7 +28,8 @@ import sct_utils as sct
 # TODO: Properly test when first PR (that includes list_type) gets merged
 from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, parse_num_list, init_sct
 from spinalcordtoolbox import process_seg
-from spinalcordtoolbox.aggregate_slicewise import *
+from spinalcordtoolbox.aggregate_slicewise import aggregate_per_slice_or_level, save_as_csv, func_wa, func_std, \
+    func_sum, merge_dict
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -25,7 +25,7 @@ from spinalcordtoolbox.image import Image
 import sct_image
 import sct_utils as sct
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 from spinalcordtoolbox.centerline import optic
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -448,7 +448,7 @@ def propseg(img_input, options_dict):
     remove_temp_files = arguments.r
 
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     # Update for propseg binary
     if verbose > 0:
         cmd += ["-verbose"]
@@ -662,7 +662,7 @@ def main(arguments):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     parser = get_parser()
     arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     res = main(arguments)

--- a/scripts/sct_qc.py
+++ b/scripts/sct_qc.py
@@ -11,7 +11,8 @@
 from __future__ import absolute_import, division
 
 import argparse
-import sct_utils as sct
+
+from spinalcordtoolbox.utils import init_sct
 
 
 def get_parser():
@@ -84,5 +85,5 @@ def main(args):
 
 if __name__ == '__main__':
     arguments = get_parser().parse_args()
-    sct.init_sct(log_level=2 if arguments.v else 1)
+    init_sct(log_level=2 if arguments.v else 1)
     main(arguments)

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -39,7 +39,7 @@ import numpy as np
 
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.registration.register import Paramreg, ParamregMultiStep
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 
 import sct_utils as sct
 from sct_register_to_template import register_wrapper
@@ -336,7 +336,7 @@ def main(args=None):
     interp = arguments.x
     remove_temp_files = arguments.r
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # sct.printv(arguments)
     sct.printv('\nInput parameters:')
@@ -405,6 +405,6 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -46,7 +46,7 @@ from sct_convert import convert
 from sct_image import split_data, concat_warp2d
 
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
 import sct_apply_transfo
 
 
@@ -326,7 +326,7 @@ def main(args=None):
     ref = arguments.ref
     param.remove_temp_files = arguments.r
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both
     param_centerline = ParamCenterline(
         algo_fitting=arguments.centerline_algo,
@@ -1293,6 +1293,6 @@ def register(src, dest, step, param):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # call main function
     main()

--- a/scripts/sct_resample.py
+++ b/scripts/sct_resample.py
@@ -6,7 +6,7 @@
 # ---------------------------------------------------------------------------------------
 # Copyright (c) 2014 Polytechnique Montreal <www.neuro.polymtl.ca>
 # Authors: Julien Cohen-Adad, Sara Dupont
-# 
+#
 # About the license: see the file LICENSE.TXT
 #########################################################################################
 
@@ -19,7 +19,7 @@ import sys
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
 import spinalcordtoolbox.resampling
 
 # DEFAULT PARAMETERS
@@ -146,12 +146,12 @@ def run_main():
         else:
             param.interpolation = arguments.x
     param.verbose = int(arguments.v)
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
                                                param.interpolation, param.verbose, fname_ref=param.ref)
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     run_main()

--- a/scripts/sct_run_batch.py
+++ b/scripts/sct_run_batch.py
@@ -35,7 +35,7 @@ import psutil
 from textwrap import dedent
 from types import SimpleNamespace
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, Tee, send_email, __get_commit, __get_git_origin
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, Tee, send_email, __get_commit, __get_git_origin, init_sct
 from spinalcordtoolbox import __version__
 
 import sct_utils as sct
@@ -220,7 +220,7 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
 
 def main(argv):
     # Print the sct startup info
-    sct.init_sct()
+    init_sct()
 
     # Parse the command line arguments
     parser = get_parser()

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -26,7 +26,7 @@ import sct_maths
 import spinalcordtoolbox.image as msct_image
 from sct_convert import convert
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type, init_sct
 
 # PARAMETERS
 class Param:
@@ -133,7 +133,7 @@ def main(args=None):
         sigma = arguments.smooth
     remove_temp_files = arguments.r
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
 
     # Display arguments
     sct.printv('\nCheck input arguments...')
@@ -253,5 +253,5 @@ def main(args=None):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_straighten_spinalcord.py
+++ b/scripts/sct_straighten_spinalcord.py
@@ -22,7 +22,7 @@ import argparse
 from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 
 import sct_utils as sct
 
@@ -236,7 +236,7 @@ def main(args=None):
     sc_straight.path_output = arguments.ofolder
     path_qc = arguments.qc
     verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     sc_straight.verbose = verbose
 
     # if arguments.cpu_nb is not None:
@@ -285,5 +285,5 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     main()

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -18,6 +18,7 @@ import signal
 import numpy as np
 from pandas import DataFrame
 
+from spinalcordtoolbox.utils import init_sct
 import sct_utils as sct
 
 sys.path.append(os.path.join(sct.__sct_dir__, 'testing'))
@@ -224,7 +225,7 @@ def main(args=None):
     jobs = arguments.jobs
 
     param.verbose = arguments.verbose
-    sct.init_sct(log_level=param.verbose, update=True)  # Update log level
+    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     start_time = time.time()
 
@@ -608,7 +609,7 @@ def update_param(param):
 # START PROGRAM
 # ==========================================================================================
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     # initialize parameters
     param = Param()
     # call main function

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -49,48 +49,6 @@ from spinalcordtoolbox import __version__, __sct_dir__, __data_dir__
 from spinalcordtoolbox.utils import check_exe, sct_dir_local_path
 
 
-def init_sct(log_level=1, update=False):
-    """
-    Initialize the sct for typical terminal usage
-    :param log_level: int: 0: warning, 1: info, 2: debug.
-    :param update: Bool: If True, only update logging log level. Otherwise, set logging + Sentry.
-    :return:
-    """
-    dict_log_levels = {0: 'WARNING', 1: 'INFO', 2: 'DEBUG'}
-
-    def _format_wrap(old_format):
-        def _format(record):
-            res = old_format(record)
-            if record.levelno >= logging.ERROR:
-                res = "\x1B[31;1m{}\x1B[0m".format(res)
-            elif record.levelno >= logging.WARNING:
-                res = "\x1B[33m{}\x1B[0m".format(res)
-            else:
-                pass
-            return res
-        return _format
-
-    # Set logging level for logger and increase level for global config (to avoid logging when calling child functions)
-    logger.setLevel(getattr(logging, dict_log_levels[log_level]))
-    logging.root.setLevel(getattr(logging, dict_log_levels[log_level]))
-
-    if not update:
-        # Initialize logging
-        hdlr = logging.StreamHandler(sys.stdout)
-        fmt = logging.Formatter()
-        fmt.format = _format_wrap(fmt.format)
-        hdlr.setFormatter(fmt)
-        logging.root.addHandler(hdlr)
-
-        # Sentry config
-        init_error_client()
-        if os.environ.get("SCT_TIMER", None) is not None:
-            add_elapsed_time_counter()
-
-        # Display SCT version
-        logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
-
-
 def add_elapsed_time_counter():
     """
     """

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -31,9 +31,6 @@ import spinalcordtoolbox.utils as utils
 
 logger = logging.getLogger(__name__)
 
-if os.getenv('SENTRY_DSN', None):
-    # do no import if Sentry is not set (i.e., if variable SENTRY_DSN is not defined)
-    import raven
 
 if sys.hexversion < 0x03030000:
     import pipes
@@ -44,102 +41,8 @@ else:
     def list2cmdline(lst):
         return " ".join(shlex.quote(x) for x in lst)
 
-
 from spinalcordtoolbox import __version__, __sct_dir__, __data_dir__
 from spinalcordtoolbox.utils import check_exe, sct_dir_local_path
-
-
-def add_elapsed_time_counter():
-    """
-    """
-    import atexit
-    class Timer():
-        def __init__(self):
-            self._t0 = time.time()
-        def atexit(self):
-            print("Elapsed time: %.3f seconds" % (time.time()-self._t0))
-    t = Timer()
-    atexit.register(t.atexit)
-
-
-def init_error_client():
-    """ Send traceback to neuropoly servers
-
-    :return:
-    """
-    if os.getenv('SENTRY_DSN'):
-        logger.debug('Configuring sentry report')
-        try:
-            client = raven.Client(
-             release=__version__,
-             processors=(
-              'raven.processors.RemoveStackLocalsProcessor',
-              'raven.processors.SanitizePasswordsProcessor'),
-            )
-            server_log_handler(client)
-            traceback_to_server(client)
-
-            old_exitfunc = sys.exitfunc
-            def exitfunc():
-                sent_something = False
-                try:
-                    # implementation-specific
-                    import atexit
-                    for handler, args, kw in atexit._exithandlers:
-                        if handler.__module__.startswith("raven."):
-                            sent_something = True
-                except:
-                    pass
-                old_exitfunc()
-                if sent_something:
-                    print("Note: you can opt out of Sentry reporting by editing the file ${SCT_DIR}/bin/sct_launcher and delete the line starting with \"export SENTRY_DSN\"")
-
-            sys.exitfunc = exitfunc
-        except raven.exceptions.InvalidDsn:
-            # This could happen if sct staff change the dsn
-            logger.debug('Sentry DSN not valid anymore, not reporting errors')
-
-
-def traceback_to_server(client):
-    """
-        Send all traceback children of Exception to sentry
-    """
-
-    def excepthook(exctype, value, traceback):
-        if issubclass(exctype, Exception):
-            client.captureException(exc_info=(exctype, value, traceback))
-        sys.__excepthook__(exctype, value, traceback)
-
-    sys.excepthook = excepthook
-
-
-def server_log_handler(client):
-    """ Adds sentry log handler to the logger
-
-    :return: the sentry handler
-    """
-    from raven.handlers.logging import SentryHandler
-
-    sh = SentryHandler(client=client, level=logging.ERROR)
-
-    # Don't send Sentry events for command-line usage errors
-    old_emit = sh.emit
-    def emit(self, record):
-        if record.message.startswith("Command-line usage error:"):
-            return
-        return old_emit(record)
-
-    sh.emit = lambda x: emit(sh, x)
-
-
-    fmt = ("[%(asctime)s][%(levelname)s] %(filename)s: %(lineno)d | "
-            "%(message)s")
-    formatter = logging.Formatter(fmt=fmt, datefmt="%H:%M:%S")
-    formatter.converter = time.gmtime
-    sh.setFormatter(formatter)
-
-    logger.addHandler(sh)
-    return sh
 
 
 # define class color

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -18,7 +18,7 @@ import argparse
 
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
 import sct_utils as sct
 
 
@@ -237,7 +237,7 @@ def main(args=None):
     folder_out = arguments.ofolder
     path_template = arguments.t
     verbose = int(arguments.v)
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    init_sct(log_level=verbose, update=True)  # Update log level
     path_qc = arguments.qc
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
@@ -276,6 +276,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    sct.init_sct()
+    init_sct()
     param = Param()
     main()

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -441,7 +441,7 @@ def make_a_string(item):
         return item
 
 
-def _merge_dict(dict_in):
+def merge_dict(dict_in):
     """
     Merge n dictionaries that are contained at the root key
     Example:

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -24,7 +24,6 @@ if os.getenv('SENTRY_DSN', None):
     import raven
 
 # TODO: add test
-
 def init_sct(log_level=1, update=False):
     """
     Initialize the sct for typical terminal usage

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -20,6 +20,47 @@ logger = logging.getLogger(__name__)
 
 # TODO: add test
 
+def init_sct(log_level=1, update=False):
+    """
+    Initialize the sct for typical terminal usage
+    :param log_level: int: 0: warning, 1: info, 2: debug.
+    :param update: Bool: If True, only update logging log level. Otherwise, set logging + Sentry.
+    :return:
+    """
+    dict_log_levels = {0: 'WARNING', 1: 'INFO', 2: 'DEBUG'}
+
+    def _format_wrap(old_format):
+        def _format(record):
+            res = old_format(record)
+            if record.levelno >= logging.ERROR:
+                res = "\x1B[31;1m{}\x1B[0m".format(res)
+            elif record.levelno >= logging.WARNING:
+                res = "\x1B[33m{}\x1B[0m".format(res)
+            else:
+                pass
+            return res
+        return _format
+
+    # Set logging level for logger and increase level for global config (to avoid logging when calling child functions)
+    logger.setLevel(getattr(logging, dict_log_levels[log_level]))
+    logging.root.setLevel(getattr(logging, dict_log_levels[log_level]))
+
+    if not update:
+        # Initialize logging
+        hdlr = logging.StreamHandler(sys.stdout)
+        fmt = logging.Formatter()
+        fmt.format = _format_wrap(fmt.format)
+        hdlr.setFormatter(fmt)
+        logging.root.addHandler(hdlr)
+
+        # Sentry config
+        init_error_client()
+        if os.environ.get("SCT_TIMER", None) is not None:
+            add_elapsed_time_counter()
+
+        # Display SCT version
+        logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
+
 
 class ActionCreateFolder(argparse.Action):
     """

--- a/spinalcordtoolbox/utils.py
+++ b/spinalcordtoolbox/utils.py
@@ -13,10 +13,15 @@ import subprocess
 import shutil
 import tqdm
 import zipfile
+import time
 from enum import Enum
 
 logger = logging.getLogger(__name__)
 
+
+if os.getenv('SENTRY_DSN', None):
+    # do no import if Sentry is not set (i.e., if variable SENTRY_DSN is not defined)
+    import raven
 
 # TODO: add test
 
@@ -41,6 +46,7 @@ def init_sct(log_level=1, update=False):
             return res
         return _format
 
+
     # Set logging level for logger and increase level for global config (to avoid logging when calling child functions)
     logger.setLevel(getattr(logging, dict_log_levels[log_level]))
     logging.root.setLevel(getattr(logging, dict_log_levels[log_level]))
@@ -61,6 +67,90 @@ def init_sct(log_level=1, update=False):
         # Display SCT version
         logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
 
+
+def add_elapsed_time_counter():
+        import atexit
+        class Timer():
+            def __init__(self):
+                self._t0 = time.time()
+            def atexit(self):
+                print("Elapsed time: %.3f seconds" % (time.time()-self._t0))
+        t = Timer()
+        atexit.register(t.atexit)
+
+
+def traceback_to_server(client):
+    """
+        Send all traceback children of Exception to sentry
+    """
+
+    def excepthook(exctype, value, traceback):
+        if issubclass(exctype, Exception):
+            client.captureException(exc_info=(exctype, value, traceback))
+        sys.__excepthook__(exctype, value, traceback)
+
+    sys.excepthook = excepthook
+
+
+def init_error_client():
+    if os.getenv('SENTRY_DSN'):
+        logger.debug('Configuring sentry report')
+        try:
+            client = raven.Client(
+            release=__version__,
+            processors=(
+            'raven.processors.RemoveStackLocalsProcessor',
+            'raven.processors.SanitizePasswordsProcessor'),
+            )
+            server_log_handler(client)
+            traceback_to_server(client)
+            old_exitfunc = sys.exitfunc
+            def exitfunc():
+                sent_something = False
+                try:
+                    # implementation-specific
+                    import atexit
+                    for handler, args, kw in atexit._exithandlers:
+                        if handler.__module__.startswith("raven."):
+                            sent_something = True
+                except:
+                    pass
+                old_exitfunc()
+                if sent_something:
+                    print("Note: you can opt out of Sentry reporting by editing the file ${SCT_DIR}/bin/sct_launcher and delete the line starting with \"export SENTRY_DSN\"")
+            sys.exitfunc = exitfunc
+        except raven.exceptions.InvalidDsn:
+            # This could happen if sct staff change the dsn
+            logger.debug('Sentry DSN not valid anymore, not reporting errors')
+
+
+def server_log_handler(client):
+    """ Adds sentry log handler to the logger
+
+    :return: the sentry handler
+    """
+    from raven.handlers.logging import SentryHandler
+
+    sh = SentryHandler(client=client, level=logging.ERROR)
+
+    # Don't send Sentry events for command-line usage errors
+    old_emit = sh.emit
+    def emit(self, record):
+        if record.message.startswith("Command-line usage error:"):
+            return
+        return old_emit(record)
+
+    sh.emit = lambda x: emit(sh, x)
+
+
+    fmt = ("[%(asctime)s][%(levelname)s] %(filename)s: %(lineno)d | "
+            "%(message)s")
+    formatter = logging.Formatter(fmt=fmt, datefmt="%H:%M:%S")
+    formatter.converter = time.gmtime
+    sh.setFormatter(formatter)
+
+    logger.addHandler(sh)
+    return sh
 
 class ActionCreateFolder(argparse.Action):
     """

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -17,10 +17,9 @@ from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, f
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.testing.create_test_data import dummy_centerline
 import spinalcordtoolbox.math
-from spinalcordtoolbox.utils import sct_test_path
+from spinalcordtoolbox.utils import sct_test_path, init_sct
 
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
-from sct_utils import init_sct
 
 
 init_sct(log_level=2)  # Set logger in debug mode

--- a/unit_testing/test_qmri.py
+++ b/unit_testing/test_qmri.py
@@ -11,8 +11,7 @@ import pytest
 
 from spinalcordtoolbox.qmri import mt
 from spinalcordtoolbox.image import Image
-
-from sct_utils import init_sct
+from spinalcordtoolbox.utils import init_sct
 
 init_sct(log_level=2)  # Set logger in debug mode
 VERBOSE = 0  # Set to 2 to save images, 0 otherwise


### PR DESCRIPTION
In the scope of #2898 

Move `init_sct()` and associated deps to `spinalcordtoolbox.utils`. Since this touches a lot of files (basically all of them) I decided to put it in its own PR.