### PR TITLE
Remove deepseg postprocessing

### DIFF
--- a/contrib/fsl_integration/sct_plugin.py
+++ b/contrib/fsl_integration/sct_plugin.py
@@ -35,6 +35,10 @@ import wx.html as html
 logger = logging.getLogger(__name__)
 aui_manager = frame.getAuiManager() # from FSLeyes context
 
+# keep track of all output folder text inputs so that we can update
+# all of them if one changes
+ofolder_txt_ctrls = []
+
 class ErrorDialog(wx.Dialog):
     """
     Panel to display if there is an error, instructing user what to do.
@@ -203,6 +207,46 @@ class TextBox:
         return self.textctrl.GetValue()
 
 
+class OutputFolderWidget():
+    """
+    Custom widget to allow selecting the output folder and displaying it.
+    """
+    def __init__(self, sctpanel):
+        self.sct_panel = sctpanel
+        self.hbox = wx.BoxSizer(wx.HORIZONTAL)
+        self.textctrl = wx.TextCtrl(sctpanel)
+        self.textctrl.SetValue(self.sct_panel.ofolder)
+
+        button_select_ofolder = wx.Button(self.sct_panel, -1, label="Set Output Folder")
+        button_select_ofolder.Bind(wx.EVT_BUTTON, self.on_button_select_ofolder)
+
+        self.hbox.Add(button_select_ofolder, 0, wx.ALIGN_LEFT| wx.RIGHT, 10)
+        self.hbox.Add(self.textctrl, 1, wx.ALIGN_LEFT|wx.LEFT, 10)
+        ofolder_txt_ctrls.append(self)
+
+    def on_button_select_ofolder(self, event):
+        """
+        Select a dir dialog
+        """
+        dlg = wx.DirDialog (None, "Choose output directory", "",
+                    wx.DD_DEFAULT_STYLE | wx.DD_DIR_MUST_EXIST)
+
+        if dlg.ShowModal() == wx.ID_OK:
+            ofolder = dlg.GetPath()
+            self.update_all_ofolders(ofolder)
+            logger.info(f"Output folder set to: {ofolder}")
+
+    def get_output_folder(self):
+        return self.textctrl.GetValue()
+
+    def update_all_ofolders(self, ofolder):
+        """
+        Update all ofolder text controls for convenience.
+        """
+        for ctrl in ofolder_txt_ctrls:
+            ctrl.textctrl.SetValue(ofolder)
+
+
 # Creates the standard panel for each tool
 class SCTPanel(wx.Panel):
     """
@@ -223,6 +267,8 @@ class SCTPanel(wx.Panel):
 
     def __init__(self, parent, id_):
         super(SCTPanel, self).__init__(parent=parent, id=id_)
+
+        self.ofolder = os.getcwd()
 
         # main layout consists of one row with 3 main columns
         self.main_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -348,6 +394,7 @@ class TabPanelPropSeg(SCTPanel):
         super(TabPanelPropSeg, self).__init__(parent=parent, id_=wx.ID_ANY)
 
         self.hbox_filein = TextBox(self, label="Input file")
