### PR TITLE
Fixes inconsistencies between PAM50 levels and cord

### DIFF
--- a/scripts/sct_download_data.py
+++ b/scripts/sct_download_data.py
@@ -78,10 +78,8 @@ def main(args=None):
             "https://github.com/sct-data/sct_testing_data/releases/download/r20201030/sct_testing_data-r20201030.zip",
             "https://osf.io/download/5f9c271187b7df04593b03e0/"],
         "PAM50": [
-            "https://github.com/sct-data/PAM50/releases/download/r20191029/20191029_pam50.zip",
-            "https://osf.io/u79sr/download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20191029_PAM50.zip",
-        ],
+            "https://github.com/sct-data/PAM50/releases/download/r20201104/PAM50-r20201104.zip", 
+            "https://osf.io/download/5fa21326a5bb9d00610a5a21/"],
         "MNI-Poly-AMU": [
             "https://github.com/sct-data/MNI-Poly-AMU/releases/download/r20170310/20170310_MNI-Poly-AMU.zip",
             "https://osf.io/sh6h4/?action=download",


### PR DESCRIPTION
In the current PAM50 (v4.0.0-beta.0), the cord, levels and levels_continuous are not perfectly matched. See below (slice 904):

PAM50_levels.nii.gz (red) overlaid on PAM50_cord.nii.gz (white):
![screen shot 2019-02-25 at 15 40 18](https://user-images.githubusercontent.com/2482071/53367360-f6d7a400-3913-11e9-8a70-42562c472568.png)

PAM50_levels_continuous.nii.gz (red) overlaid on PAM50_cord.nii.gz (white):
![screen shot 2019-02-25 at 15 40 10](https://user-images.githubusercontent.com/2482071/53367374-ff2fdf00-3913-11e9-86b3-83d4bb545d5e.png)

The purpose of this PR is to update the link to the [new release of the PAM50](https://github.com/sct-data/PAM50/releases/tag/r20201104), which fixes the issue. 

Fixes #2172

P.S. Thank you @lrouhier for generating these new files 💯 