### PR TITLE
fix doc build warnings + associated bug

### DIFF
--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -61,6 +61,5 @@ SCT is a comprehensive, free and open-source software dedicated to the processin
 
    dev_section/CONTRIBUTING.rst
    dev_section/api.rst
-   dev_section/development.rst
    dev_section/CHANGES.md
    dev_section/license.rst

--- a/spinalcordtoolbox/__init__.py
+++ b/spinalcordtoolbox/__init__.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
 
+# convenience and backwards compat
 from .utils import __version__, __sct_dir__, __data_dir__, __deepseg_dir__

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -442,7 +442,9 @@ def make_a_string(item):
 def merge_dict(dict_in):
     """
     Merge n dictionaries that are contained at the root key
-    Example:
+
+    code::
+
       dict_in = {
           'area': {(0): {'Level': 0, 'Mean(area)': 0.5}, (1): {'Level': 1, 'Mean(area)': 0.2}}
           'angle_RL': {(0): {'Level': 0, 'Mean(angle_RL)': 15}, (1): {'Level': 1, 'Mean(angle_RL)': 12}}
@@ -452,8 +454,6 @@ def merge_dict(dict_in):
           (1): {'Level': 1, 'Mean(area): 0.2, 'Mean(angle_RL): 12}
       }
 
-    :param dict_in:
-    :return:
     """
     dict_merged = {}
     metrics = [k for i, (k, v) in enumerate(dict_in.items())]

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -443,7 +443,7 @@ def merge_dict(dict_in):
     """
     Merge n dictionaries that are contained at the root key
 
-    code::
+    .. code-block:: python
 
       dict_in = {
           'area': {(0): {'Level': 0, 'Mean(area)': 0.5}, (1): {'Level': 1, 'Mean(area)': 0.2}}
@@ -453,6 +453,9 @@ def merge_dict(dict_in):
           (0): {'Level': 0, 'Mean(area): 0.5, 'Mean(angle_RL): 15}
           (1): {'Level': 1, 'Mean(area): 0.2, 'Mean(angle_RL): 12}
       }
+
+    :param dict_in: input dict.
+    :return: normalized dict with sub-dicts at root level
 
     """
     dict_merged = {}

--- a/spinalcordtoolbox/centerline/__init__.py
+++ b/spinalcordtoolbox/centerline/__init__.py
@@ -1,0 +1,1 @@
+from . import core, curve_fitting, nurbs, optic

--- a/spinalcordtoolbox/compat/__init__.py
+++ b/spinalcordtoolbox/compat/__init__.py
@@ -1,0 +1,1 @@
+from . import launcher

--- a/spinalcordtoolbox/deepseg/__init__.py
+++ b/spinalcordtoolbox/deepseg/__init__.py
@@ -1,0 +1,1 @@
+from . import core, models

--- a/spinalcordtoolbox/deepseg_gm/__init__.py
+++ b/spinalcordtoolbox/deepseg_gm/__init__.py
@@ -1,0 +1,1 @@
+from . import deepseg_gm, model

--- a/spinalcordtoolbox/deepseg_lesion/__init__.py
+++ b/spinalcordtoolbox/deepseg_lesion/__init__.py
@@ -1,0 +1,1 @@
+from . import core

--- a/spinalcordtoolbox/deepseg_lesion/core.py
+++ b/spinalcordtoolbox/deepseg_lesion/core.py
@@ -13,6 +13,7 @@ from spinalcordtoolbox.image import Image, add_suffix, zeros_like, empty_like
 from spinalcordtoolbox.deepseg_sc.core import find_centerline, crop_image_around_centerline, uncrop_image, _normalize_data
 from spinalcordtoolbox import resampling
 from spinalcordtoolbox.utils import sct_dir_local_path, TempFolder
+from spinalcordtoolbox.deepseg_sc.cnn_models_3d import load_trained_model
 
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,6 @@ def apply_intensity_normalization(img, contrast):
 
 
 def segment_3d(model_fname, contrast_type, im):
