### PR TITLE
Revert "More sane package imports"

### DIFF
--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -16,6 +16,9 @@ import os
 import sys
 
 import spinalcordtoolbox.deepseg as deepseg
+import spinalcordtoolbox.deepseg.models
+import spinalcordtoolbox.deepseg.core
+
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv
 

--- a/spinalcordtoolbox/__init__.py
+++ b/spinalcordtoolbox/__init__.py
@@ -1,4 +1,3 @@
 #!/usr/bin/env python
 
-# convenience and backwards compat
 from .utils import __version__, __sct_dir__, __data_dir__, __deepseg_dir__

--- a/spinalcordtoolbox/centerline/__init__.py
+++ b/spinalcordtoolbox/centerline/__init__.py
@@ -1,1 +1,0 @@
-from . import core, curve_fitting, nurbs, optic

--- a/spinalcordtoolbox/compat/__init__.py
+++ b/spinalcordtoolbox/compat/__init__.py
@@ -1,1 +1,0 @@
-from . import launcher

--- a/spinalcordtoolbox/deepseg/__init__.py
+++ b/spinalcordtoolbox/deepseg/__init__.py
@@ -1,1 +1,0 @@
-from . import core, models

--- a/spinalcordtoolbox/deepseg_gm/__init__.py
+++ b/spinalcordtoolbox/deepseg_gm/__init__.py
@@ -1,1 +1,0 @@
-from . import deepseg_gm, model

--- a/spinalcordtoolbox/deepseg_lesion/__init__.py
+++ b/spinalcordtoolbox/deepseg_lesion/__init__.py
@@ -1,1 +1,0 @@
-from . import core

--- a/spinalcordtoolbox/deepseg_sc/__init__.py
+++ b/spinalcordtoolbox/deepseg_sc/__init__.py
@@ -1,1 +1,0 @@
-from . import cnn_models, cnn_models_3d, core, postprocessing

--- a/spinalcordtoolbox/gui/__init__.py
+++ b/spinalcordtoolbox/gui/__init__.py
@@ -1,1 +1,0 @@
-from . import base, centerline, sagittal, widgets

--- a/spinalcordtoolbox/qmri/__init__.py
+++ b/spinalcordtoolbox/qmri/__init__.py
@@ -1,1 +1,0 @@
-from . import mt

--- a/spinalcordtoolbox/registration/__init__.py
+++ b/spinalcordtoolbox/registration/__init__.py
@@ -1,1 +1,0 @@
-from . import landmarks, register

--- a/spinalcordtoolbox/reports/__init__.py
+++ b/spinalcordtoolbox/reports/__init__.py
@@ -1,1 +1,1 @@
-from . import qc, slice
+# -*- coding: utf-8 -*-

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -21,8 +21,8 @@ from matplotlib.figure import Figure
 import matplotlib.colors as color
 
 from spinalcordtoolbox.image import Image
-from . import slice as qcslice
-from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, copy, extract_fname
+import spinalcordtoolbox.reports.slice as qcslice
+from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, printv, copy, extract_fname
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -22,7 +22,7 @@ import matplotlib.colors as color
 
 from spinalcordtoolbox.image import Image
 import spinalcordtoolbox.reports.slice as qcslice
-from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, printv, copy, extract_fname
+from spinalcordtoolbox.utils import sct_dir_local_path, list2cmdline, __version__, copy, extract_fname
 
 logger = logging.getLogger(__name__)
 

--- a/spinalcordtoolbox/vertebrae/__init__.py
+++ b/spinalcordtoolbox/vertebrae/__init__.py
@@ -1,1 +1,0 @@
-from . import core, detect_c2c3


### PR DESCRIPTION
This reverts commit f65df321b078b939e5de66755ca0561fe773ed82.

Based on discussion: https://github.com/neuropoly/spinalcordtoolbox/issues/2989

Implicit imports causing undesirable increase in load time.
