### PR TITLE
Update sct_extract_metric help to fix RTD error + fix outdated usage

### DIFF
--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -50,33 +50,22 @@ def get_parser():
 
     param_default = Param()
 
-    # Read .txt files referencing the labels (for extended usage description)
-    file_label = os.path.join(param_default.path_label,
-                              param_default.file_info_label)
-    check_file_exist(file_label, 0)
-    default_info_label = open(file_label, 'r')
-    label_references = default_info_label.read()
-    default_info_label.close()
-
     description = (f"This program extracts metrics (e.g., DTI or MTR) within labels. Labels could be a single file or "
-                   f"a folder generated with 'sct_warp_template' and containing multiple label files and a label "
+                   f"a folder generated with 'sct_warp_template' containing multiple label files and a label "
                    f"description file (info_label.txt). The labels should be in the same space coordinates as the "
                    f"input image.\n"
                    f"\n"
-                   f"To list white matter atlas labels: {os.path.basename(__file__)} -f "
-                   f"{os.path.join(__data_dir__, 'atlas')}\n"
+                   f"The labels used by default are taken from the PAM50 template. To learn about the available PAM50 "
+                   f"white/grey matter atlas labels and their corresponding ID values, please refer to: "
+                   f"https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas \n"
                    f"\n"
-                   f"To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method: "
-                   f"{os.path.basename(__file__)} -i dti_FA.nii.gz -f label/atlas -l 0,2,3 -v 2:7 -m bin\n")
-
-    if label_references != '':
-        description += (f"\nTo compute average MTR in a region defined by a single label file (could be binary or 0-1 "
-                        f"weighted mask) between slices 1 and 4: {os.path.basename(__file__)} -i mtr.nii.gz -f "
-                        f"my_mask.nii.gz -z 1:4 -m wa\n"
-                        f"List of labels in {file_label}:\n"
-                        f"--------------------------------------------------------------------------------------\n"
-                        f"{label_references}\n"
-                        f"--------------------------------------------------------------------------------------\n")
+                   f"To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:\n"
+                   f"{os.path.basename(__file__)} -i dti_FA.nii.gz -l 0,2,3 -v 2:7 -m bin\n"
+                   f"\n"
+                   f"To compute average MTR in a region defined by a single label file (could be binary or 0-1 "
+                   f"weighted mask) between slices 1 and 4:\n"
+                   f"{os.path.basename(__file__)} -i mtr.nii.gz -f "
+                   f"my_mask.nii.gz -z 1:4 -m wa")
 
     parser = argparse.ArgumentParser(
         description=description,

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -62,11 +62,11 @@ def get_parser():
             f"https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas\n"
             f"\n"
             f"To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:\n"
-            f"{os.path.basename(__file__)} -i dti_FA.nii.gz -l 0,2,3 -v 2:7 -m bin\n"
+            f"sct_extract_metric -i dti_FA.nii.gz -l 0,2,3 -v 2:7 -m bin\n"
             f"\n"
             f"To compute average MTR in a region defined by a single label file (could be binary or 0-1 "
             f"weighted mask) between slices 1 and 4:\n"
-            f"{os.path.basename(__file__)} -i mtr.nii.gz -f "
+            f"sct_extract_metric -i mtr.nii.gz -f "
             f"my_mask.nii.gz -z 1:4 -m wa"
         ),
         formatter_class=SmartFormatter,

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -50,25 +50,25 @@ def get_parser():
 
     param_default = Param()
 
