### PR TITLE
Drop 10.12 testing in TravisCI (and fix numpy preinstall)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ matrix:
           packages:
             - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.13 (High Sierra)"
-      if: branch = release or type = cron
+      # if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ matrix:
           packages:
             - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.13 (High Sierra)"
-      # if: branch = release or type = cron
+      if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,16 +110,7 @@ matrix:
     - name: "OSX 10.13 (High Sierra)"
       if: branch = release or type = cron
       os: osx
-      addons:
-        homebrew:
-          packages:
-            - libomp  # Needed for onnxruntime Python package, see issue #2930
-          update: true  # Fixes issue w/outdated Homebrew in older MacOS images
       osx_image: xcode9.4
-    - name: "OSX 10.12 (Sierra)"
-      if: branch = release or type = cron
-      os: osx
-      osx_image: xcode9.2
       addons:
         homebrew:
           packages:

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -17,7 +17,7 @@ Requirements
 
 * Operating System (OS):
 
-  * macOS >= 10.12
+  * macOS >= 10.13
   * Debian >=9
   * Ubuntu >= 16.04
   * Fedora >= 19

--- a/install_sct
+++ b/install_sct
@@ -529,11 +529,6 @@ conda activate venv_sct
 
 # Install Python dependencies
 print info "Installing Python dependencies..."
-# numpy is an undeclared build dependency: https://github.com/scikit-image/scikit-image/issues/4919
-# so explicitly install it as a workaround; note that in releases with requirements-freeze.txt
-# this can cause a strange double-install: https://github.com/neuropoly/spinalcordtoolbox/issues/2750
-# but we can live with that until https://github.com/scikit-image/scikit-image/pull/4920 is merged.
-pip install numpy
 # Check if a frozen version of the requirements exist (for release only)
 if [[ -f "requirements-freeze.txt" ]]; then
   print info "Using requirements-freeze.txt (release installation)"


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2930 and #2841. Supersedes #2919.

### Description

Apple dropped support for 10.12 in October 2019. Other third-party tools we depend on have either limited support, or have dropped support entirely for 10.12. In several cases, this has forced us to hack together solutions to keep support for 10.12 alive.

By dropping support for 10.12, this PR deals with 2 such 10.12-specific issues at once: `onnxruntime` requiring `libomp` to be installed in the build environment (tricky for 10.12), and `scikit-image`'s 10.12 sdist requiring a `numpy` preinstall.