### PR TITLE
Move Docker installation instructions from GitHub Wiki to RTD

### DIFF
--- a/contrib/docker/Erase_fingerprint_docker.sh
+++ b/contrib/docker/Erase_fingerprint_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+grep -v "192.168.99.100" ~/.ssh/known_hosts | grep -v "localhost" | grep -v "127.0.0.1" > ~/.ssh/known_hosts.txt
+cat ~/.ssh/known_hosts.txt > ~/.ssh/known_hosts
+rm ~/.ssh/known_hosts.txt

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -8,3 +8,7 @@ Inside this directory, run:
 
     docker build -t dockersct .
     docker run --name sctcontainer -i -t dockersct
+    
+# SCT installation with GUI
+
+This directory also contains launcher scripts for XMing. These are used in the "Install SCT using Docker" steps found in the ReadTheDocs documentation.

--- a/contrib/docker/sct-win.xlaunch
+++ b/contrib/docker/sct-win.xlaunch
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<XLaunch xmlns="http://www.straightrunning.com/XmingNotes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.straightrunning.com/XmingNotes XLaunch.xsd" WindowMode="MultiWindow" ClientMode="StartProgram" Program="lxterminal" ClientStart="OpenSSH" PathToProtocol="C:\\Program Files\\Git\\usr\\bin\\" RemoteHost="127.0.0.1" RemoteUser="sct" ExtraSSH="-p 2222 -Y" Display="0" Clipboard="true"/>

--- a/contrib/docker/sct-win_docker_toolbox.xlaunch
+++ b/contrib/docker/sct-win_docker_toolbox.xlaunch
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<XLaunch xmlns="http://www.straightrunning.com/XmingNotes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.straightrunning.com/XmingNotes XLaunch.xsd" WindowMode="MultiWindow" ClientMode="StartProgram" Program="lxterminal" ClientStart="OpenSSH" PathToProtocol="C:\\Program Files\\Git\\usr\\bin\\" RemoteHost="192.168.99.100" RemoteUser="sct" ExtraSSH="-p 2222 -Y" Display="0" Clipboard="true"/>

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -169,7 +169,7 @@ First, save your Docker image:
    docker commit <CONTAINER_ID> <YOUR_NAME>/<DISTROS>:<VERSION>
 
 For macOS and Linux users
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create an X11 server for handling display:
 

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -96,9 +96,120 @@ In the context of SCT, it can be used:
   virtual machine
 - <your reason here>
 
-See https://github.com/neuropoly/sct_docker for more information. We also provide a
-`tutorial to install SCT via Docker <https://github.com/neuropoly/spinalcordtoolbox/wiki/testing#run-docker-image>`_.
+Option 1: Without GUI
+=====================
 
