### PR TITLE
remove models for sct_deepseg 

### DIFF
--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -17,7 +17,7 @@ import sys
 
 import spinalcordtoolbox.deepseg as deepseg
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import printv
+from spinalcordtoolbox.utils.sys import printv, init_sct
 
 
 def get_parser():
@@ -145,4 +145,5 @@ def main():
 
 
 if __name__ == '__main__':
+    init_sct()
     main()

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -145,5 +145,4 @@ def main():
 
 
 if __name__ == '__main__':
-    init_sct()
     main()

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -17,7 +17,7 @@ import sys
 
 import spinalcordtoolbox.deepseg as deepseg
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import printv
 
 
 def get_parser():

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -100,6 +100,9 @@ def main():
     parser = get_parser()
     args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
+    # Update log_level
+    init_sct(log_level=args.v, update=True)
+
     # Deal with task
     if args.list_tasks:
         deepseg.models.display_list_tasks()

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -16,8 +16,6 @@ import os
 import sys
 
 import spinalcordtoolbox.deepseg as deepseg
-import spinalcordtoolbox.deepseg.models
-import spinalcordtoolbox.deepseg.core
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv
 
@@ -54,25 +52,6 @@ def get_parser():
         "-install-task",
         help="Install models that are required for specified task.",
         choices=list(deepseg.models.TASKS.keys()))
