### PR TITLE
Refactor sct_maths callers to remove subprocess and use API

### DIFF
--- a/spinalcordtoolbox/registration/register.py
+++ b/spinalcordtoolbox/registration/register.py
@@ -205,16 +205,19 @@ def register_step_ants_registration(src, dest, step, masking, ants_registration_
 
         src_img = image.Image(src)
         src_out = src_img.copy()
+
+        src = image.add_suffix(src, '_laplacian')
+        dest = image.add_suffix(dest, '_laplacian')
+
+        sigmas = [sigmas[i] / src_img.dim[i + 4] for i in range(3)]
+
         src_out.data = laplacian(src_out.data, sigmas)
-        src_out.save(path=image.add_suffix(src, '_laplacian'))
+        src_out.save(path=src)
 
         dest_img = image.Image(dest)
         dest_out = dest_img.copy()
         dest_out.data = laplacian(dest_out.data, sigmas)
-        dest_out.save(path=image.add_suffix(dest, '_laplacian'))
-
-        src = image.add_suffix(src, '_laplacian')
-        dest = image.add_suffix(dest, '_laplacian')
+        dest_out.save(path=dest)
 
     # Estimate transformation
     logger.info(f"\nEstimate transformation")

--- a/spinalcordtoolbox/registration/register.py
+++ b/spinalcordtoolbox/registration/register.py
@@ -21,6 +21,7 @@ from sklearn.decomposition import PCA
 from scipy.io import loadmat
 
 import spinalcordtoolbox.image as image
+from spinalcordtoolbox.math import laplacian
 from spinalcordtoolbox.registration.landmarks import register_landmarks
 from spinalcordtoolbox.utils import sct_progress_bar, copy_helper, run_proc, tmp_create
 
@@ -199,10 +200,19 @@ def register_step_ants_registration(src, dest, step, masking, ants_registration_
     # apply Laplacian filter
     if not step.laplacian == '0':
         logger.info(f"\nApply Laplacian filter")
-        run_proc(['sct_maths', '-i', src, '-laplacian', step.laplacian + ','
-                 + step.laplacian + ',0', '-o', image.add_suffix(src, '_laplacian')])
-        run_proc(['sct_maths', '-i', dest, '-laplacian', step.laplacian + ','
-                 + step.laplacian + ',0', '-o', image.add_suffix(dest, '_laplacian')])
+
+        sigmas = [step.laplacian, step.laplacian, 0]
+
+        src_img = image.Image(src)
+        src_out = src_img.copy()
+        src_out.data = laplacian(src_out.data, sigmas)
+        src_out.save(path=image.add_suffix(src, '_laplacian'))
+
+        dest_img = image.Image(dest)
+        dest_out = dest_img.copy()
+        dest_out.data = laplacian(dest_out.data, sigmas)
+        dest_out.save(path=image.add_suffix(dest, '_laplacian'))
+
         src = image.add_suffix(src, '_laplacian')
         dest = image.add_suffix(dest, '_laplacian')
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -201,7 +201,12 @@ class ExtractGLCM:
             # Average across angles and save it as wrk_folder/fnameIn_feature_distance_mean.extension
             fname_out = im_m + str(self.param_glcm.distance) + '_mean' + extension
             run_proc('sct_image -i ' + ' '.join(im2mean_lst) + ' -concat t -o ' + fname_out)
-            run_proc('sct_maths -i ' + fname_out + ' -mean t -o ' + fname_out)
+
+            img = Image(fname_out)
+            dim_idx = 3 # 3 dimensions + time
+            img.data = np.mean(img.data, dim_idx)
+            img.save()
+
             self.fname_metric_lst[im_m + str(self.param_glcm.distance) + '_mean'] = fname_out
 
     def extract_slices(self):

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -15,7 +15,7 @@ import itertools
 import numpy as np
 from skimage.feature import greycomatrix, greycoprops
 
-from spinalcordtoolbox.image import Image, add_suffix, zeros_like
+from spinalcordtoolbox.image import Image, add_suffix, zeros_like, concat_data
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
@@ -200,10 +200,11 @@ class ExtractGLCM:
 
             # Average across angles and save it as wrk_folder/fnameIn_feature_distance_mean.extension
             fname_out = im_m + str(self.param_glcm.distance) + '_mean' + extension
-            run_proc('sct_image -i ' + ' '.join(im2mean_lst) + ' -concat t -o ' + fname_out)
 
+            dim_idx = 3 # img is [x, y, z, angle] so specify 4th dimension (angle)
+
+            img = concat_data(im2mean_lst, dim_idx).save(fname_out)
             img = Image(fname_out)
-            dim_idx = 3 # 3 dimensions + time
             img.data = np.mean(img.data, dim_idx)
             img.save()
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -219,18 +219,6 @@ class ExtractGLCM:
         # extract axial slices in self.dct_im_seg
         self.dct_im_seg['im'], self.dct_im_seg['seg'] = [im.data[:, :, z] for z in range(im.dim[2])], [seg.data[:, :, z] for z in range(im.dim[2])]
 
-    # def init_metric_im(self):
-    #     # open image and re-orient it to RPI if needed
-    #     im_tmp = Image(self.param.fname_im)
-    #     if self.orientation_im != self.orientation_extraction:
-    #         im_tmp = msct_image.change_orientation(im_tmp, self.orientation_extraction)
-
-    #     # create Image objects with zeros values for each output image needed
-    #     for m in self.metric_lst:
-    #         im_2save = msct_image.zeros_like(im_tmp, dtype=np.float64)
-    #         fname_out = add_suffix(''.join(extract_fname(self.param.fname_im)[1:]), '_' + m)
-    #         im_2save.save(fname_out)
-    #         self.fname_metric_lst[m] = fname_out
 
     def compute_texture(self):
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -203,8 +203,10 @@ class ExtractGLCM:
 
             dim_idx = 3 # img is [x, y, z, angle] so specify 4th dimension (angle)
 
-            img = concat_data(im2mean_lst, dim_idx).save(fname_out)
-            img = Image(fname_out)
+            img = concat_data(im2mean_lst, dim_idx).save(fname_out, mutable=True)
+
+            if len(np.shape(img.data)) < 4: # in case input volume is 3d and dim=t
+                img.data = img.data[..., np.newaxis]
             img.data = np.mean(img.data, dim_idx)
             img.save()
 

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -19,6 +19,7 @@ from spinalcordtoolbox.image import Image, add_suffix, empty_like, change_orient
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname
+from spinalcordtoolbox.math import binarize
 
 # TODO: display results ==> not only max : with a violin plot of h1 and h2 distribution ? see dev/straightening --> seaborn.violinplot
 # TODO: add the option Hyberbolic Hausdorff's distance : see  choi and seidel paper
@@ -400,7 +401,9 @@ def resample_image(fname, suffix='_resampled.nii.gz', binary=False, npx=0.3, npy
             im_split.save(name_resample)
 
         if binary:
-            run_proc(['sct_maths', '-i', name_resample, '-bin', str(thr), '-o', name_resample])
+            img = Image(name_resample)
+            img.data = binarize(img.data, thr)
+            img.save()
 
         if orientation != 'RPI':
             name_resample = Image(name_resample) \

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -28,7 +28,9 @@ from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_l
 from spinalcordtoolbox.utils.fs import tmp_create, check_file_exist, extract_fname, rmtree, copy
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate
+from spinalcordtoolbox.math import concatenate_along_4th_dimension
 
+from spinalcordtoolbox.scripts.sct_maths import get_data_or_scalar
 from spinalcordtoolbox.scripts.sct_image import concat_data
 
 
@@ -286,7 +288,11 @@ def create_line(param, fname, coord, nz):
     copy(fname, 'line.nii', verbose=param.verbose)
 
     # set all voxels to zero
-    run_proc(['sct_maths', '-i', 'line.nii', '-mul', '0', '-o', 'line.nii'], param.verbose)
+    img = Image('line.nii')
+    data = get_data_or_scalar('0', img.data)
+    data_concat = concatenate_along_4th_dimension(img.data, data)
+    img.data = np.prod(data_concat, axis=3)
+    img.save()
 
     labels = []
 
@@ -297,7 +303,7 @@ def create_line(param, fname, coord, nz):
         # backwards compat
         labels.extend([Coordinate([coord[0], coord[1], iz, 1]) for iz in range(nz)])
 
-    create_labels(Image("line.nii"), labels).save(path="line.nii")
+    create_labels(img, labels).save()
 
     return 'line.nii'
 

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -130,19 +130,16 @@ def main(argv=None):
         fname_input1_bin = add_suffix(fname_input1, '_bin')
         im_1_bin = im_1.copy()
         im_1_bin.data = binarize(im_1.data, 0)
-        im_1_bin.save(fname_input1_bin)
-        fname_input1 = fname_input1_bin
+        im_1_bin.save(fname_input1_bin, mutable=True)
+        im_1 = im_1_bin
 
         fname_input2_bin = add_suffix(fname_input2, '_bin')
         im_2_bin = Image(fname_input2)
         im_2_bin.data = binarize(im_2.data, 0)
-        im_2_bin.save(fname_input2_bin)
-        fname_input2 = fname_input2_bin
+        im_2_bin.save(fname_input2_bin, mutable=True)
+        im_2 = im_2_bin
 
     # copy header of im_1 to im_2
-    im_1 = Image(fname_input1)
-    im_2 = Image(fname_input2)
-
     im_2.header = im_1.header
     im_2.save()
 

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -16,7 +16,8 @@ import os
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
-from spinalcordtoolbox.image import add_suffix
+from spinalcordtoolbox.image import Image, add_suffix
+from spinalcordtoolbox.math import binarize
 
 
 def get_parser():
@@ -122,18 +123,26 @@ def main(argv=None):
     curdir = os.getcwd()
     os.chdir(tmp_dir)  # go to tmp directory
 
+    im_1 = Image(fname_input1)
+    im_2 = Image(fname_input2)
+
     if arguments.bin is not None:
         fname_input1_bin = add_suffix(fname_input1, '_bin')
-        run_proc(['sct_maths', '-i', fname_input1, '-bin', '0', '-o', fname_input1_bin])
+        im_1_bin = im_1.copy()
+        im_1_bin.data = binarize(im_1.data, 0)
+        im_1_bin.save(fname_input1_bin)
         fname_input1 = fname_input1_bin
+
         fname_input2_bin = add_suffix(fname_input2, '_bin')
-        run_proc(['sct_maths', '-i', fname_input2, '-bin', '0', '-o', fname_input2_bin])
+        im_2_bin = Image(fname_input2)
+        im_2_bin.data = binarize(im_2.data, 0)
+        im_2_bin.save(fname_input2_bin)
         fname_input2 = fname_input2_bin
 
     # copy header of im_1 to im_2
-    from spinalcordtoolbox.image import Image
     im_1 = Image(fname_input1)
     im_2 = Image(fname_input2)
+
     im_2.header = im_1.header
     im_2.save()
 

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -134,7 +134,7 @@ def main(argv=None):
         im_1 = im_1_bin
 
         fname_input2_bin = add_suffix(fname_input2, '_bin')
-        im_2_bin = Image(fname_input2)
+        im_2_bin = im_2.copy()
         im_2_bin.data = binarize(im_2.data, 0)
         im_2_bin.save(fname_input2_bin, mutable=True)
         im_2 = im_2_bin

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -127,17 +127,17 @@ def main(argv=None):
     im_2 = Image(fname_input2)
 
     if arguments.bin is not None:
+        im_1.data = binarize(im_1.data, 0)
         fname_input1_bin = add_suffix(fname_input1, '_bin')
-        im_1_bin = im_1.copy()
-        im_1_bin.data = binarize(im_1.data, 0)
-        im_1_bin.save(fname_input1_bin, mutable=True)
-        im_1 = im_1_bin
+        im_1.save(fname_input1_bin, mutable=True)
 
+        im_2.data = binarize(im_2.data, 0)
         fname_input2_bin = add_suffix(fname_input2, '_bin')
-        im_2_bin = im_2.copy()
-        im_2_bin.data = binarize(im_2.data, 0)
-        im_2_bin.save(fname_input2_bin, mutable=True)
-        im_2 = im_2_bin
+        im_2.save(fname_input2_bin, mutable=True)
+
+        # Use binarized images in subsequent steps
+        fname_input1 = fname_input1_bin
+        fname_input2 = fname_input2_bin
 
     # copy header of im_1 to im_2
     im_2.header = im_1.header

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -194,7 +194,13 @@ def main(argv=None):
     # Average b=0 images
     if average:
         printv('\nAverage b=0...', verbose)
-        run_proc(['sct_maths', '-i', b0_name + ext, '-o', b0_mean_name + ext, '-mean', 't'], verbose)
+        img = Image(b0_name + ext)
+        out = img.copy()
+        dim_idx = 3 # 3 dimensions + time
+        if dim_idx + 1 > len(np.shape(img.data)):
+            out.data = out.data[..., np.newaxis]
+        out.data = np.mean(out.data, dim_idx)
+        out.save(path=b0_mean_name + ext)
 
     # Merge DWI
     l = []
@@ -205,7 +211,13 @@ def main(argv=None):
     # Average DWI images
     if average:
         printv('\nAverage DWI...', verbose)
-        run_proc(['sct_maths', '-i', dwi_name + ext, '-o', dwi_mean_name + ext, '-mean', 't'], verbose)
+        img = Image(dwi_name + ext)
+        out = img.copy()
+        dim_idx = 3 # 3 dimensions + time
+        if dim_idx + 1 > len(np.shape(img.data)):
+            out.data = out.data[..., np.newaxis]
+        out.data = np.mean(out.data, dim_idx)
+        out.save(path=dwi_mean_name + ext)
 
     # come back
     os.chdir(curdir)

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -196,9 +196,9 @@ def main(argv=None):
         printv('\nAverage b=0...', verbose)
         img = Image(b0_name + ext)
         out = img.copy()
-        dim_idx = 3 # 3 dimensions + time
-        if dim_idx + 1 > len(np.shape(img.data)):
-            out.data = out.data[..., np.newaxis]
+        dim_idx = 3
+        if len(np.shape(img.data)) < dim_idx + 1:
+            raise ValueError("Expecting image with 4 dimensions!")
         out.data = np.mean(out.data, dim_idx)
         out.save(path=b0_mean_name + ext)
 
@@ -213,9 +213,9 @@ def main(argv=None):
         printv('\nAverage DWI...', verbose)
         img = Image(dwi_name + ext)
         out = img.copy()
-        dim_idx = 3 # 3 dimensions + time
-        if dim_idx + 1 > len(np.shape(img.data)):
-            out.data = out.data[..., np.newaxis]
+        dim_idx = 3
+        if len(np.shape(img.data)) < dim_idx + 1:
+            raise ValueError("Expecting image with 4 dimensions!")
         out.data = np.mean(out.data, dim_idx)
         out.save(path=dwi_mean_name + ext)
 

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -330,8 +330,7 @@ def main(argv=None):
 
     # Threshold segmentation at 0.5
     img = Image('segmentation_straight.nii')
-    data_thr = threshold(img.data, 0.5)
-    img.data = data_thr
+    img.data = threshold(img.data, 0.5)
     img.save()
 
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -22,8 +22,8 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree
+from spinalcordtoolbox.math import binarize
 
-from spinalcordtoolbox.scripts import sct_maths
 from spinalcordtoolbox.scripts import sct_apply_transfo
 
 
@@ -146,11 +146,12 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
             '-x', param.interp,
             '-o', 'src_' + str(i_file) + '_template.nii.gz',
             '-v', str(param.verbose)])
+
         # create binary mask from input file by assigning one to all non-null voxels
-        sct_maths.main(argv=[
-            '-i', fname_src,
-            '-bin', str(param.almost_zero),
-            '-o', 'src_' + str(i_file) + 'native_bin.nii.gz'])
+        img = Image(fname_src)
+        out = img.copy()
+        out.data = binarize(out.data, param.almost_zero)
+        out.save(path=f"src_{i_file}native_bin.nii.gz")
 
         # apply transformation to binary mask to compute partial volume
         sct_apply_transfo.main(argv=[

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -25,7 +25,7 @@ from spinalcordtoolbox.image import Image, add_suffix, generate_output_file, con
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.resampling import resample_file
-from spinalcordtoolbox.math import dilate
+from spinalcordtoolbox.math import dilate, binarize
 from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
 from spinalcordtoolbox.types import Coordinate
@@ -33,8 +33,6 @@ from spinalcordtoolbox.utils import *
 from spinalcordtoolbox import __data_dir__
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels
-
-from spinalcordtoolbox.scripts import sct_maths
 from spinalcordtoolbox.scripts import sct_apply_transfo
 from spinalcordtoolbox.scripts.sct_image import split_data
 
@@ -430,9 +428,10 @@ def main(argv=None):
     # binarize segmentation (in case it has values below 0 caused by manual editing)
     printv('\nBinarize segmentation', verbose)
     ftmp_seg_, ftmp_seg = ftmp_seg, add_suffix(ftmp_seg, "_bin")
-    sct_maths.main(['-i', ftmp_seg_,
-                    '-bin', '0.5',
-                    '-o', ftmp_seg])
+    img = Image(ftmp_seg_)
+    out = img.copy()
+    out.data = binarize(out.data, 0.5)
+    out.save(path=ftmp_seg)
 
     # Switch between modes: subject->template or template->subject
     if ref == 'template':

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -249,8 +249,7 @@ def main(argv=None):
 
     # Generate output file
     printv('\nGenerate output file...')
-    generate_output_file(os.path.join(path_tmp, "anat_rpi_straight_smooth_curved_nonzero.nii"),
-                         file_anat + '_smooth' + ext_anat)
+    generate_output_file(os.path.join(path_tmp, "anat_rpi_straight_smooth_curved_nonzero.nii"), fname_out)
 
     # Remove temporary files
     if remove_temp_files == 1:
@@ -261,7 +260,7 @@ def main(argv=None):
     elapsed_time = time.time() - start_time
     printv('\nFinished! Elapsed time: ' + str(int(np.round(elapsed_time))) + 's\n')
 
-    display_viewer_syntax([file_anat, file_anat + '_smooth'], verbose=verbose)
+    display_viewer_syntax([fname_anat, fname_out], verbose=verbose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Continuation of #2876 
After #2966 
Closes #2878 

Remove subprocess calls of `sct_maths` and use `spinalcordtoolbox.math` API.


~~~
Version:         git-aj/2878-refactor_sct_math_callers-9ed9a41ed88c9d04ae3c56e5e03a64301fdb6feb*
Ran on:          Linux gentoo-p53 5.10.5-gentoo-x86_64
Duration:        0hrs 11min 42sec
---
t2/CSA:          73.87711295363036
mt/MTR(WM):      54.38001546261108
t2s/CSA_GM:      12.487834828856176
t2s/CSA_WM:      64.93830702088249
dmri/FA(CST_r):  0.7756265311035226
dmri/FA(CST_l):  0.7800112266489608
~~~