+First, `install Docker`_. Then, follow instructions below for creating an OS-specific SCT installation and testing.
+
+Run Docker image
+~~~~~~~~~~~~~~~~
+
+**For Ubuntu:**
+
+.. code:: bash
+
+   # in the Terminal
+   docker pull ubuntu:16.04
+   docker run -it ubuntu
+   # in docker container
+   apt-get update
+   yes | apt install git curl bzip2 libglib2.0-0 gcc
+   # Note: libglib2.0-0 is required by PyQt
+
+**For CentOS7:**
+
+.. code:: bash
+
+   # in the Terminal
+   docker pull centos:centos7
+   docker run -it centos:centos7
+   # in docker container
+   yum install -y which gcc git curl
+   # save the state of the container. Open a new Terminal and run:
+   docker ps -a  # list all containers
+   docker commit <CONTAINER_ID> <YOUR_NAME>/centos:centos7
+
+Install SCT
+~~~~~~~~~~~
+
+After having installed your favorite OS, run SCT installer and test it:
+
+.. code:: bash
+
+   git clone https://github.com/neuropoly/spinalcordtoolbox.git sct
+   cd sct
+   yes | ./install_sct
+   export PATH="/sct/bin:${PATH}"
+   sct_testing
+
+Option 2: With GUI
+==================
+
+In order to run scripts with GUI you need to allow X11 redirection.
+First, save your Docker image:
+
+1. Open another Terminal
+2. List current docker images
+
+.. code:: bash
+
+   docker ps -a
+
+3. Save container as new image
+
+.. code:: bash
+
+   docker commit <CONTAINER_ID> <YOUR_NAME>/<DISTROS>:<VERSION>
+
+For OSX and Linux users
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Create an X11 server for handling display:
+
+1. Install XQuartz X11 server.
+2. Check ‘Allow connections from network clientsoption inXQuartz\`
+   settings.
+3. Quit and restart XQuartz.
+4. In XQuartz window xhost + 127.0.0.1
+5. In your other Terminal window, run:
+
+   -  On OSX:
+      ``docker run -e DISPLAY=host.docker.internal:0 -it <CONTAINER_ID>``
+   -  On Linux:
+      ``docker run -ti --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix <CONTAINER_ID>``
+
+For windows users
+~~~~~~~~~~~~~~~~~
+
+| 1.Install Xming
+| 2.Connect to it using Xming/SSH:
+| Open a new CMD window and clone this repository:
+| ``git clone https://github.com/neuropoly/sct_docker.git``
+
+| If you are using Docker Desktop, run (double click)
+  windows/sct-win.xlaunch. If you are using Docker Toolbox, run
+  windows/sct-win_docker_toolbox.xlaunch
+| If this is the first time you have done this procedure, the system
+  will ask you if you want to add the remote PC (the docker container)
+  as trust pc, type yes. Then type the password to enter the docker
+  container (by default sct).
+
+**Troubleshooting:**
+
+| If there is no new open windows :
+| - Double click on the ‘windows/Erase_fingerprint_docker’ program
+| - Try again
+| - if it is still not working :
+| - Open the file manager and go to C:/Users/Your_username - In the
+  searchbar type ‘.ssh’ - Open the found ‘.ssh’ folder. - Open the
+  ‘known_hosts’ file with a text editor - Remove line starting with
+  ``192.168.99.100`` or ``localhost`` - try again
+
+The graphic terminal emulator LXterminal should appear (if not check the
+task bar at the bottom of the screen), which allows copying and pasting
+commands, which makes it easi
+
+.. _install Docker: https://docs.docker.com/install/
 
 Install with pip (experimental)
 -------------------------------

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -158,15 +158,15 @@ First, save your Docker image:
 1. Open another Terminal
 2. List current docker images
 
-.. code:: bash
+   .. code:: bash
 
-   docker ps -a
+      docker ps -a
 
 3. Save container as new image
 
-.. code:: bash
+   .. code:: bash
 
-   docker commit <CONTAINER_ID> <YOUR_NAME>/<DISTROS>:<VERSION>
+      docker commit <CONTAINER_ID> <YOUR_NAME>/<DISTROS>:<VERSION>
 
 For macOS and Linux users
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,28 +188,37 @@ Create an X11 server for handling display:
 For Windows users
 ~~~~~~~~~~~~~~~~~
 
-1. Install Xming
-2. Connect to it using Xming/SSH:
+#. Install Xming
+#. Connect to it using Xming/SSH:
 
-  - If you are using Docker Desktop, please download and run (double click) the following script: :download:`sct-win.xlaunch<../../../contrib/docker/sct-win.xlaunch>`.
-  - If you are using Docker Toolbox, please download and run the following script instead: :download:`sct-win_docker_toolbox.xlaunch<../../../contrib/docker/sct-win_docker_toolbox.xlaunch>`
-  - If this is the first time you have done this procedure, the system will ask you if you want to add the remote PC (the docker container) as trust pc, type yes. Then type the password to enter the docker container (by default sct).
+   - If you are using Docker Desktop, please download and run (double click) the following script: :download:`sct-win.xlaunch<../../../contrib/docker/sct-win.xlaunch>`.
+   - If you are using Docker Toolbox, please download and run the following script instead: :download:`sct-win_docker_toolbox.xlaunch<../../../contrib/docker/sct-win_docker_toolbox.xlaunch>`
+   - If this is the first time you have done this procedure, the system will ask you if you want to add the remote PC (the docker container) as trust pc, type yes. Then type the password to enter the docker container (by default sct).
 
 **Troubleshooting:**
 
-| If there are no new open windows:
-| - Please download and run the following file:
-  :download:`Erase_fingerprint_docker.sh<../../../contrib/docker/Erase_fingerprint_docker.sh>`
-| - Try again
-| - if it is still not working :
-| - Open the file manager and go to C:/Users/Your_username - In the
-  searchbar type ‘.ssh’ - Open the found ‘.ssh’ folder. - Open the
-  ‘known_hosts’ file with a text editor - Remove line starting with
-  ``192.168.99.100`` or ``localhost`` - try again
+The graphic terminal emulator LXterminal should appear (if not check the task bar at the bottom of the screen), which allows copying and pasting commands, which makes it easier for users to use it. If there are no new open windows:
 
-The graphic terminal emulator LXterminal should appear (if not check the
-task bar at the bottom of the screen), which allows copying and pasting
-commands, which makes it easi
+- Please download and run the following file: :download:`Erase_fingerprint_docker.sh<../../../contrib/docker/Erase_fingerprint_docker.sh>`
+- Try again
+- If it is still not working:
+
+  - Open the file manager and go to C:/Users/Your_username
+  - In the searchbar type ‘.ssh’ - Open the found ‘.ssh’ folder.
+  - Open the ‘known_hosts’ file with a text editor
+  - Remove line starting with ``192.168.99.100`` or ``localhost``
+  - Try again
+
+To check that X forwarding is working well write ``fsleyes &`` in LXterminal and FSLeyes should open, depending on how fast your computer is FSLeyes may take a few seconds to open. If fsleyes is not working in the LXterminal:
+
+- Check if it's working on the docker machine by running ``fsleyes &`` in the docker quickstart terminal
+- If it works, run all the commands in the docker terminal.
+- If it throws the error ``Unable to access the X Display, is $DISPLAY set properly?`` follow these next steps:
+
+  - Run ``echo $DISPLAY`` in the LXterminal
+  - Copy the output address
+  - Run ``export DISPLAY=<previously obtained address>`` in the docker quickstart terminal
+  - Run ``fsleyes &`` (in the docker quickstart terminal) to check if it is working. A new Xming window with fsleyes should appear.
 
 
 Install with pip (experimental)

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -96,8 +96,8 @@ In the context of SCT, it can be used:
   virtual machine
 - <your reason here>
 
-Option 1: Without GUI
-=====================
+Basic Installation (No GUI)
+===========================
 
 First, `install Docker <https://docs.docker.com/install/>`_. Then, follow the examples below to create an OS-specific SCT installation.
 