-    description = (f"This program extracts metrics (e.g., DTI or MTR) within labels. Labels could be a single file or "
-                   f"a folder generated with 'sct_warp_template' containing multiple label files and a label "
-                   f"description file (info_label.txt). The labels should be in the same space coordinates as the "
-                   f"input image.\n"
-                   f"\n"
-                   f"The labels used by default are taken from the PAM50 template. To learn about the available PAM50 "
-                   f"white/grey matter atlas labels and their corresponding ID values, please refer to: "
-                   f"https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas \n"
-                   f"\n"
-                   f"To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:\n"
-                   f"{os.path.basename(__file__)} -i dti_FA.nii.gz -l 0,2,3 -v 2:7 -m bin\n"
-                   f"\n"
-                   f"To compute average MTR in a region defined by a single label file (could be binary or 0-1 "
-                   f"weighted mask) between slices 1 and 4:\n"
-                   f"{os.path.basename(__file__)} -i mtr.nii.gz -f "
-                   f"my_mask.nii.gz -z 1:4 -m wa")
-
     parser = argparse.ArgumentParser(
-        description=description,
+        description=(
+            f"This program extracts metrics (e.g., DTI or MTR) within labels. Labels could be a single file or "
+            f"a folder generated with 'sct_warp_template' containing multiple label files and a label "
+            f"description file (info_label.txt). The labels should be in the same space coordinates as the "
+            f"input image.\n"
+            f"\n"
+            f"The labels used by default are taken from the PAM50 template. To learn about the available PAM50 "
+            f"white/grey matter atlas labels and their corresponding ID values, please refer to: "
+            f"https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas\n"
+            f"\n"
+            f"To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:\n"
+            f"{os.path.basename(__file__)} -i dti_FA.nii.gz -l 0,2,3 -v 2:7 -m bin\n"
+            f"\n"
+            f"To compute average MTR in a region defined by a single label file (could be binary or 0-1 "
+            f"weighted mask) between slices 1 and 4:\n"
+            f"{os.path.basename(__file__)} -i mtr.nii.gz -f "
+            f"my_mask.nii.gz -z 1:4 -m wa"
+        ),
         formatter_class=SmartFormatter,
         add_help=None,
         prog=os.path.basename(__file__).strip(".py")

--- a/scripts/sct_extract_metric.py
+++ b/scripts/sct_extract_metric.py
@@ -62,12 +62,12 @@ def get_parser():
             f"https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas\n"
             f"\n"
             f"To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:\n"
-            f"sct_extract_metric -i dti_FA.nii.gz -l 0,2,3 -v 2:7 -m bin\n"
+            f"sct_extract_metric -i dti_FA.nii.gz -l 0,2,3 -vert 2:7 -method bin\n"
             f"\n"
             f"To compute average MTR in a region defined by a single label file (could be binary or 0-1 "
             f"weighted mask) between slices 1 and 4:\n"
             f"sct_extract_metric -i mtr.nii.gz -f "
-            f"my_mask.nii.gz -z 1:4 -m wa"
+            f"my_mask.nii.gz -z 1:4 -method wa"
         ),
         formatter_class=SmartFormatter,
         add_help=None,


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2934

### Description

In `sct_extract_metric`'s help description:

 * `info_label.txt` is referenced without having been downloaded. (RTD uses pip install, which doesn't call `sct_download_data` like `install_sct` does.) So, this PR references SCT's documentation instead.
* `sct_extract_metric.py` -> `sct_extract_metric`
* `-v` -> `-vert`
* `-m` -> `-method`

New output:

```
This program extracts metrics (e.g., DTI or MTR) within labels. Labels could be a single file or a folder generated with 'sct_warp_template' containing multiple label files and a label description file (info_label.txt). The labels should be in the same space coordinates as the input image.

The labels used by default are taken from the PAM50 template. To learn about the available PAM50 white/grey matter atlas labels and their corresponding ID values, please refer to: https://spinalcordtoolbox.com/en/latest/overview/concepts/pam50.html#white-and-grey-matter-atlas-pam50-atlas

To compute FA within labels 0, 2 and 3 within vertebral levels C2 to C7 using binary method:
sct_extract_metric -i dti_FA.nii.gz -l 0,2,3 -vert 2:7 -method bin

To compute average MTR in a region defined by a single label file (could be binary or 0-1 weighted mask) between slices 1 and 4:
sct_extract_metric -i mtr.nii.gz -f my_mask.nii.gz -z 1:4 -method wa
```