-    from spinalcordtoolbox.deepseg_sc.cnn_models_3d import load_trained_model
     """Perform segmentation with 3D convolutions."""
     dct_patch_3d = {'t2': {'size': (48, 48, 48), 'mean': 871.309, 'std': 557.916},
                     't2_ax': {'size': (48, 48, 48), 'mean': 835.592, 'std': 528.386},

--- a/spinalcordtoolbox/deepseg_sc/__init__.py
+++ b/spinalcordtoolbox/deepseg_sc/__init__.py
@@ -1,0 +1,1 @@
+from . import cnn_models, cnn_models_3d, core, postprocessing

--- a/spinalcordtoolbox/deepseg_sc/cnn_models_3d.py
+++ b/spinalcordtoolbox/deepseg_sc/cnn_models_3d.py
@@ -15,6 +15,8 @@ from keras.optimizers import Adam
 from keras.models import load_model
 from keras.layers.merge import concatenate
 
+# Note: `K.set_image_data_format("channels_first")` was removed from this file because it interfered
+# with other tests. It may need to be re-added for this function to work properly. (See #2954)
 
 def dice_coefficient(y_true, y_pred, smooth=1.):
     y_true_f = K.flatten(y_true)

--- a/spinalcordtoolbox/deepseg_sc/cnn_models_3d.py
+++ b/spinalcordtoolbox/deepseg_sc/cnn_models_3d.py
@@ -13,9 +13,6 @@ from keras.engine import Input, Model
 from keras.layers import Conv3D, MaxPooling3D, UpSampling3D, Activation, BatchNormalization
 from keras.optimizers import Adam
 from keras.models import load_model
-
-K.set_image_data_format("channels_first")
-
 from keras.layers.merge import concatenate
 
 

--- a/spinalcordtoolbox/deepseg_sc/core.py
+++ b/spinalcordtoolbox/deepseg_sc/core.py
@@ -17,6 +17,7 @@ from .postprocessing import post_processing_volume_wise, keep_largest_object, fi
 from spinalcordtoolbox.image import Image, empty_like, change_type, zeros_like, add_suffix
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 from spinalcordtoolbox.utils import sct_dir_local_path, printv, TempFolder
+from spinalcordtoolbox.deepseg_sc.cnn_models_3d import load_trained_model
 
 
 # FIXME: don't import from scripts!
@@ -368,7 +369,6 @@ def segment_3d(model_fname, contrast_type, im_in):
 
     :return: seg_crop.data: ndarray float32: Output prediction
     """
-    from spinalcordtoolbox.deepseg_sc.cnn_models_3d import load_trained_model
     dct_patch_sc_3d = {'t2': {'size': (64, 64, 48), 'mean': 65.8562, 'std': 59.7999},
                        't2s': {'size': (96, 96, 48), 'mean': 87.0212, 'std': 64.425},
                        't1': {'size': (64, 64, 48), 'mean': 88.5001, 'std': 66.275}}

--- a/spinalcordtoolbox/gui/__init__.py
+++ b/spinalcordtoolbox/gui/__init__.py
@@ -1,0 +1,1 @@
+from . import base, centerline, sagittal, widgets

--- a/spinalcordtoolbox/qmri/__init__.py
+++ b/spinalcordtoolbox/qmri/__init__.py
@@ -1,0 +1,1 @@
+from . import mt

--- a/spinalcordtoolbox/registration/__init__.py
+++ b/spinalcordtoolbox/registration/__init__.py
@@ -1,0 +1,1 @@
+from . import landmarks, register

--- a/spinalcordtoolbox/reports/__init__.py
+++ b/spinalcordtoolbox/reports/__init__.py
@@ -1,1 +1,1 @@
-# -*- coding: utf-8 -*-
+from . import qc, slice

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -21,7 +21,7 @@ from matplotlib.figure import Figure
 import matplotlib.colors as color
 
 from spinalcordtoolbox.image import Image
-import spinalcordtoolbox.reports.slice as qcslice
+from . import slice as qcslice
 from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, printv, copy, extract_fname
 
 logger = logging.getLogger(__name__)

--- a/spinalcordtoolbox/vertebrae/__init__.py
+++ b/spinalcordtoolbox/vertebrae/__init__.py
@@ -1,0 +1,1 @@
+from . import core, detect_c2c3

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -40,7 +40,6 @@ def test_deep_segmentation_spinalcord(params):
     assert np.all(im_seg.data == Image(params['fname_seg_manual']).data)
 
 
-
 def test_intensity_normalization():
     data_in = np.random.rand(10, 10)
     min_out, max_out = 0, 255

--- a/unit_testing/test_deepseg_sc.py
+++ b/unit_testing/test_deepseg_sc.py
@@ -30,8 +30,7 @@ def test_deep_segmentation_spinalcord(params):
     """High level segmentation API"""
     fname_im = sct_test_path('t2', 't2.nii.gz')
     fname_centerline_manual = sct_test_path('t2', 't2_centerline-manual.nii.gz')
-    # Set at channels_first in test_deepseg_lesion.test_segment()
-    K.set_image_data_format("channels_last")
+
     # Call segmentation function
     im_seg, _, _ = sct.deepseg_sc.core.deep_segmentation_spinalcord(
         Image(fname_im), params['contrast'], ctr_algo='file', ctr_file=fname_centerline_manual, brain_bool=False,
@@ -39,6 +38,7 @@ def test_deep_segmentation_spinalcord(params):
     assert im_seg.data.dtype == np.dtype('uint8')
     # Compare with ground-truth segmentation
     assert np.all(im_seg.data == Image(params['fname_seg_manual']).data)
+
 
 
 def test_intensity_normalization():


### PR DESCRIPTION
Closes #2951 
After #2949
Closes #2954  

- Implements more standard package imports for sub-packages (see https://github.com/neuropoly/spinalcordtoolbox/issues/2951#issuecomment-710053812)
- Fixes various doc warnings
- Removes the unnecessary `set_image_data_format()` calls that cancel each other since functionality seems to have been obsoleted (see https://github.com/neuropoly/spinalcordtoolbox/issues/2954#issuecomment-713138372)