@@ -149,8 +149,8 @@ CentOS7-based installation
    docker commit <CONTAINER_ID> <YOUR_NAME>/centos:centos7
 
 
-Option 2: With GUI
-==================
+Using GUI Scripts (Optional)
+============================
 
 In order to run scripts with GUI you need to allow X11 redirection.
 First, save your Docker image:

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -168,7 +168,7 @@ First, save your Docker image:
 
    docker commit <CONTAINER_ID> <YOUR_NAME>/<DISTROS>:<VERSION>
 
-For OSX and Linux users
+For macOS and Linux users
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Create an X11 server for handling display:
@@ -180,7 +180,7 @@ Create an X11 server for handling display:
 4. In XQuartz window xhost + 127.0.0.1
 5. In your other Terminal window, run:
 
-   -  On OSX:
+   -  On macOS:
       ``docker run -e DISPLAY=host.docker.internal:0 -it <CONTAINER_ID>``
    -  On Linux:
       ``docker run -ti --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix <CONTAINER_ID>``

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -99,48 +99,55 @@ In the context of SCT, it can be used:
 Option 1: Without GUI
 =====================
 
-First, `install Docker`_. Then, follow instructions below for creating an OS-specific SCT installation and testing.
+First, `install Docker <https://docs.docker.com/install/>`_. Then, follow the examples below to create an OS-specific SCT installation.
 
-Run Docker image
-~~~~~~~~~~~~~~~~
 
-**For Ubuntu:**
+Ubuntu-based installation
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: bash
 
-   # in the Terminal
+   # Start from the Terminal
    docker pull ubuntu:16.04
+   # Launch interactive mode (command-line inside container)
    docker run -it ubuntu
-   # in docker container
+   # Now, inside Docker container, install dependencies
    apt-get update
    yes | apt install git curl bzip2 libglib2.0-0 gcc
-   # Note: libglib2.0-0 is required by PyQt
-
-**For CentOS7:**
-
-.. code:: bash
-
-   # in the Terminal
-   docker pull centos:centos7
-   docker run -it centos:centos7
-   # in docker container
-   yum install -y which gcc git curl
-   # save the state of the container. Open a new Terminal and run:
-   docker ps -a  # list all containers
-   docker commit <CONTAINER_ID> <YOUR_NAME>/centos:centos7
-
-Install SCT
-~~~~~~~~~~~
-
-After having installed your favorite OS, run SCT installer and test it:
-
-.. code:: bash
-
+   # Note for above: libglib2.0-0 is required by PyQt
+   # Install SCT
    git clone https://github.com/neuropoly/spinalcordtoolbox.git sct
    cd sct
    yes | ./install_sct
    export PATH="/sct/bin:${PATH}"
+   # Test SCT
    sct_testing