+        self.hbox_ofolder = OutputFolderWidget(self)
         lbl_contrasts = ['t1', 't2', 't2s', 'dwi']
 
         self.rbox_contrast = wx.RadioBox(self, label='Select contrast:',
@@ -360,6 +407,7 @@ class TabPanelPropSeg(SCTPanel):
 
         self.column_center.Add(self.hbox_filein.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(self.rbox_contrast, 0, wx.ALL, 5)
+        self.column_center.Add(self.hbox_ofolder.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(button_run, 0, wx.ALL, 5)
 
     def on_button_run(self, event):
@@ -377,7 +425,7 @@ class TabPanelPropSeg(SCTPanel):
         base_name = os.path.basename(fname_input)
         fname, fext = base_name.split(os.extsep, 1)
         fname_out = "{}_seg.{}".format(fname, fext)
-        cmd_line = "sct_propseg -i {} -c {}".format(fname_input, contrast)
+        cmd_line = f"sct_propseg -i {fname_input} -c {contrast} -ofolder {self.hbox_ofolder.get_output_folder()}"
         self.call_sct_command(cmd_line)
 
         # Add output to the list of overlay
@@ -385,6 +433,7 @@ class TabPanelPropSeg(SCTPanel):
         overlayList.append(image)
         opts = displayCtx.getOpts(image)
         opts.cmap = 'red'
+
 
 
 class TabPanelSCSeg(SCTPanel):
@@ -412,6 +461,7 @@ class TabPanelSCSeg(SCTPanel):
         super(TabPanelSCSeg, self).__init__(parent=parent, id_=wx.ID_ANY)
 
         self.hbox_filein = TextBox(self, label="Input file")
+        self.hbox_ofolder = OutputFolderWidget(self)
         lbl_contrasts = ['t1', 't2', 't2s', 'dwi']
         self.rbox_contrast = wx.RadioBox(self, label='Select contrast:',
                                          choices=lbl_contrasts,
@@ -423,6 +473,7 @@ class TabPanelSCSeg(SCTPanel):
 
         self.column_center.Add(self.hbox_filein.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(self.rbox_contrast, 0, wx.ALL, 5)
+        self.column_center.Add(self.hbox_ofolder.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(button_run, 0, wx.ALL, 5)
 
     def on_button_run(self, event):
@@ -440,7 +491,7 @@ class TabPanelSCSeg(SCTPanel):
         base_name = os.path.basename(fname_input)
         fname, fext = base_name.split(os.extsep, 1)
         fname_out = "{}_seg.{}".format(fname, fext)
-        cmd_line = "sct_deepseg_sc -i {} -c {}".format(fname_input, contrast)
+        cmd_line = f"sct_deepseg_sc -i {fname_input} -c {contrast} -ofolder {self.hbox_ofolder.get_output_folder()}"
         self.call_sct_command(cmd_line)
 
         # Add output to the list of overlay
@@ -475,11 +526,13 @@ class TabPanelGMSeg(SCTPanel):
         super(TabPanelGMSeg, self).__init__(parent=parent, id_=wx.ID_ANY)
 
         self.hbox_filein = TextBox(self, label="Input file")
+        self.hbox_ofolder = OutputFolderWidget(self)
 
         button_run = wx.Button(self, id=wx.ID_ANY, label="Run")
         button_run.Bind(wx.EVT_BUTTON, self.on_button_run)
 
         self.column_center.Add(self.hbox_filein.hbox, 0, wx.EXPAND|wx.ALL, 5)
+        self.column_center.Add(self.hbox_ofolder.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(button_run, 0, wx.ALL, 5)
 
     def on_button_run(self, event):
@@ -495,8 +548,8 @@ class TabPanelGMSeg(SCTPanel):
 
         base_name = os.path.basename(fname_input)
         fname, fext = base_name.split(os.extsep, 1)
-        fname_out = "{}_gmseg.{}".format(fname, fext)
-        cmd_line = "sct_deepseg_gm -i {} -o {}".format(fname_input, fname_out)
+        default_fname_out = "{}_gmseg.{}".format(fname, fext)
+        cmd_line = f"sct_deepseg_gm -i {fname_input} -o {os.path.join(self.hbox_ofolder.get_output_folder(), default_fname_out)}"
         self.call_sct_command(cmd_line)
 
         # Add output to the list of overlay
@@ -532,6 +585,7 @@ class TabPanelVertLB(SCTPanel):
         super(TabPanelVertLB, self).__init__(parent=parent, id_=wx.ID_ANY)
 
         self.hbox_im = TextBox(self, label="Input image")
+        self.hbox_ofolder = OutputFolderWidget(self)
         self.hbox_seg = TextBox(self, label="Input segmentation")
 
         lbl_contrasts = ['t1', 't2']
@@ -547,6 +601,7 @@ class TabPanelVertLB(SCTPanel):
         self.column_center.Add(self.hbox_im.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(self.hbox_seg.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(self.rbox_contrast, 0, wx.ALL, 5)
+        self.column_center.Add(self.hbox_ofolder.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(button_run, 0, wx.ALL, 5)
 
     def on_button_run(self, event):
@@ -576,7 +631,7 @@ class TabPanelVertLB(SCTPanel):
         base_name = os.path.basename(fname_seg)
         fname, fext = base_name.split(os.extsep, 1)
         fname_out = "{}_labeled.{}".format(fname, fext)
-        cmd_line = "sct_label_vertebrae -i {} -s {} -c {}".format(fname_im, fname_seg, contrast)
+        cmd_line = f"sct_label_vertebrae -i {fname_im} -s {fname_seg} -c {contrast} -ofolder {self.hbox_ofolder.get_output_folder()}"
         self.call_sct_command(cmd_line)
 
         # Add output to the list of overlay
@@ -614,6 +669,7 @@ class TabPanelRegisterToTemplate(SCTPanel):
         super(TabPanelRegisterToTemplate, self).__init__(parent=parent, id_=wx.ID_ANY)
 
         self.hbox_im = TextBox(self, label="Input image")
+        self.hbox_ofolder = OutputFolderWidget(self)
         self.hbox_seg = TextBox(self, label="Input segmentation")
         self.hbox_label = TextBox(self, label="Input labels")
 
@@ -630,6 +686,7 @@ class TabPanelRegisterToTemplate(SCTPanel):
         self.column_center.Add(self.hbox_seg.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(self.hbox_label.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(self.rbox_contrast, 0, wx.ALL, 5)
+        self.column_center.Add(self.hbox_ofolder.hbox, 0, wx.EXPAND|wx.ALL, 5)
         self.column_center.Add(button_run, 0, wx.ALL, 5)
 
     def on_button_run(self, event):
@@ -667,8 +724,7 @@ class TabPanelRegisterToTemplate(SCTPanel):
             return
 
         contrast = self.rbox_contrast.GetStringSelection()
-        cmd_line = \
-            "sct_register_to_template -i {} -s {} -ldisc {} -c {}".format(fname_im, fname_seg, fname_label, contrast)
+        cmd_line = f"sct_register_to_template -i {fname_im} -s {fname_seg} -ldisc {fname_label} -c {contrast} -ofolder {self.hbox_ofolder.get_output_folder()}"
         self.call_sct_command(cmd_line)
 
         # Add output to the list of overlay

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ colored
 dipy
 futures
 h5py
-ivadomed==2.0.2
+ivadomed==2.4.0
 Keras==2.1.5
 matplotlib
 nibabel

--- a/scripts/sct_check_dependencies.py
+++ b/scripts/sct_check_dependencies.py
@@ -20,16 +20,15 @@ import argparse
 import sys
 import io
 import os
-import re
 import platform
 import importlib
 import warnings
-import subprocess
+import psutil
 
 import requirements
 
 from spinalcordtoolbox.utils.shell import SmartFormatter
-from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__, printv
+from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__
 
 
 # DEFAULT PARAMETERS
@@ -118,57 +117,6 @@ def module_import(module_name, suppress_stderr=False):
     else:
         module = importlib.import_module(module_name)
     return module
-
-
-def check_ram(os, verbose=1):
-    if (os == 'linux'):
-        status, output = run_proc('grep MemTotal /proc/meminfo', 0)
-        printv('RAM: ' + output)
-        ram_split = output.split()
-        ram_total = float(ram_split[1])
-        status, output = run_proc('free -m', 0)
-        printv(output)
-        return ram_total / 1024
-
-    elif (os == 'osx'):
-        status, output = run_proc('hostinfo | grep memory', 0)
-        printv('RAM: ' + output)
-        ram_split = output.split(' ')
-        ram_total = float(ram_split[3])
-
-        # Get process info
-        ps = subprocess.Popen(['ps', '-caxm', '-orss,comm'], stdout=subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding)
-        vm = subprocess.Popen(['vm_stat'], stdout=subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding)
-
-        # Iterate processes
-        processLines = ps.split('\n')
-        sep = re.compile(r'[\s]+')
-        rssTotal = 0  # kB
-        for row in range(1, len(processLines)):
-            rowText = processLines[row].strip()
-            rowElements = sep.split(rowText)
-            try:
-                rss = float(rowElements[0]) * 1024
-            except:
-                rss = 0  # ignore...
-            rssTotal += rss
-
-        # Process vm_stat
-        vmLines = vm.split('\n')
-        sep = re.compile(r':[\s]+')
-        vmStats = {}
-        for row in range(1, len(vmLines) - 2):
-            rowText = vmLines[row].strip()
-            rowElements = sep.split(rowText)
-            vmStats[(rowElements[0])] = int(rowElements[1].strip(r'\.')) * 4096
-
-        if verbose:
-            printv('  Wired Memory:\t\t%d MB' % (vmStats["Pages wired down"] / 1024 / 1024))
-            printv('  Active Memory:\t%d MB' % (vmStats["Pages active"] / 1024 / 1024))
-            printv('  Inactive Memory:\t%d MB' % (vmStats["Pages inactive"] / 1024 / 1024))
-            printv('  Free Memory:\t\t%d MB' % (vmStats["Pages free"] / 1024 / 1024))
-
-        return ram_total
 
 
 def get_version(module):
@@ -304,14 +252,11 @@ def main():
         os_running = 'linux'
 
     print('OS: ' + os_running + ' (' + platform.platform() + ')')
+    print('CPU cores: Available: {}, Used by ITK functions: {}'.format(psutil.cpu_count(), int(os.getenv('ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS', 0))))
 
-    # Check number of CPU cores
-    from multiprocessing import cpu_count
-    output = int(os.getenv('ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS', 0))
-    print('CPU cores: Available: {}, Used by SCT: {}'.format(cpu_count(), output))
-
-    # check RAM
-    check_ram(os_running, 0)
+    ram = psutil.virtual_memory()
+    factor_MB = 1024 * 1024
+    print('RAM: Total: {}MB, Used: {}MB, Available: {}MB'.format(ram.total // factor_MB, ram.used // factor_MB, ram.available // factor_MB))
 
     if arguments.short:
         sys.exit()

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -95,6 +95,11 @@ def get_parser():
         help="Fill small holes in the segmentation.",
         choices=(0, 1),
         default=deepseg.core.DEFAULTS['fill_holes'])
+    misc.add_argument(
+        "-remove-small",
+        type=str,
+        help="Minimal object size to keep with unit (mm or vox). Example: 3mm, 5vox. (default: 0mm)",
+        default=deepseg.core.DEFAULTS['remove_small'])
 
     misc = parser.add_argument_group('\nMISC')
     misc.add_argument(

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -98,7 +98,7 @@ def get_parser():
     misc.add_argument(
         "-remove-small",
         type=str,
-        help="Minimal object size to keep with unit (mm or vox). Example: 3mm, 5vox. (default: 0mm)",
+        help="Minimal object size to keep with unit (mm3 or vox). Example: 1mm3, 5vox. (default: 0vox)",
         default=deepseg.core.DEFAULTS['remove_small'])
 
     misc = parser.add_argument_group('\nMISC')

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -170,7 +170,7 @@ def main():
                 parser.error("The input model is invalid: {}".format(path_model))
 
         # Call segment_nifti
-        fname_seg = deepseg.core.segment_nifti(args.i, path_model, fname_prior, args)
+        fname_seg = deepseg.core.segment_nifti(args.i, path_model, fname_prior, vars(args))
         # Use the result of the current model as additional input of the next model
         fname_prior = fname_seg
 

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -117,11 +117,11 @@ def main():
     args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     # Deal with model
-    if args.list_models is not None:
+    if args.list_models:
         deepseg.models.display_list_models()
 
     # Deal with task
-    if args.list_tasks is not None:
+    if args.list_tasks:
         deepseg.models.display_list_tasks()
 
     if args.install_model is not None:

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -16,6 +16,8 @@ import os
 import sys
 
 import spinalcordtoolbox.deepseg as deepseg
+import spinalcordtoolbox.deepseg.models
+import spinalcordtoolbox.deepseg.core
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv
 
@@ -30,7 +32,6 @@ def get_parser():
     input_output = parser.add_argument_group("\nINPUT/OUTPUT")
     input_output.add_argument(
         "-i",
-        required=True,
         help="Image to segment.",
         metavar=Metavar.file)
     input_output.add_argument(

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -16,8 +16,6 @@ import os
 import sys
 
 import spinalcordtoolbox.deepseg as deepseg
-import spinalcordtoolbox.deepseg.models
-import spinalcordtoolbox.deepseg.core
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv
 

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -98,7 +98,7 @@ def get_parser():
     misc.add_argument(
         "-remove-small",
         type=str,
-        help="Minimal object size to keep with unit (mm3 or vox). Example: 1mm3, 5vox. (default: 0vox)",
+        help="Minimal object size to keep with unit (mm3 or vox). Example: 1mm3, 5vox.",
         default=deepseg.core.DEFAULTS['remove_small'])
 
     misc = parser.add_argument_group('\nMISC')

--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -75,8 +75,8 @@ def main(args=None):
             "https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip",
         ],
         "sct_testing_data": [
-            "https://github.com/sct-data/sct_testing_data/releases/download/r20200904/sct_testing_data-r20200904.zip",
-            "https://osf.io/download/5f516b634f1e5e00226f0599/"],
+            "https://github.com/sct-data/sct_testing_data/releases/download/r20201030/sct_testing_data-r20201030.zip",
+            "https://osf.io/download/5f9c271187b7df04593b03e0/"],
         "PAM50": [
             "https://github.com/sct-data/PAM50/releases/download/r20191029/20191029_pam50.zip",
             "https://osf.io/u79sr/download",

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -24,7 +24,7 @@ DEFAULTS = {
     'thr': 0.9,
     'largest': 0,
     'fill_holes': 0,
-    'remove_small': '0vox'
+    'remove_small': None
 }
 
 

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -9,13 +9,9 @@ import logging
 import os
 
 import ivadomed as imed
-import ivadomed.utils
-import ivadomed.postprocessing
 import nibabel as nib
-import numpy as np
 
 import spinalcordtoolbox as sct
-import spinalcordtoolbox.deepseg.models
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -12,6 +12,7 @@ import ivadomed as imed
 import nibabel as nib
 
 import spinalcordtoolbox as sct
+from spinalcordtoolbox import image
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ def segment_nifti(fname_image, folder_model, fname_prior=None, param=None):
     nii_seg = imed.utils.segment_volume(folder_model, fname_image, options=options)
 
     # Save output seg
-    if 'o' in options:
+    if 'o' in options and options['o'] is not None:
         fname_out = options['o']
     else:
         fname_out = ''.join([sct.image.splitext(fname_image)[0], '_seg.nii.gz'])

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     'thr': 0.9,
     'largest': 1,
     'fill_holes': 1,
+    'remove_small': None
 }
 
 
@@ -41,7 +42,7 @@ def segment_nifti(fname_image, folder_model, fname_prior=None, param=None):
         param = {}
 
     options = {**DEFAULTS, **vars(param)}
-    nii_seg = imed.utils.segment_volume(folder_model, fname_image, fname_prior, options)
+    nii_seg = imed.utils.segment_volume(folder_model, fname_image, fname_prior, options=options)
 
     # Save output seg
     if 'o' in options:

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 # Default values if not asked during CLI call and if not present in json metadata.
 DEFAULTS = {
     'thr': 0.9,
-    'largest': 1,
-    'fill_holes': 1,
+    'largest': 0,
+    'fill_holes': 0,
     'remove_small': '0vox'
 }
 

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -41,7 +41,7 @@ def segment_nifti(fname_image, folder_model, fname_prior=None, param=None):
     if param is None:
         param = {}
 
-    options = {**DEFAULTS, **vars(param), "fname_prior": fname_prior}
+    options = {**DEFAULTS, **param, "fname_prior": fname_prior}
     nii_seg = imed.utils.segment_volume(folder_model, fname_image, options=options)
 
     # Save output seg

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -24,7 +24,7 @@ DEFAULTS = {
     'thr': 0.9,
     'largest': 1,
     'fill_holes': 1,
-    'remove_small': None
+    'remove_small': '0mm'
 }
 
 

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -24,7 +24,7 @@ DEFAULTS = {
     'thr': 0.9,
     'largest': 1,
     'fill_holes': 1,
-    'remove_small': '0mm'
+    'remove_small': '0vox'
 }
 
 

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -27,66 +27,6 @@ DEFAULTS = {
 }
 
 
-def postprocess(nii_seg, options):
-    """
-    Wrapper to apply postprocessing on the segmentation, depending on user's, metadata or default options.
-
-    :param nii_seg: nibabel: Segmentation
-    :param options: dict: Parameters for postprocessing, including keys such as: threshold, keep_largest_object.
-    :return: postprocessed segmentation
-    """
-
-    def threshold(nii_seg, thr):
-        """Threshold the prediction. For no threshold, set 'thr' to 0."""
-        logger.info("Threshold: {}".format(thr))
-        if thr:
-            nii_seg = imed.postprocessing.threshold_predictions(nii_seg, thr)
-        return nii_seg
-
-    def keep_largest_objects(nii_seg, n_objects):
-        """Only keep the n largest objects."""
-        logger.info("Keep largest objects: {}".format(n_objects))
-        if n_objects > 1:
-            # TODO: implement the thing below.
-            NotImplementedError("For now, the algorithm can only remove the largest object, no more than that.")
-        # Make sure input is binary. If not, skip with verbose.
-        if np.array_equal(nii_seg.get_fdata(), nii_seg.get_fdata().astype(bool)):
-            # Fetch axis corresponding to superior-inferior direction
-            # TODO: move that code in image
-            affine = nii_seg.get_header().get_best_affine()
-            code = nib.orientations.aff2axcodes(affine)
-            if 'I' in code:
-                axis_infsup = code.index('I')
-            elif 'S' in code:
-                axis_infsup = code.index('S')
-            else:
-                raise ValueError(
-                    "Neither I nor S is present in code: {}, for affine matrix: {}".format(code, affine))
-            nii_seg = imed.postprocessing.keep_largest_object_per_slice(nii_seg, axis=axis_infsup)
-        else:
-            logger.warning("Algorithm 'keep largest object' can only be run on binary segmentation. Skipping.")
-        return nii_seg
-
-    def fill_holes(nii_seg):
-        """Fill holes"""
-        logger.info("Fill holes")
-        # Make sure input is binary. If not, skip with verbose.
-        if np.array_equal(nii_seg.get_fdata(), nii_seg.get_fdata().astype(bool)):
-            nii_seg = imed.postprocessing.fill_holes(nii_seg)
-        else:
-            logger.warning("Algorithm 'fill holes' can only be run on binary segmentation. Skipping.")
-        return nii_seg
-
-    logger.info("\nProcessing segmentation\n" + "-" * 23)
-    if options['thr']:
-        nii_seg = threshold(nii_seg, options['thr'])
-    if options['largest']:
-        nii_seg = keep_largest_objects(nii_seg, options['largest'])
-    if options['fill_holes']:
-        nii_seg = fill_holes(nii_seg)
-    return nii_seg
-
-
 def segment_nifti(fname_image, folder_model, fname_prior=None, param=None):
     """
     Segment a nifti file.
@@ -100,12 +40,8 @@ def segment_nifti(fname_image, folder_model, fname_prior=None, param=None):
     if param is None:
         param = {}
 
-    nii_seg = imed.utils.segment_volume(folder_model, fname_image, fname_prior)
-
-    # Postprocessing
-    metadata = sct.deepseg.models.get_metadata(folder_model)
-    options = {**DEFAULTS, **metadata, **param}
-    nii_seg = postprocess(nii_seg, options)
+    options = {**DEFAULTS, **vars(param)}
+    nii_seg = imed.utils.segment_volume(folder_model, fname_image, fname_prior, options)
 
     # Save output seg
     if 'o' in options:

--- a/spinalcordtoolbox/deepseg/core.py
+++ b/spinalcordtoolbox/deepseg/core.py
@@ -24,7 +24,7 @@ DEFAULTS = {
     'thr': 0.9,
     'largest': 0,
     'fill_holes': 0,
-    'remove_small': None
+    'remove_small': '0vox'
 }
 
 
@@ -41,8 +41,8 @@ def segment_nifti(fname_image, folder_model, fname_prior=None, param=None):
     if param is None:
         param = {}
 
-    options = {**DEFAULTS, **vars(param)}
-    nii_seg = imed.utils.segment_volume(folder_model, fname_image, fname_prior, options=options)
+    options = {**DEFAULTS, **vars(param), "fname_prior": fname_prior}
+    nii_seg = imed.utils.segment_volume(folder_model, fname_image, options=options)
 
     # Save output seg
     if 'o' in options:


### PR DESCRIPTION
Postprocessing is dealt by ivadomed, hence is removed from SCT to avoid code duplication.
Changes include:
- New postprocessing option: remove small objects
- Remove postprocessing code from SCT
- Change default params of '-fill-holes' and '-largest' (now set to 0 by default)

Before merging, a release of ivadomed will be required (sister PR: https://github.com/ivadomed/ivadomed/pull/486)