-
-    seg = parser.add_argument_group('\nMODELS')
-    seg.add_argument(
-        "-model",
-        # TODO: add instructions at: https://github.com/neuropoly/ivado-medical-imaging
-        help="Model to use. It could either be an official SCT model (in that case, simply enter the name of the "
-             "model, example: -model t2_sc), or a path to the directory that contains a model, example: "
-             "-model my_models/model. To list official models, run: sct_deepseg -list-models."
-             "To build your own model, follow instructions at: https://github.com/neuropoly/ivado-medical-imaging",
-        nargs='+',
-        metavar=Metavar.str)
-    seg.add_argument(
-        "-list-models",
-        action='store_true',
-        help="Display a list of available models.")
-    seg.add_argument(
-        "-install-model",
-        help="Install specified model.",
-        choices=list(deepseg.models.MODELS.keys()))
 
     misc = parser.add_argument_group('\nPARAMETERS')
     misc.add_argument(
@@ -121,17 +100,9 @@ def main():
     parser = get_parser()
     args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
-    # Deal with model
-    if args.list_models:
-        deepseg.models.display_list_models()
-
     # Deal with task
     if args.list_tasks:
         deepseg.models.display_list_tasks()
-
-    if args.install_model is not None:
-        deepseg.models.install_model(args.install_model)
-        exit(0)
 
     if args.install_task is not None:
         for name_model in deepseg.models.TASKS[args.install_task]['models']:
@@ -143,15 +114,11 @@ def main():
         parser.error("This file does not exist: {}".format(args.i))
 
     # Check if at least a model or task has been specified
-    if args.model is None and args.task is None:
-        parser.error("You need to specify a model or a task.")
+    if args.task is None:
+        parser.error("You need to specify a task.")
 
     # Get pipeline model names
-    if args.task is not None:
-        name_models = deepseg.models.TASKS[args.task]['models']
-
-    if args.model is not None:
-        name_models = args.model
+    name_models = deepseg.models.TASKS[args.task]['models']
 
     # Run pipeline by iterating through the models
     fname_prior = None

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -16,6 +16,8 @@ import os
 import sys
 
 import spinalcordtoolbox.deepseg as deepseg
+import spinalcordtoolbox.deepseg.models
+import spinalcordtoolbox.deepseg.core
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv
 
@@ -30,7 +32,6 @@ def get_parser():
     input_output = parser.add_argument_group("\nINPUT/OUTPUT")
     input_output.add_argument(
         "-i",
-        required=True,
         help="Image to segment.",
         metavar=Metavar.file)
     input_output.add_argument(

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -17,7 +17,7 @@ import sys
 
 import spinalcordtoolbox.deepseg as deepseg
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import printv, init_sct
+from spinalcordtoolbox.utils.sys import init_sct, printv
 
 
 def get_parser():
@@ -99,9 +99,6 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-
-    # Update log_level
-    init_sct(log_level=args.v, update=True)
 
     # Deal with task
     if args.list_tasks:

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -135,7 +135,6 @@ def display_list_tasks():
     tasks = sct.deepseg.models.list_tasks()
     # Display beautiful output
     color = {True: 'green', False: 'red'}
-    default = {True: '[*]', False: ''}
     print("{:<20s}{:<50s}MODELS".format("TASK", "DESCRIPTION"))
     print("-" * 80)
     for name_task, value in tasks.items():
@@ -151,10 +150,9 @@ def display_list_tasks():
         print("{}{}{}".format(task_status, description_status, models_status))
 
     print(
-        '\nLegend: {} | {} | default: {}\n'.format(
+        '\nLegend: {} | {}\n'.format(
             colored.stylize("installed", colored.fg(color[True])),
-            colored.stylize("not installed", colored.fg(color[False])),
-            default[True]))
+            colored.stylize("not installed", colored.fg(color[False]))))
     exit(0)
 
 

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -123,39 +123,6 @@ def is_valid(path_model):
            os.path.exists(os.path.join(path_model, name_model + '.json'))
 
 
-def list_models():
-    """
-    Display available models with description. Color is used to indicate if model is installed or not. For default
-    models, a '*' is added next to the model name.
-
-    :return: dict: Models that are installed
-    """
-    return {name: value for name, value in MODELS.items()}
-
-
-def display_list_models():
-    models = sct.deepseg.models.list_models()
-    # Display beautiful output
-    color = {True: 'green', False: 'red'}
-    default = {True: '[*]', False: ''}
-    print("{:<25s}DESCRIPTION".format("MODEL"))
-    print("-" * 80)
-    for name_model, value in models.items():
-        path_model = sct.deepseg.models.folder(name_model)
-        print("{}{}".format(
-            colored.stylize(''.join((name_model, default[value['default']])).ljust(25),
-                            colored.fg(color[sct.deepseg.models.is_valid(path_model)])),
-            colored.stylize(value['description'],
-                            colored.fg(color[sct.deepseg.models.is_valid(path_model)]))
-        ))
-    print(
-        '\nLegend: {} | {} | default: {}\n'.format(
-            colored.stylize("installed", colored.fg(color[True])),
-            colored.stylize("not installed", colored.fg(color[False])),
-            default[True]))
-    exit(0)
-
-
 def list_tasks():
     """
     Display available tasks with description.

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -119,8 +119,8 @@ def is_valid(path_model):
     """
     name_model = path_model.rstrip(os.sep).split(os.sep)[-1]
     return (os.path.exists(os.path.join(path_model, name_model + '.pt')) or
-           os.path.exists(os.path.join(path_model, name_model + '.onnx'))) and \
-           os.path.exists(os.path.join(path_model, name_model + '.json'))
+            os.path.exists(os.path.join(path_model, name_model + '.onnx'))) and os.path.exists(
+        os.path.join(path_model, name_model + '.json'))
 
 
 def list_tasks():

--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -11,7 +11,6 @@ import nibabel
 
 import spinalcordtoolbox as sct
 from spinalcordtoolbox.utils import sct_test_path
-import spinalcordtoolbox.deepseg.core
 
 
 param_deepseg = [

--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -12,7 +12,6 @@ import nibabel
 import spinalcordtoolbox as sct
 from spinalcordtoolbox.utils import sct_test_path
 import spinalcordtoolbox.deepseg.core
-import spinalcordtoolbox.deepseg.models
 
 
 param_deepseg = [


### PR DESCRIPTION
This PR introduces the following changes:
- To avoid confusion and errors, sct_deepseg will only have task (and no models). Fixes #2994
- Update legend to remove the "default [*]" in `-list-tasks`. Fixes #2996

To address in subsequent PRs:
- Remove the field "default" in models: https://github.com/neuropoly/spinalcordtoolbox/issues/3007
- Duplication of logs output. Fixes #2993