+   # save the state of the container. Open a new Terminal and run:
+   docker ps -a  # list all containers
+   docker commit <CONTAINER_ID> <YOUR_NAME>/ubuntu:ubuntu16.04
+
+CentOS7-based installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+   # Start from the Terminal
+   docker pull centos:centos7
+   # Launch interactive mode (command-line inside container)
+   docker run -it centos:centos7
+   # Now, inside Docker container, install dependencies
+   yum install -y which gcc git curl
+   # Install SCT
+   git clone https://github.com/neuropoly/spinalcordtoolbox.git sct
+   cd sct
+   yes | ./install_sct
+   export PATH="/sct/bin:${PATH}"
+   # Test SCT
+   sct_testing
+   # save the state of the container. Open a new Terminal and run:
+   docker ps -a  # list all containers
+   docker commit <CONTAINER_ID> <YOUR_NAME>/centos:centos7
+
 
 Option 2: With GUI
 ==================
@@ -209,7 +216,6 @@ The graphic terminal emulator LXterminal should appear (if not check the
 task bar at the bottom of the screen), which allows copying and pasting
 commands, which makes it easi
 
-.. _install Docker: https://docs.docker.com/install/
 
 Install with pip (experimental)
 -------------------------------

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -220,6 +220,23 @@ To check that X forwarding is working well write ``fsleyes &`` in LXterminal and
   - Run ``export DISPLAY=<previously obtained address>`` in the docker quickstart terminal
   - Run ``fsleyes &`` (in the docker quickstart terminal) to check if it is working. A new Xming window with fsleyes should appear.
 
+Notes:
+
+- If after closing a program with graphical interface (i.e. FSLeyes) LXterminal does not raise the shell ($) prompt then press Ctrl + C to finish closing the program.
+- Docker exposes the forwarded SSH server at different endpoints depending on whether Docker Desktop or Docker Toolbox is installed.
+
+  - Docker Desktop:
+
+    .. code:: bash
+
+       ssh -Y -p 2222 sct@127.0.0.1
+
+  - Docker Toolbox:
+
+    .. code:: bash
+
+       ssh -Y -p 2222 sct@192.168.99.100
+
 
 Install with pip (experimental)
 -------------------------------

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -188,23 +188,18 @@ Create an X11 server for handling display:
 For Windows users
 ~~~~~~~~~~~~~~~~~
 
-| 1.Install Xming
-| 2.Connect to it using Xming/SSH:
-| Open a new CMD window and clone this repository:
-| ``git clone https://github.com/neuropoly/sct_docker.git``
+1. Install Xming
+2. Connect to it using Xming/SSH:
 
-| If you are using Docker Desktop, run (double click)
-  windows/sct-win.xlaunch. If you are using Docker Toolbox, run
-  windows/sct-win_docker_toolbox.xlaunch
-| If this is the first time you have done this procedure, the system
-  will ask you if you want to add the remote PC (the docker container)
-  as trust pc, type yes. Then type the password to enter the docker
-  container (by default sct).
+  - If you are using Docker Desktop, please download and run (double click) the following script: :download:`sct-win.xlaunch<../../../contrib/docker/sct-win.xlaunch>`.
+  - If you are using Docker Toolbox, please download and run the following script instead: :download:`sct-win_docker_toolbox.xlaunch<../../../contrib/docker/sct-win_docker_toolbox.xlaunch>`
+  - If this is the first time you have done this procedure, the system will ask you if you want to add the remote PC (the docker container) as trust pc, type yes. Then type the password to enter the docker container (by default sct).
 
 **Troubleshooting:**
 
-| If there is no new open windows :
-| - Double click on the ‘windows/Erase_fingerprint_docker’ program
+| If there are no new open windows:
+| - Please download and run the following file:
+  :download:`Erase_fingerprint_docker.sh<../../../contrib/docker/Erase_fingerprint_docker.sh>`
 | - Try again
 | - if it is still not working :
 | - Open the file manager and go to C:/Users/Your_username - In the

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -185,7 +185,7 @@ Create an X11 server for handling display:
    -  On Linux:
       ``docker run -ti --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix <CONTAINER_ID>``
 
-For windows users
+For Windows users
 ~~~~~~~~~~~~~~~~~
 
 | 1.Install Xming


### PR DESCRIPTION
### Related issues/PRs

Fixes #2964. 
Related to #2965.

### Description

To start this PR, I've left the steps mostly as they were from [the GitHub Wiki page](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Docker-(Installing-SCT,-using-GUI)). But, I imagine these steps will change following discussion from the dev team, especially due to #2965.

**➤ Rendered doc: https://spinalcordtoolbox.com/en/jn-2964-fix-docker-install-docs/**