### PR TITLE
sct_utils: cleanup dead code

### DIFF
--- a/scripts/isct_convert_binary_to_trilinear.py
+++ b/scripts/isct_convert_binary_to_trilinear.py
@@ -23,7 +23,7 @@ import time
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import init_sct
+from spinalcordtoolbox.utils import init_sct, run_proc
 
 import sct_utils as sct
 
@@ -112,7 +112,7 @@ def main():
 
     # upsample data
     sct.printv('\nUpsample data...', verbose)
-    sct.run(["sct_resample",
+    run_proc(["sct_resample",
      "-i", "data.nii",
      "-x", "linear",
      "-vox", str(nx * interp_factor) + 'x' + str(ny * interp_factor) + 'x' + str(nz * interp_factor),
@@ -120,7 +120,7 @@ def main():
 
     # Smooth along centerline
     sct.printv('\nSmooth along centerline...', verbose)
-    sct.run(["sct_smooth_spinalcord",
+    run_proc(["sct_smooth_spinalcord",
      "-i", "data_up.nii",
      "-s", "data_up.nii",
      "-smooth", str(smoothing_sigma),
@@ -129,7 +129,7 @@ def main():
 
     # downsample data
     sct.printv('\nDownsample data...', verbose)
-    sct.run(["sct_resample",
+    run_proc(["sct_resample",
      "-i", "data_up_smooth.nii",
      "-x", "linear",
      "-vox", str(nx) + 'x' + str(ny) + 'x' + str(nz),

--- a/scripts/isct_test_ants.py
+++ b/scripts/isct_test_ants.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 import nibabel as nib
 
-from spinalcordtoolbox.utils import init_sct
+from spinalcordtoolbox.utils import init_sct, run_proc
 
 import sct_utils as sct
 
@@ -82,7 +82,7 @@ def main():
     # Estimate rigid transformation
     sct.printv('\nEstimate rigid transformation between paired landmarks...', verbose)
     # TODO fixup isct_ants* parsers
-    sct.run(['isct_antsRegistration',
+    run_proc(['isct_antsRegistration',
      '-d', '3',
      '-t', 'syn[1,3,1]',
      '-m', 'MeanSquares[data_dest.nii.gz,data_src.nii.gz,1,3]',
@@ -95,25 +95,25 @@ def main():
 
     # # Apply rigid transformation
     # sct.printv('\nApply rigid transformation to curved landmarks...', verbose)
-    # sct.run('sct_apply_transfo -i data_src.nii.gz -o data_src_rigid.nii.gz -d data_dest.nii.gz -w curve2straight_rigid.txt -p nn', verbose)
+    # run_proc('sct_apply_transfo -i data_src.nii.gz -o data_src_rigid.nii.gz -d data_dest.nii.gz -w curve2straight_rigid.txt -p nn', verbose)
     #
     # # Estimate b-spline transformation curve --> straight
     # sct.printv('\nEstimate b-spline transformation: curve --> straight...', verbose)
-    # sct.run('isct_ANTSLandmarksBSplineTransform data_dest.nii.gz data_src_rigid.nii.gz warp_curve2straight_intermediate.nii.gz 5x5x5 3 2 0', verbose)
+    # run_proc('isct_ANTSLandmarksBSplineTransform data_dest.nii.gz data_src_rigid.nii.gz warp_curve2straight_intermediate.nii.gz 5x5x5 3 2 0', verbose)
     #
     # # Concatenate rigid and non-linear transformations...
     # sct.printv('\nConcatenate rigid and non-linear transformations...', verbose)
     # cmd = 'isct_ComposeMultiTransform 3 warp_curve2straight.nii.gz -R data_dest.nii.gz warp_curve2straight_intermediate.nii.gz curve2straight_rigid.txt'
     # sct.printv('>> '+cmd, verbose)
-    # sct.run(cmd)
+    # run_proc(cmd)
     #
     # # Apply deformation to input image
     # sct.printv('\nApply transformation to input image...', verbose)
-    # sct.run('sct_apply_transfo -i data_src.nii.gz -o data_src_warp.nii.gz -d data_dest.nii.gz -w warp_curve2straight.nii.gz -p nn', verbose)
+    # run_proc('sct_apply_transfo -i data_src.nii.gz -o data_src_warp.nii.gz -d data_dest.nii.gz -w warp_curve2straight.nii.gz -p nn', verbose)
     #
     # Compute DICE coefficient between src and dest
     sct.printv('\nCompute DICE coefficient...', verbose)
-    sct.run(["sct_dice_coefficient",
+    run_proc(["sct_dice_coefficient",
      "-i", "data_dest.nii.gz",
      "-d", "data_src_reg.nii.gz",
      "-o", "dice.txt"], verbose)

--- a/scripts/sct_analyze_texture.py
+++ b/scripts/sct_analyze_texture.py
@@ -22,7 +22,7 @@ from skimage.feature import greycomatrix, greycoprops
 import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, sct_progress_bar, init_sct
+from spinalcordtoolbox.utils import *
 
 def get_parser():
     # Initialize the parser
@@ -207,8 +207,8 @@ class ExtractGLCM:
 
             # Average across angles and save it as wrk_folder/fnameIn_feature_distance_mean.extension
             fname_out = im_m + str(self.param_glcm.distance) + '_mean' + extension
-            sct.run('sct_image -i ' + ' '.join(im2mean_lst) + ' -concat t -o ' + fname_out)
-            sct.run('sct_maths -i ' + fname_out + ' -mean t -o ' + fname_out)
+            run_proc('sct_image -i ' + ' '.join(im2mean_lst) + ' -concat t -o ' + fname_out)
+            run_proc('sct_maths -i ' + fname_out + ' -mean t -o ' + fname_out)
             self.fname_metric_lst[im_m + str(self.param_glcm.distance) + '_mean'] = fname_out
 
     def extract_slices(self):

--- a/scripts/sct_apply_transfo.py
+++ b/scripts/sct_apply_transfo.py
@@ -19,7 +19,7 @@ from __future__ import division, absolute_import
 import sys, io, os, time, functools
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, run_proc
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
@@ -220,7 +220,7 @@ class Transform:
                 fname_src = fname_dilated_labels
 
             sct.printv("\nApply transformation and resample to destination space...", verbose)
-            sct.run(['isct_antsApplyTransforms',
+            run_proc(['isct_antsApplyTransforms',
                      '-d', dim,
                      '-i', fname_src,
                      '-o', fname_out,
@@ -264,7 +264,7 @@ class Transform:
                 file_data_split = 'data_T' + str(it).zfill(4) + '.nii'
                 file_data_split_reg = 'data_reg_T' + str(it).zfill(4) + '.nii'
 
-                status, output = sct.run(['isct_antsApplyTransforms',
+                status, output = run_proc(['isct_antsApplyTransforms',
                                           '-d', '3',
                                           '-i', file_data_split,
                                           '-o', file_data_split_reg,

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -31,7 +31,7 @@ import warnings
 import requirements
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import SmartFormatter, sct_dir_local_path, init_sct
+from spinalcordtoolbox.utils import SmartFormatter, sct_dir_local_path, init_sct, run_proc
 
 
 # DEFAULT PARAMETERS
@@ -235,9 +235,9 @@ def main():
 
     # complete test
     if complete_test:
-        print(sct.run('date', verbose))
-        print(sct.run('whoami', verbose))
-        print(sct.run('pwd', verbose))
+        print(run_proc('date', verbose))
+        print(run_proc('whoami', verbose))
+        print(run_proc('pwd', verbose))
         bash_profile = os.path.expanduser("~/.bash_profile")
         if os.path.isfile(bash_profile):
             with io.open(bash_profile, "r") as f:
@@ -318,7 +318,7 @@ def main():
     # Check ANTs integrity
     print_line('Check ANTs compatibility with OS ')
     cmd = 'isct_test_ants'
-    status, output = sct.run(cmd, verbose=0, raise_exception=False)
+    status, output = run_proc(cmd, verbose=0, raise_exception=False)
     if status == 0:
         print_ok()
     else:
@@ -331,7 +331,7 @@ def main():
 
     # check PropSeg compatibility with OS
     print_line('Check PropSeg compatibility with OS ')
-    status, output = sct.run('isct_propseg', verbose=0, raise_exception=False, is_sct_binary=True)
+    status, output = run_proc('isct_propseg', verbose=0, raise_exception=False, is_sct_binary=True)
     if status in (0, 1):
         print_ok()
     else:

--- a/scripts/sct_compute_hausdorff_distance.py
+++ b/scripts/sct_compute_hausdorff_distance.py
@@ -19,7 +19,7 @@ import numpy as np
 import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, run_proc
 
 # TODO: display results ==> not only max : with a violin plot of h1 and h2 distribution ? see dev/straightening --> seaborn.violinplot
 # TODO: add the option Hyberbolic Hausdorff's distance : see  choi and seidel paper
@@ -391,17 +391,17 @@ def resample_image(fname, suffix='_resampled.nii.gz', binary=False, npx=0.3, npy
         if nz == 1:
             # when data is 2d: we convert it to a 3d image in order to avoid conversion problem with 2d data
             # TODO: check if this above problem is still present (now that we are using nibabel instead of nipy)
-            sct.run(['sct_image', '-i', ','.join([fname, fname]), '-concat', 'z', '-o', fname])
+            run_proc(['sct_image', '-i', ','.join([fname, fname]), '-concat', 'z', '-o', fname])
 
-        sct.run(['sct_resample', '-i', fname, '-mm', str(npx) + 'x' + str(npy) + 'x' + str(pz), '-o', name_resample, '-x', interpolation])
+        run_proc(['sct_resample', '-i', fname, '-mm', str(npx) + 'x' + str(npy) + 'x' + str(pz), '-o', name_resample, '-x', interpolation])
 
         if nz == 1:  # when input data was 2d: re-convert data 3d-->2d
-            sct.run(['sct_image', '-i', name_resample, '-split', 'z'])
+            run_proc(['sct_image', '-i', name_resample, '-split', 'z'])
             im_split = Image(name_resample.split('.nii.gz')[0] + '_Z0000.nii.gz')
             im_split.save(name_resample)
 
         if binary:
-            sct.run(['sct_maths', '-i', name_resample, '-bin', str(thr), '-o', name_resample])
+            run_proc(['sct_maths', '-i', name_resample, '-bin', str(thr), '-o', name_resample])
 
         if orientation != 'RPI':
             name_resample = Image(name_resample) \

--- a/scripts/sct_create_mask.py
+++ b/scripts/sct_create_mask.py
@@ -29,7 +29,7 @@ import sct_utils as sct
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from sct_image import concat_data
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, run_proc
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate
 
@@ -294,7 +294,7 @@ def create_line(param, fname, coord, nz):
     sct.copy(fname, 'line.nii', verbose=param.verbose)
 
     # set all voxels to zero
-    sct.run(['sct_maths', '-i', 'line.nii', '-mul', '0', '-o', 'line.nii'], param.verbose)
+    run_proc(['sct_maths', '-i', 'line.nii', '-mul', '0', '-o', 'line.nii'], param.verbose)
 
     labels = []
 

--- a/scripts/sct_detect_pmj.py
+++ b/scripts/sct_detect_pmj.py
@@ -23,7 +23,7 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct, run_proc
 
 
 def get_parser():
@@ -201,7 +201,7 @@ class DetectPMJ:
         os.environ["FSLOUTPUTTYPE"] = "NIFTI_PAIR"
         cmd_pmj = ['isct_spine_detect', self.pmj_model, self.slice2D_im.split('.nii')[0], self.dection_map_pmj]
         print(cmd_pmj)
-        sct.run(cmd_pmj, verbose=0, is_sct_binary=True)
+        run_proc(cmd_pmj, verbose=0, is_sct_binary=True)
 
         img = nib.load(self.dection_map_pmj + '_svm.hdr')  # convert .img and .hdr files to .nii
         nib.save(img, self.dection_map_pmj + '.nii')
@@ -234,7 +234,7 @@ class DetectPMJ:
             self.rl_coord = int(img.dim[2] / 2)  # Right_left coordinate
             del img
 
-        sct.run(['sct_crop_image', '-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1), '-o', self.slice2D_im])
+        run_proc(['sct_crop_image', '-i', self.fname_im, '-zmin', str(self.rl_coord), '-zmax', str(self.rl_coord + 1), '-o', self.slice2D_im])
 
     def orient2pir(self):
         """Orient input data to PIR orientation."""

--- a/scripts/sct_dice_coefficient.py
+++ b/scripts/sct_dice_coefficient.py
@@ -17,7 +17,7 @@ import os
 import argparse
 
 import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, run_proc
 
 
 def get_parser():
@@ -127,10 +127,10 @@ if __name__ == "__main__":
 
     if arguments.bin is not None:
         fname_input1_bin = sct.add_suffix(fname_input1, '_bin')
-        sct.run(['sct_maths', '-i', fname_input1, '-bin', '0', '-o', fname_input1_bin])
+        run_proc(['sct_maths', '-i', fname_input1, '-bin', '0', '-o', fname_input1_bin])
         fname_input1 = fname_input1_bin
         fname_input2_bin = sct.add_suffix(fname_input2, '_bin')
-        sct.run(['sct_maths', '-i', fname_input2, '-bin', '0', '-o', fname_input2_bin])
+        run_proc(['sct_maths', '-i', fname_input2, '-bin', '0', '-o', fname_input2_bin])
         fname_input2 = fname_input2_bin
 
     # copy header of im_1 to im_2
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     # #dice = compute_dice(Image(fname_input1), Image(fname_input2), mode='3d', zboundaries=False)
     # #sct.printv('Dice (python-based) = ' + str(dice), verbose)
 
-    status, output = sct.run(cmd, verbose, is_sct_binary=True)
+    status, output = run_proc(cmd, verbose, is_sct_binary=True)
 
     os.chdir(curdir) # go back to original directory
 

--- a/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -26,7 +26,7 @@ from spinalcordtoolbox.image import Image
 from sct_image import split_data
 from sct_convert import convert
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct, run_proc
 import argparse
 
 
@@ -202,7 +202,7 @@ def main(args=None):
     # Average b=0 images
     if average:
         sct.printv('\nAverage b=0...', verbose)
-        sct.run(['sct_maths', '-i', b0_name + ext, '-o', b0_mean_name + ext, '-mean', 't'], verbose)
+        run_proc(['sct_maths', '-i', b0_name + ext, '-o', b0_mean_name + ext, '-mean', 't'], verbose)
 
     # Merge DWI
     l = []
@@ -213,7 +213,7 @@ def main(args=None):
     # Average DWI images
     if average:
         sct.printv('\nAverage DWI...', verbose)
-        sct.run(['sct_maths', '-i', dwi_name + ext, '-o', dwi_mean_name + ext, '-mean', 't'], verbose)
+        run_proc(['sct_maths', '-i', dwi_name + ext, '-o', dwi_mean_name + ext, '-mean', 't'], verbose)
 
     # come back
     os.chdir(curdir)

--- a/scripts/sct_image.py
+++ b/scripts/sct_image.py
@@ -19,7 +19,7 @@ import numpy as np
 
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image, concat_data
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, run_proc
 from nibabel import Nifti1Image
 from nibabel.processing import resample_from_to
 
@@ -551,7 +551,7 @@ def visualize_warp(fname_warp, fname_grid=None, step=3, rm_tmp=True):
         from numpy import zeros
         tmp_dir = sct.tmp_create()
         im_warp = Image(fname_warp)
-        status, out = sct.run(['fslhd', fname_warp])
+        status, out = run_proc(['fslhd', fname_warp])
         curdir = os.getcwd()
         os.chdir(tmp_dir)
         dim1 = 'dim1           '
@@ -576,12 +576,12 @@ def visualize_warp(fname_warp, fname_grid=None, step=3, rm_tmp=True):
         im_grid.absolutepath = fname_grid
         im_grid.save()
         fname_grid_resample = sct.add_suffix(fname_grid, '_resample')
-        sct.run(['sct_resample', '-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample])
+        run_proc(['sct_resample', '-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample])
         fname_grid = os.path.join(tmp_dir, fname_grid_resample)
         os.chdir(curdir)
     path_warp, file_warp, ext_warp = sct.extract_fname(fname_warp)
     grid_warped = os.path.join(path_warp, sct.extract_fname(fname_grid)[1] + '_' + file_warp + ext_warp)
-    sct.run(['sct_apply_transfo', '-i', fname_grid, '-d', fname_grid, '-w', fname_warp, '-o', grid_warped])
+    run_proc(['sct_apply_transfo', '-i', fname_grid, '-d', fname_grid, '-w', fname_warp, '-o', grid_warped])
     if rm_tmp:
         sct.rmtree(tmp_dir)
 

--- a/scripts/sct_label_vertebrae.py
+++ b/scripts/sct_label_vertebrae.py
@@ -26,7 +26,7 @@ from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import create_labels_along_segmentation
 
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, run_proc
 import sct_utils as sct
 import sct_straighten_spinalcord
 
@@ -304,7 +304,7 @@ def main(args=None):
         sct.copy(os.path.join(curdir, "warp_straight2curve.nii.gz"), 'warp_straight2curve.nii.gz')
         sct.copy(os.path.join(curdir, "straight_ref.nii.gz"), 'straight_ref.nii.gz')
         # apply straightening
-        s, o = sct.run(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
+        s, o = run_proc(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
     else:
         sct_straighten_spinalcord.main(args=[
             '-i', 'data.nii',
@@ -316,12 +316,12 @@ def main(args=None):
 
     # resample to 0.5mm isotropic to match template resolution
     sct.printv('\nResample to 0.5mm isotropic...', verbose)
-    s, o = sct.run(['sct_resample', '-i', 'data_straight.nii', '-mm', '0.5x0.5x0.5', '-x', 'linear', '-o', 'data_straightr.nii'], verbose=verbose)
+    s, o = run_proc(['sct_resample', '-i', 'data_straight.nii', '-mm', '0.5x0.5x0.5', '-x', 'linear', '-o', 'data_straightr.nii'], verbose=verbose)
 
     # Apply straightening to segmentation
     # N.B. Output is RPI
     sct.printv('\nApply straightening to segmentation...', verbose)
-    sct.run('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
+    run_proc('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
             ('segmentation.nii',
              'data_straightr.nii',
              'warp_curve2straight.nii.gz',
@@ -331,13 +331,13 @@ def main(args=None):
             is_sct_binary=True,
            )
     # Threshold segmentation at 0.5
-    sct.run(['sct_maths', '-i', 'segmentation_straight.nii', '-thr', '0.5', '-o', 'segmentation_straight.nii'], verbose)
+    run_proc(['sct_maths', '-i', 'segmentation_straight.nii', '-thr', '0.5', '-o', 'segmentation_straight.nii'], verbose)
 
     # If disc label file is provided, label vertebrae using that file instead of automatically
     if fname_disc:
         # Apply straightening to disc-label
         sct.printv('\nApply straightening to disc labels...', verbose)
-        sct.run('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
+        run_proc('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
                 (fname_disc,
                  'data_straightr.nii',
                  'warp_curve2straight.nii.gz',
@@ -389,7 +389,7 @@ def main(args=None):
 
         # Apply straightening to z-label
         sct.printv('\nAnd apply straightening to label...', verbose)
-        sct.run('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
+        run_proc('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
                 (file_labelz,
                  'data_straightr.nii',
                  'warp_curve2straight.nii.gz',
@@ -406,12 +406,12 @@ def main(args=None):
         # denoise data
         if denoise:
             sct.printv('\nDenoise data...', verbose)
-            sct.run(['sct_maths', '-i', 'data_straightr.nii', '-denoise', 'h=0.05', '-o', 'data_straightr.nii'], verbose)
+            run_proc(['sct_maths', '-i', 'data_straightr.nii', '-denoise', 'h=0.05', '-o', 'data_straightr.nii'], verbose)
 
         # apply laplacian filtering
         if laplacian:
             sct.printv('\nApply Laplacian filter...', verbose)
-            sct.run(['sct_maths', '-i', 'data_straightr.nii', '-laplacian', '1', '-o', 'data_straightr.nii'], verbose)
+            run_proc(['sct_maths', '-i', 'data_straightr.nii', '-laplacian', '1', '-o', 'data_straightr.nii'], verbose)
 
         # detect vertebral levels on straight spinal cord
         init_disc[1]=init_disc[1]-1
@@ -420,7 +420,7 @@ def main(args=None):
 
     # un-straighten labeled spinal cord
     sct.printv('\nUn-straighten labeling...', verbose)
-    sct.run('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
+    run_proc('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
             ('segmentation_straight_labeled.nii',
              'segmentation.nii',
              'warp_straight2curve.nii.gz',

--- a/scripts/sct_propseg.py
+++ b/scripts/sct_propseg.py
@@ -25,7 +25,7 @@ from spinalcordtoolbox.image import Image
 import sct_image
 import sct_utils as sct
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, run_proc
 from spinalcordtoolbox.centerline import optic
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -604,7 +604,7 @@ def propseg(img_input, options_dict):
     cmd += ['-centerline-binary']
 
     # run propseg
-    status, output = sct.run(cmd, verbose, raise_exception=False, is_sct_binary=True)
+    status, output = run_proc(cmd, verbose, raise_exception=False, is_sct_binary=True)
 
     # check status is not 0
     if not status == 0:

--- a/scripts/sct_register_multimodal.py
+++ b/scripts/sct_register_multimodal.py
@@ -39,7 +39,7 @@ import numpy as np
 
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.registration.register import Paramreg, ParamregMultiStep
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, run_proc
 
 import sct_utils as sct
 from sct_register_to_template import register_wrapper
@@ -372,7 +372,7 @@ def main(args=None):
     # TODO: Check if necessary to do that
     # TODO: use that as step=0
     # sct.printv('\nPut source into destination space using header...', verbose)
-    # sct.run('isct_antsRegistration -d 3 -t Translation[0] -m MI[dest_pad.nii,src.nii,1,16] -c 0 -f 1 -s 0 -o
+    # run_proc('isct_antsRegistration -d 3 -t Translation[0] -m MI[dest_pad.nii,src.nii,1,16] -c 0 -f 1 -s 0 -o
     # [regAffine,src_regAffine.nii] -n BSpline[3]', verbose)
     # if segmentation, also do it for seg
 

--- a/scripts/sct_register_to_template.py
+++ b/scripts/sct_register_to_template.py
@@ -36,6 +36,7 @@ from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
 from spinalcordtoolbox.types import Coordinate
+from spinalcordtoolbox.utils import run_proc
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels
 
@@ -554,7 +555,7 @@ def main(args=None):
 
         dimensionality = len(Image(ftmp_data).hdr.get_data_shape())
         cmd = ['isct_ComposeMultiTransform', f"{dimensionality}", 'warp_straight2curve.nii.gz', '-R', ftmp_data, 'warp_straight2curve.nii.gz']
-        status, output = sct.run(cmd, verbose=verbose, is_sct_binary=True)
+        status, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
         if status != 0:
             raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 
@@ -596,7 +597,7 @@ def main(args=None):
 
             dimensionality = len(Image("template.nii").hdr.get_data_shape())
             cmd = ['isct_ComposeMultiTransform', f"{dimensionality}", 'warp_curve2straightAffine.nii.gz', '-R', 'template.nii', 'straight2templateAffine.txt', 'warp_curve2straight.nii.gz']
-            status, output = sct.run(cmd, verbose=verbose, is_sct_binary=True)
+            status, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
             if status != 0:
                 raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 
@@ -654,13 +655,13 @@ def main(args=None):
         # sub-sample in z-direction
         # TODO: refactor to use python module instead of doing i/o
         sct.printv('\nSub-sample in z-direction (for faster processing)...', verbose)
-        sct.run(['sct_resample', '-i', ftmp_template, '-o', add_suffix(ftmp_template, '_sub'), '-f', '1x1x' + zsubsample], verbose)
+        run_proc(['sct_resample', '-i', ftmp_template, '-o', add_suffix(ftmp_template, '_sub'), '-f', '1x1x' + zsubsample], verbose)
         ftmp_template = add_suffix(ftmp_template, '_sub')
-        sct.run(['sct_resample', '-i', ftmp_template_seg, '-o', add_suffix(ftmp_template_seg, '_sub'), '-f', '1x1x' + zsubsample], verbose)
+        run_proc(['sct_resample', '-i', ftmp_template_seg, '-o', add_suffix(ftmp_template_seg, '_sub'), '-f', '1x1x' + zsubsample], verbose)
         ftmp_template_seg = add_suffix(ftmp_template_seg, '_sub')
-        sct.run(['sct_resample', '-i', ftmp_data, '-o', add_suffix(ftmp_data, '_sub'), '-f', '1x1x' + zsubsample], verbose)
+        run_proc(['sct_resample', '-i', ftmp_data, '-o', add_suffix(ftmp_data, '_sub'), '-f', '1x1x' + zsubsample], verbose)
         ftmp_data = add_suffix(ftmp_data, '_sub')
-        sct.run(['sct_resample', '-i', ftmp_seg, '-o', add_suffix(ftmp_seg, '_sub'), '-f', '1x1x' + zsubsample], verbose)
+        run_proc(['sct_resample', '-i', ftmp_seg, '-o', add_suffix(ftmp_seg, '_sub'), '-f', '1x1x' + zsubsample], verbose)
         ftmp_seg = add_suffix(ftmp_seg, '_sub')
 
         # Registration straight spinal cord to template
@@ -679,7 +680,7 @@ def main(args=None):
 
         dimensionality = len(Image("template.nii").hdr.get_data_shape())
         cmd = ['isct_ComposeMultiTransform', f"{dimensionality}", 'warp_anat2template.nii.gz', '-R', 'template.nii', warp_forward, 'warp_curve2straightAffine.nii.gz']
-        status, output = sct.run(cmd, verbose=verbose, is_sct_binary=True)
+        status, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
         if status != 0:
             raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 
@@ -690,14 +691,14 @@ def main(args=None):
         if level_alignment:
             dimensionality = len(Image("data.nii").hdr.get_data_shape())
             cmd = ['isct_ComposeMultiTransform', f"{dimensionality}", 'warp_template2anat.nii.gz', '-R', 'data.nii', 'warp_straight2curve.nii.gz', warp_inverse]
-            status, output = sct.run(cmd, verbose=verbose, is_sct_binary=True)
+            status, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
             if status != 0:
                 raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 
         else:
             dimensionality = len(Image("data.nii").hdr.get_data_shape())
             cmd = ['isct_ComposeMultiTransform', f"{dimensionality}", 'warp_template2anat.nii.gz', '-R', 'data.nii', 'warp_straight2curve.nii.gz', '-i', 'straight2templateAffine.txt', warp_inverse]
-            status, output = sct.run(cmd, verbose=verbose, is_sct_binary=True)
+            status, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
             if status != 0:
                 raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 
@@ -743,8 +744,8 @@ def main(args=None):
         os.rename(warp_inverse, 'warp_anat2template.nii.gz')
 
     # Apply warping fields to anat and template
-    sct.run(['sct_apply_transfo', '-i', 'template.nii', '-o', 'template2anat.nii.gz', '-d', 'data.nii', '-w', 'warp_template2anat.nii.gz', '-crop', '0'], verbose)
-    sct.run(['sct_apply_transfo', '-i', 'data.nii', '-o', 'anat2template.nii.gz', '-d', 'template.nii', '-w', 'warp_anat2template.nii.gz', '-crop', '0'], verbose)
+    run_proc(['sct_apply_transfo', '-i', 'template.nii', '-o', 'template2anat.nii.gz', '-d', 'data.nii', '-w', 'warp_template2anat.nii.gz', '-crop', '0'], verbose)
+    run_proc(['sct_apply_transfo', '-i', 'data.nii', '-o', 'anat2template.nii.gz', '-d', 'template.nii', '-w', 'warp_anat2template.nii.gz', '-crop', '0'], verbose)
 
     # come back
     os.chdir(curdir)
@@ -1073,7 +1074,7 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
     if warp_forward:
         cmd += reversed(warp_forward)
 
-    status, output = sct.run(cmd, is_sct_binary=True)
+    status, output = run_proc(cmd, is_sct_binary=True)
     if status != 0:
         raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 
@@ -1088,7 +1089,7 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
     if warp_inverse:
         cmd += reversed(warp_inverse)
 
-    status, output = sct.run(cmd, is_sct_binary=True)
+    status, output = run_proc(cmd, is_sct_binary=True)
     if status != 0:
         raise RuntimeError(f"Subprocess call {cmd} returned non-zero: {output}")
 

--- a/scripts/sct_smooth_spinalcord.py
+++ b/scripts/sct_smooth_spinalcord.py
@@ -26,7 +26,7 @@ import sct_maths
 import spinalcordtoolbox.image as msct_image
 from sct_convert import convert
 # TODO: Properly test when first PR (that includes list_type) gets merged
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, list_type, init_sct, run_proc
 
 # PARAMETERS
 class Param:
@@ -201,9 +201,9 @@ def main(args=None):
         sct.copy(os.path.join(curdir, 'warp_straight2curve.nii.gz'), 'warp_straight2curve.nii.gz')
         sct.copy(os.path.join(curdir, 'straight_ref.nii.gz'), 'straight_ref.nii.gz')
         # apply straightening
-        sct.run(['sct_apply_transfo', '-i', fname_anat_rpi, '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'anat_rpi_straight.nii', '-x', 'spline'], verbose)
+        run_proc(['sct_apply_transfo', '-i', fname_anat_rpi, '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'anat_rpi_straight.nii', '-x', 'spline'], verbose)
     else:
-        sct.run(['sct_straighten_spinalcord', '-i', fname_anat_rpi, '-o', 'anat_rpi_straight.nii', '-s', fname_centerline_rpi, '-x', 'spline', '-param', 'algo_fitting='+param.algo_fitting], verbose)
+        run_proc(['sct_straighten_spinalcord', '-i', fname_anat_rpi, '-o', 'anat_rpi_straight.nii', '-s', fname_centerline_rpi, '-x', 'spline', '-param', 'algo_fitting='+param.algo_fitting], verbose)
         sct.cache_save(cachefile, cache_sig)
         # move warping fields locally (to use caching next time)
         sct.copy('warp_curve2straight.nii.gz', os.path.join(curdir, 'warp_curve2straight.nii.gz'))
@@ -218,7 +218,7 @@ def main(args=None):
                          '-v', '0'])
     # Apply the reversed warping field to get back the curved spinal cord
     sct.printv('\nApply the reversed warping field to get back the curved spinal cord...')
-    sct.run(['sct_apply_transfo', '-i', 'anat_rpi_straight_smooth.nii', '-o', 'anat_rpi_straight_smooth_curved.nii', '-d', 'anat.nii', '-w', 'warp_straight2curve.nii.gz', '-x', 'spline'], verbose)
+    run_proc(['sct_apply_transfo', '-i', 'anat_rpi_straight_smooth.nii', '-o', 'anat_rpi_straight_smooth_curved.nii', '-d', 'anat.nii', '-w', 'warp_straight2curve.nii.gz', '-x', 'spline'], verbose)
 
     # replace zeroed voxels by original image (issue #937)
     sct.printv('\nReplace zeroed voxels by original image...', verbose)

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -180,10 +180,6 @@ def process_function(fname, param):
         # test function
         try:
             param_test = test_function(param_test)
-        except sct.RunError as e:
-            list_status_function.append(1)
-            list_output.append("Got SCT exception:")
-            list_output.append(e.args[0])
         except Exception as e:
             list_status_function.append(1)
             list_output.append("Got exception: %s" % e)

--- a/scripts/sct_testing.py
+++ b/scripts/sct_testing.py
@@ -18,7 +18,7 @@ import signal
 import numpy as np
 from pandas import DataFrame
 
-from spinalcordtoolbox.utils import init_sct
+from spinalcordtoolbox.utils import init_sct, run_proc
 import sct_utils as sct
 
 sys.path.append(os.path.join(sct.__sct_dir__, 'testing'))
@@ -569,7 +569,7 @@ def test_function(param_test):
         #     # in case of relative path, we want a subfolder too
         #     os.makedirs(param_test.path_output)
         # os.chdir(path_testing)
-        param_test.status, o = sct.run(cmd, verbose=0)
+        param_test.status, o = run_proc(cmd, verbose=0)
         if param_test.status:
             raise Exception
     except Exception as err:

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -81,17 +81,6 @@ def add_suffix(fname, suffix):
 #=======================================================================================================================
 # run
 #=======================================================================================================================
-def which_sct_binaries():
-    """
-    :return name of the sct binaries to use on this platform
-    """
-
-    if sys.platform.startswith("linux"):
-        return "binaries_linux"
-    else:
-        return "binaries_osx"
-
-
 def display_open(file):
     """Print the syntax to open a file based on the platform."""
     if sys.platform == 'linux':

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -349,28 +349,9 @@ def check_write_permission(fname, verbose=1):
         path_fname, file_fname, ext_fname = extract_fname(os.path.abspath(fname))
         return os.access(path_fname, os.W_OK)
 
-
-#=======================================================================================================================
-# create_folder:  create folder (check if exists before creating it)
-#   output: 0 -> folder created
-#           1 -> folder already exist
-#           2 -> permission denied
-#=======================================================================================================================
-def create_folder(folder):
-    if not os.path.exists(folder):
-        try:
-            os.makedirs(folder)
-            return 0
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                return 2
-    else:
-        return 1
-
 #=======================================================================================================================
 # check_dim
 #=======================================================================================================================
-
 def check_dim(fname, dim_lst=[3]):
     """
     Check if input dimension matches the input dimension requirements specified in the dim list.

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -163,24 +163,6 @@ def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='',
         printv(cmd + '\n', verbose=1, type='info')
 
 
-def mkdir(path, verbose=1):
-    """Create a folder, like os.mkdir
-    """
-    try:
-        printv("mkdir %s" % (path), verbose=verbose, type="code")
-        os.mkdir(path)
-    except Exception as e:
-        raise
-
-def rm(path, verbose=1):
-    """Remove a file, almost like os.remove
-    """
-    try:
-        printv("rm %s" % (path), verbose=verbose, type="code")
-        os.remove(path)
-    except Exception as e:
-        raise
-
 def mv(src, dst, verbose=1):
     """Move a file from src to dst, almost like os.rename
     """
@@ -296,11 +278,10 @@ def get_absolute_path(fname):
     else:
         printv('\nERROR: ' + fname + ' does not exist. Exit program.\n', 1, 'error')
 
+
 #=======================================================================================================================
 # check_file_exist:  Check existence of a file or path
 #=======================================================================================================================
-
-
 def check_file_exist(fname, verbose=1):
     if fname[0] == '-':
         # fname should be a warping field that will be inverted, ignore the "-"
@@ -315,33 +296,6 @@ def check_file_exist(fname, verbose=1):
         printv('\nERROR: The file ' + fname + ' does not exist. Exit program.\n', 1, 'error')
         return False
 
-
-#=======================================================================================================================
-# check_folder_exist:  Check existence of a folder.
-#   Does not create it. If you want to create a folder, use create_folder
-#=======================================================================================================================
-def check_folder_exist(fname, verbose=1):
-    if os.path.isdir(fname):
-        printv('  OK: ' + fname, verbose, 'normal')
-        return True
-    else:
-        printv('\nWarning: The directory ' + str(fname) + ' does not exist.\n', 1, 'warning')
-        return False
-
-
-#=======================================================================================================================
-# check_write_permission:  Check existence of a folder.
-#   Does not create it. If you want to create a folder, use create_folder
-#=======================================================================================================================
-def check_write_permission(fname, verbose=1):
-    if os.path.isdir(fname):
-        if os.path.isdir(fname):
-            return os.access(fname, os.W_OK)
-        else:
-            printv('\nERROR: The directory ' + fname + ' does not exist. Exit program.\n', 1, 'error')
-    else:
-        path_fname, file_fname, ext_fname = extract_fname(os.path.abspath(fname))
-        return os.access(path_fname, os.W_OK)
 
 #=======================================================================================================================
 # check_dim
@@ -362,28 +316,6 @@ def check_dim(fname, dim_lst=[3]):
         sys.exit(2)
     else:
         return True
-
-
-#=======================================================================================================================
-# find_file_within_folder
-#=======================================================================================================================
-def find_file_within_folder(fname, directory, seek_type='file'):
-    """Find file (or part of file, e.g. 'my_file*.txt') within folder tree recursively - fname and directory must be
-    strings
-    seek_type: 'file' or 'dir' to look for either a file or a directory respectively."""
-    import fnmatch
-
-    all_path = []
-    for root, dirs, files in os.walk(directory):
-        if seek_type == 'dir':
-            for folder in dirs:
-                if fnmatch.fnmatch(folder, fname):
-                    all_path.append(os.path.join(root, folder))
-        else:
-            for file in files:
-                if fnmatch.fnmatch(file, fname):
-                    all_path.append(os.path.join(root, file))
-    return all_path
 
 
 def tmp_create(basename=None, verbose=1):
@@ -431,21 +363,6 @@ class TempFolder(object):
     def cleanup(self):
         """Remove the created folder and its contents."""
         rmtree(self.path_tmp)
-
-
-#=======================================================================================================================
-# copy a nifti file to (temporary) folder and convert to .nii or .nii.gz
-#=======================================================================================================================
-def tmp_copy_nifti(fname, path_tmp, fname_out='data.nii', verbose=0):
-    # tmp_copy_nifti('input.nii', path_tmp, 'raw.nii')
-    path_fname, file_fname, ext_fname = extract_fname(fname)
-    path_fname_out, file_fname_out, ext_fname_out = extract_fname(fname_out)
-
-    utils.run_proc('cp ' + fname + ' ' + path_tmp + file_fname_out + ext_fname)
-    if ext_fname_out == '.nii':
-        utils.run_proc('fslchfiletype NIFTI ' + path_tmp + file_fname_out, 0)
-    elif ext_fname_out == '.nii.gz':
-        utils.run_proc('fslchfiletype NIFTI_GZ ' + path_tmp + file_fname_out, 0)
 
 
 #=======================================================================================================================
@@ -510,34 +427,6 @@ def generate_output_file(fname_in, fname_out, squeeze_data=True, verbose=1):
     return os.path.join(path_out, file_out + ext_out)
 
 
-#=======================================================================================================================
-# check_if_installed
-#=======================================================================================================================
-# check if dependant software is installed
-def check_if_installed(cmd, name_software):
-    status, output = utils.run_proc(cmd)
-    if status != 0:
-        printv('\nERROR: ' + name_software + ' is not installed.\nExit program.\n')
-        sys.exit(2)
-
-
-#=======================================================================================================================
-# check_if_same_space
-#=======================================================================================================================
-# check if two images are in the same space and same orientation
-def check_if_same_space(fname_1, fname_2):
-    from spinalcordtoolbox.image import Image
-
-    im_1 = Image(fname_1)
-    im_2 = Image(fname_2)
-    q1 = im_1.hdr.get_qform()
-    q2 = im_2.hdr.get_qform()
-
-    dec = int(np.abs(np.round(np.log10(np.min(np.abs(q1[np.nonzero(q1)]))))) + 1)
-    dec = 4 if dec > 4 else dec
-    return np.all(np.around(q1, dec) == np.around(q2, dec))
-
-
 def printv(string, verbose=1, type='normal'):
     """
     Enables to print color-coded messages, depending on verbose status. Only use in command-line programs (e.g.,
@@ -568,20 +457,6 @@ def sign(x):
         return 1
     else:
         return -1
-
-
-#=======================================================================================================================
-# delete_nifti: delete nifti file(s)
-#=======================================================================================================================
-def delete_nifti(fname_in):
-    # extract input file extension
-    path_in, file_in, ext_in = extract_fname(fname_in)
-    # delete nifti if exist
-    if os.path.isfile(os.path.join(path_in, file_in + '.nii')):
-        os.system('rm ' + os.path.join(path_in, file_in + '.nii'))
-    # delete nifti if exist
-    if os.path.isfile(os.path.join(path_in, file_in + '.nii.gz')):
-        os.system('rm ' + os.path.join(path_in, file_in + '.nii.gz'))
 
 
 def get_interpolation(program, interp):
@@ -618,330 +493,12 @@ def get_interpolation(program, interp):
     return interp_program.strip().split()
 
 
-#=======================================================================================================================
-# template file dictionary
-#=======================================================================================================================
-def template_dict(template):
-    """
-    Dictionary of file names for template
-    :param template:
-    :return: dict_template
-    """
-    if template == 'PAM50':
-        dict_template = {'t2': 'template/PAM50_t2.nii.gz',
-                         't1': 'template/PAM50_t1.nii.gz'}
-    return dict_template
-
-
 class UnsupportedOs(Exception):
     def __init__(self, value):
         self.value = value
 
     def __str__(self):
         return repr(self.value)
-
-
-class Os(object):
-    '''Work out which platform we are running on'''
-
-    def __init__(self):
-        import os
-        if os.name != 'posix':
-            raise UnsupportedOs('We only support macOS/Linux')
-        import platform
-        self.os = platform.system().lower()
-        self.arch = platform.machine()
-        self.applever = ''
-
-        if self.os == 'darwin':
-            self.os = 'osx'
-            self.vendor = 'apple'
-            self.version = Version(platform.release())
-            (self.applever, _, _) = platform.mac_ver()
-            if self.arch == 'Power Macintosh':
-                raise UnsupportedOs('We do not support PowerPC')
-            self.glibc = ''
-            self.bits = ''
-        elif self.os == 'linux':
-            if hasattr(platform, 'linux_distribution'):
-                # We have a modern python (>2.4)
-                (self.vendor, version, _) = platform.linux_distribution(full_distribution_name=0)
-            else:
-                (self.vendor, version, _) = platform.dist()
-            self.vendor = self.vendor.lower()
-            self.version = Version(version)
-            self.glibc = platform.libc_ver()
-            if self.arch == 'x86_64':
-                self.bits = '64'
-            else:
-                self.bits = '32'
-                # raise UnsupportedOs("We no longer support 32 bit Linux. If you must use 32 bit Linux then try building from our sources.")
-        else:
-            raise UnsupportedOs("We do not support this OS.")
-
-
-class Version(object):
-    def __init__(self, version_sct):
-        self.version_sct = version_sct
-
-        if not isinstance(version_sct, basestring):
-            printv(version_sct)
-            raise Exception('Version is not a string.')
-
-        # detect beta, if it exist
-        version_sct_beta = version_sct.split('_')
-        try:
-            self.beta = version_sct_beta[1]
-            version_sct_main = version_sct_beta[0]
-            self.isbeta = True
-        except IndexError:
-            self.beta = ""
-            version_sct_main = version_sct
-            self.isbeta = False
-
-        version_sct_split = version_sct_main.split('.')
-
-        for v in version_sct_split:
-            if not v.isdigit():
-                raise ValueError('Bad version string.')
-        self.major = int(version_sct_split[0])
-        try:
-            self.minor = int(version_sct_split[1])
-        except IndexError:
-            self.minor = 0
-        try:
-            self.patch = int(version_sct_split[2])
-        except IndexError:
-            self.patch = 0
-        try:
-            self.hotfix = int(version_sct_split[3])
-        except IndexError:
-            self.hotfix = 0
-
-    def __repr__(self):
-        return "Version(%s,%s,%s,%s,%r)" % (self.major, self.minor, self.patch, self.hotfix, self.beta)
-
-    def __str__(self):
-        result = str(self.major) + "." + str(self.minor)
-        if self.patch != 0:
-            result = result + "." + str(self.patch)
-        if self.hotfix != 0:
-            result = result + "." + str(self.hotfix)
-        if self.beta != "":
-            result = result + "_" + self.beta
-        return result
-
-    def __ge__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self > other or self == other:
-            return True
-        return False
-
-    def __le__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self < other or self == other:
-            return True
-        return False
-
-    def __cmp__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self.__lt__(other):
-            return -1
-        if self.__gt__(other):
-            return 1
-        return 0
-
-    def __lt__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self.major < other.major:
-            return True
-        if self.major > other.major:
-            return False
-        if self.minor < other.minor:
-            return True
-        if self.minor > other.minor:
-            return False
-        if self.patch < other.patch:
-            return True
-        if self.patch > other.patch:
-            return False
-        if self.hotfix < other.hotfix:
-            return True
-        if self.hotfix > other.hotfix:
-            return False
-        if self.isbeta and not other.isbeta:
-            return True
-        if not self.isbeta and other.isbeta:
-            return False
-        # major, minor and patch all match so this is not less than
-        return False
-
-    def __gt__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self.major > other.major:
-            return True
-        if self.major < other.major:
-            return False
-        if self.minor > other.minor:
-            return True
-        if self.minor < other.minor:
-            return False
-        if self.patch > other.patch:
-            return True
-        if self.patch < other.patch:
-            return False
-        if self.hotfix > other.hotfix:
-            return True
-        if self.hotfix < other.hotfix:
-            return False
-        if not self.isbeta and other.isbeta:
-            return True
-        if self.isbeta and not other.isbeta:
-            return False
-        # major, minor and patch all match so this is not less than
-        return False
-
-    def __eq__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self.major == other.major and self.minor == other.minor and self.patch == other.patch and self.hotfix == other.hotfix and self.beta == other.beta:
-            return True
-        return False
-
-    def __ne__(self, other):
-        if not isinstance(other, Version):
-            return NotImplemented
-        if self.__eq__(other):
-            return False
-        return True
-
-    def isLessThan_MajorMinor(self, other):
-        if self.major < other.major:
-            return True
-        if self.major > other.major:
-            return False
-        if self.minor < other.minor:
-            return True
-        else:
-            return False
-
-    def isGreaterOrEqualThan_MajorMinor(self, other):
-        if self.major > other.major:
-            return True
-        if self.major < other.major:
-            return False
-        if self.minor >= other.minor:
-            return True
-        else:
-            return False
-
-    def isEqualTo_MajorMinor(self, other):
-        return self.major == other.major and self.minor == other.minor
-
-    def isLessPatchThan_MajorMinor(self, other):
-        if self.isEqualTo_MajorMinor(other):
-            if self.patch < other.patch:
-                return True
-        return False
-
-    def getFolderName(self):
-        result = str(self.major) + "." + str(self.minor)
-        if self.patch != 0:
-            result = result + "." + str(self.patch)
-        if self.hotfix != 0:
-            result = result + "." + str(self.hotfix)
-        result = result + "_" + self.beta
-        return result
-
-
-class MsgUser(object):
-    # TODO: check if should be removed
-    __debug = False
-    __quiet = False
-
-    @classmethod
-    def debugOn(cls):
-        cls.__debug = True
-
-    @classmethod
-    def debugOff(cls):
-        cls.__debug = False
-
-    @classmethod
-    def quietOn(cls):
-        cls.__quiet = True
-
-    @classmethod
-    def quietOff(cls):
-        cls.__quiet = False
-
-    @classmethod
-    def isquiet(cls):
-        return cls.__quiet
-
-    @classmethod
-    def isdebug(cls):
-        return cls.__debug
-
-    @classmethod
-    def debug(cls, message, newline=True):
-        if cls.__debug:
-            from sys import stderr
-            mess = str(message)
-            if newline:
-                mess += "\n"
-            stderr.write(mess)
-
-    @classmethod
-    def message(cls, msg):
-        if cls.__quiet:
-            return
-        printv(msg)
-
-    @classmethod
-    def question(cls, msg):
-        printv(msg,)
-
-    @classmethod
-    def skipped(cls, msg):
-        if cls.__quiet:
-            return
-        printv("".join((bcolors.magenta, "[Skipped] ", bcolors.normal, msg)))
-
-    @classmethod
-    def ok(cls, msg):
-        if cls.__quiet:
-            return
-        log.info("".join((bcolors.green, "[OK] ", bcolors.normal, msg)))
-
-    @classmethod
-    def failed(cls, msg):
-        log.error("".join((bcolors.red, "[FAILED] ", bcolors.normal, msg)))
-
-    @classmethod
-    def warning(cls, msg):
-        if cls.__quiet:
-            return
-        log.warning("".join((bcolors.yellow, bcolors.bold, "[Warning]", bcolors.normal, " ", msg)))
-
-
-class Error(Exception):
-    """
-    The sct Basic error class
-    """
-    pass
-
-
-class RunError(Error):
-    """
-    sct runtime error
-    """
-    pass
 
 
 def cache_signature(input_files=[], input_data=[], input_params={}):

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -184,11 +184,8 @@ def rm(path, verbose=1):
 def mv(src, dst, verbose=1):
     """Move a file from src to dst, almost like os.rename
     """
-    try:
-        printv("mv %s %s" % (src, dst), verbose=verbose, type="code")
-        os.rename(src, dst)
-    except Exception as e:
-        raise
+    printv("mv %s %s" % (src, dst), verbose=verbose, type="code")
+    os.rename(src, dst)
 
 def copy(src, dst, verbose=1):
     """Copy src to dst, almost like shutil.copy
@@ -214,11 +211,8 @@ def copy(src, dst, verbose=1):
 def rmtree(folder, verbose=1):
     """Recursively remove folder, almost like shutil.rmtree
     """
-    try:
-        printv("rm -rf %s" % (folder), verbose=verbose, type="code")
-        shutil.rmtree(folder, ignore_errors=True)
-    except Exception as e:
-        raise # Must be another error
+    printv("rm -rf %s" % (folder), verbose=verbose, type="code")
+    shutil.rmtree(folder, ignore_errors=True)
 
 
 #=======================================================================================================================

--- a/scripts/sct_utils.py
+++ b/scripts/sct_utils.py
@@ -81,16 +81,6 @@ def add_suffix(fname, suffix):
 #=======================================================================================================================
 # run
 #=======================================================================================================================
-# Run UNIX command
-def run_old(cmd, verbose=1):
-    if verbose:
-        printv(bcolors.blue + cmd + bcolors.normal)
-    status, output = run(cmd)
-    if status != 0:
-        printv('\nERROR! \n' + output + '\nExit program.\n', 1, 'error')
-    else:
-        return status, output
-
 def which_sct_binaries():
     """
     :return name of the sct binaries to use on this platform

--- a/scripts/sct_warp_template.py
+++ b/scripts/sct_warp_template.py
@@ -18,7 +18,7 @@ import argparse
 
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, init_sct, run_proc
 import sct_utils as sct
 
 
@@ -110,7 +110,7 @@ def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, p
         for i in range(0, len(template_label_file)):
             fname_label = os.path.join(path_label, folder_label, template_label_file[i])
             # apply transfo
-            sct.run('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
+            run_proc('isct_antsApplyTransforms -d 3 -i %s -r %s -t %s -o %s -n %s' %
                     (fname_label,
                      fname_src,
                      fname_transfo,

--- a/spinalcordtoolbox/centerline/optic.py
+++ b/spinalcordtoolbox/centerline/optic.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import sct_utils as sct
 from ..image import Image
-from spinalcordtoolbox.utils import sct_dir_local_path
+from spinalcordtoolbox.utils import sct_dir_local_path, run_proc
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ def detect_centerline(img, contrast, verbose=1):
     ]
     # TODO: output coordinates, for each slice, in continuous (not discrete) values.
 
-    sct.run(cmd_optic, is_sct_binary=True, verbose=0)
+    run_proc(cmd_optic, is_sct_binary=True, verbose=0)
 
     # convert .img and .hdr files to .nii.gz
     img_ctl = Image(file_img + '_optic_ctr.hdr')

--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -101,7 +101,10 @@ def copy_mat_files(nt, list_file_mat, index, folder_out, param):
     :return: None
     """
     # create final mat folder
-    sct.create_folder(folder_out)
+    try:
+        os.makedirs(folder_out)
+    except FileExistsError:
+        pass
     # Loop across registration matrices and copy to mat_final folder
     # First loop is accross z. If axial orientation, there is only one z (i.e., len(file_mat)=1)
     for iz in range(len(list_file_mat)):
@@ -497,8 +500,10 @@ def moco(param):
     sct.printv('  Mask  ................. ' + param.fname_mask, param.verbose)
     sct.printv('  Output mat folder ..... ' + folder_mat, param.verbose)
 
-    # create folder for mat files
-    sct.create_folder(folder_mat)
+    try:
+        os.makedirs(folder_mat)
+    except FileExistsError:
+        pass
 
     # Get size of data
     sct.printv('\nData dimensions:', verbose)
@@ -794,8 +799,11 @@ def spline(folder_mat, nt, nz, verbose, index_b0 = [], graph=0):
 
     # Copying the existing Matrices to another folder
     old_mat = os.path.join(folder_mat, "old")
-    if not os.path.exists(old_mat):
+    try:
         os.makedirs(old_mat)
+    except FileExistsError:
+        pass
+
     # TODO
     for mat in glob.glob(os.path.join(folder_mat, '*.txt')):
         sct.copy(mat, old_mat)

--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -25,7 +25,7 @@ import operator
 import csv
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import sct_progress_bar
+from spinalcordtoolbox.utils import sct_progress_bar, run_proc
 
 import sct_utils as sct
 import sct_dmri_separate_b0_and_dwi
@@ -747,7 +747,7 @@ def register(param, file_src, file_dest, file_mat, file_out, im_mask=None):
             kw.update(dict(is_sct_binary=True))
             # reducing the number of CPU used for moco (see issue #201 and #2642)
             env = {**os.environ, **{"ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS": "1"}}
-            status, output = sct.run(cmd, verbose=1 if param.verbose == 2 else 0, env=env, **kw)
+            status, output = run_proc(cmd, verbose=1 if param.verbose == 2 else 0, env=env, **kw)
 
     elif param.todo == 'apply':
         sct_apply_transfo.main(args=['-i', file_src,

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -17,7 +17,7 @@ from spinalcordtoolbox.types import Centerline
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
-from spinalcordtoolbox.utils import sct_progress_bar
+from spinalcordtoolbox.utils import sct_progress_bar, run_proc
 
 import sct_utils as sct
 from sct_image import pad_image
@@ -137,7 +137,7 @@ class SpinalCordStraightener(object):
             sct.mv('centerline_rpi.nii.gz', 'centerline_rpi_native.nii.gz')
             pz_native = pz
             # TODO: remove system call
-            sct.run(['sct_resample', '-i', 'centerline_rpi_native.nii.gz', '-mm',
+            run_proc(['sct_resample', '-i', 'centerline_rpi_native.nii.gz', '-mm',
                      str(px_r) + 'x' + str(py_r) + 'x' + str(pz_r), '-o', 'centerline_rpi.nii.gz'])
             image_centerline = Image('centerline_rpi.nii.gz')
             nx, ny, nz, nt, px, py, pz, pt = image_centerline.dim
@@ -256,7 +256,7 @@ class SpinalCordStraightener(object):
             # TODO: Maybe this if case is not needed?
             if intermediate_resampling:
                 padding_z = int(np.ceil(1.5 * ((length_centerline - size_z_centerline) / 2.0) / pz_native))
-                sct.run(
+                run_proc(
                     ['sct_image', '-i', 'centerline_rpi_native.nii.gz', '-o', 'tmp.centerline_pad_native.nii.gz',
                      '-pad', '0,0,' + str(padding_z)])
                 image_centerline_pad = Image('centerline_rpi_native.nii.gz')
@@ -522,7 +522,7 @@ class SpinalCordStraightener(object):
         image_centerline_straight.save(fname_ref)
         if self.curved2straight:
             logger.info('Apply transformation to input image...')
-            sct.run(['isct_antsApplyTransforms',
+            run_proc(['isct_antsApplyTransforms',
                      '-d', '3',
                      '-r', fname_ref,
                      '-i', 'data.nii',
@@ -538,7 +538,7 @@ class SpinalCordStraightener(object):
             # Ideally, the error should be zero.
             # Apply deformation to input image
             logger.info('Apply transformation to centerline image...')
-            sct.run(['isct_antsApplyTransforms',
+            run_proc(['isct_antsApplyTransforms',
                      '-d', '3',
                      '-r', fname_ref,
                      '-i', 'centerline.nii.gz',

--- a/spinalcordtoolbox/vertebrae/detect_c2c3.py
+++ b/spinalcordtoolbox/vertebrae/detect_c2c3.py
@@ -28,8 +28,8 @@ import nibabel as nib
 from scipy.ndimage.measurements import center_of_mass
 from skimage.measure import label as label_regions
 
-import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.image import Image, zeros_like
+from spinalcordtoolbox.utils import run_proc
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
     nb_sag_avg_half = int(nb_sag_avg / 2 / nii_im.dim[6])
     midSlice = np.mean(nii_im.data[:, :, mid_RL-nb_sag_avg_half:mid_RL+nb_sag_avg_half+1], 2) # average 7 slices
     midSlice_seg = nii_seg_flat.data[:, :, mid_RL]
-    nii_midSlice = msct_image.zeros_like(nii_im)
+    nii_midSlice = zeros_like(nii_im)
     nii_midSlice.data = midSlice
     nii_midSlice.save('data_midSlice.nii')
 
@@ -81,7 +81,7 @@ def detect_c2c3(nii_im, nii_seg, contrast, nb_sag_avg=7.0, verbose=1):
                     (path_model, 'data_midSlice', 'data_midSlice_pred')
     # The command below will fail, but we don't care because it will output an image (prediction), which we
     # will use later on.
-    s, o = sct.run(cmd_detection, verbose=0, is_sct_binary=True, raise_exception=False)
+    s, o = run_proc(cmd_detection, verbose=0, is_sct_binary=True, raise_exception=False)
     pred = nib.load('data_midSlice_pred_svm.hdr').get_data()
     if verbose >= 2:
         # copy the "prediction data before post-processing" in an Image object

--- a/testing/test_sct_dmri_moco.py
+++ b/testing/test_sct_dmri_moco.py
@@ -13,6 +13,7 @@
 from pandas import read_csv
 from numpy import allclose
 
+from spinalcordtoolbox.utils import run_proc
 import sct_utils as sct
 
 
@@ -21,10 +22,10 @@ def init(param_test):
     Initialize class: param_test
     """
     # Reorient image to sagittal for testing another orientation (and crop to save time)
-    sct.run('sct_image -i dmri/dmri.nii.gz -setorient AIL -o dmri/dmri_AIL.nii', verbose=0)
-    sct.run('sct_crop_image -i dmri/dmri_AIL.nii -zmin 19 -zmax 21 -o dmri/dmri_AIL_crop.nii', verbose=0)
+    run_proc('sct_image -i dmri/dmri.nii.gz -setorient AIL -o dmri/dmri_AIL.nii', verbose=0)
+    run_proc('sct_crop_image -i dmri/dmri_AIL.nii -zmin 19 -zmax 21 -o dmri/dmri_AIL_crop.nii', verbose=0)
     # Create Gaussian mask for testing
-    sct.run('sct_create_mask -i dmri/dmri_T0000.nii.gz -p center -size 5mm -f gaussian -o dmri/mask.nii', verbose=0)
+    run_proc('sct_create_mask -i dmri/dmri_T0000.nii.gz -p center -size 5mm -f gaussian -o dmri/mask.nii', verbose=0)
 
     # initialization
     default_args = [

--- a/testing/test_sct_orientation.py
+++ b/testing/test_sct_orientation.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+from spinalcordtoolbox.utils import run_proc
 import sct_utils as sct
 
 def test(data_path):
@@ -25,12 +26,12 @@ def test(data_path):
 
     # test 3d data
     cmd = 'sct_orientation -i ' + data_path + folder_data[0] + file_data[0]
-    status, output = sct.run(cmd)
+    status, output = run_proc(cmd)
 
     # test 4d data
     if status == 0:
         cmd = 'sct_orientation -i ' + data_path + folder_data[1] + file_data[1]
-        status, output = sct.run(cmd)
+        status, output = run_proc(cmd)
 
     # return
     return status, output

--- a/testing/test_sct_propseg.py
+++ b/testing/test_sct_propseg.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import sct_utils as sct
 from spinalcordtoolbox.image import Image, compute_dice
+from spinalcordtoolbox.utils import run_proc
 
 
 def init(param_test):
@@ -30,7 +31,7 @@ def init(param_test):
 
     # check if isct_propseg compatibility
     # TODO: MAKE SURE THIS CASE WORKS AFTER MAJOR REFACTORING
-    status_isct_propseg, output_isct_propseg = sct.run('isct_propseg', verbose=0, raise_exception=False)
+    status_isct_propseg, output_isct_propseg = run_proc('isct_propseg', verbose=0, raise_exception=False)
     isct_propseg_version = output_isct_propseg.split('\n')[0]
     if isct_propseg_version != 'sct_propseg - Version 1.1 (2015-03-24)':
         status = 99


### PR DESCRIPTION
In the scope of #2898

After #2943 

Groundwork for further refactoring

- cleanup dead code in `sct_utils.py`
- refactor `sct_utils.run()` to use `spinalcordtoolbox.run_proc()`