### PR TITLE
Pin h5py~=2.10.0 as a workaround for upstream Keras/TensorFlow issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colored
 dipy
 futures
-h5py
+h5py==2.10.0
 ivadomed==2.0.2
 Keras==2.1.5
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 colored
 dipy
 futures
-h5py
+# h5py is pinned to minor than 3 due to issues with Keras/TF
+# https://github.com/tensorflow/tensorflow/issues/44467
+h5py<3.0
 ivadomed==2.0.2
 Keras==2.1.5
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dipy
 futures
 # h5py is pinned to minor than 3 due to issues with Keras/TF
 # https://github.com/tensorflow/tensorflow/issues/44467
-h5py<3.0
+h5py~=2.10.0
 ivadomed==2.0.2
 Keras==2.1.5
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colored
 dipy
 futures
-h5py==2.10.0
+h5py
 ivadomed==2.0.2
 Keras==2.1.5
 matplotlib


### PR DESCRIPTION
### Related PRs/issues

Fixes #2987.