### PR TITLE
Logging and printing fixes

### DIFF
--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -11,7 +11,7 @@ import argparse
 
 from enum import Enum
 
-from .sys import check_exe
+from .sys import check_exe, printv
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +19,14 @@ logger = logging.getLogger(__name__)
 def display_open(file):
     """Print the syntax to open a file based on the platform."""
     if sys.platform == 'linux':
-        logger.info('Done! To view results, type:')
-        logger.info('xdg-open %s', file)
+        printv('\nDone! To view results, type:')
+        printv('xdg-open ' + file + '\n', verbose=1, type='info')
     elif sys.platform == 'darwin':
-        logger.info('Done! To view results, type:')
-        logger.info('open %s', file)
+        printv('\nDone! To view results, type:')
+        printv('open ' + file + '\n', verbose=1, type='info')
     else:
-        logger.info('Done! To view results, open the following file:')
-        logger.info('%s', file)
+        printv('\nDone! To view results, open the following file:')
+        printv(file + '\n', verbose=1, type='info')
 
 
 def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='', verbose=1):
@@ -93,8 +93,9 @@ def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='',
                     cmd += ' -a ' + str(float(opacities[i]) * 100)  # in percentage
     cmd += ' &'
 
-    logger.info('Done! To view results, type:')
-    logger.info('%s', cmd)
+    if verbose:
+        printv('\nDone! To view results, type:')
+        printv(cmd + '\n', verbose=1, type='info')
 
 
 class ActionCreateFolder(argparse.Action):

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -273,7 +273,7 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
         cmdline = list2cmdline(cmd)
 
     if verbose:
-        logger.info(f"{cmdline} # in {cwd}")
+        printv("%s # in %s" % (cmdline, cwd), 1, 'code')
 
     shell = isinstance(cmd, str)
 

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -272,7 +272,8 @@ def run_proc(cmd, verbose=1, raise_exception=True, cwd=None, env=None, is_sct_bi
     else:
         cmdline = list2cmdline(cmd)
 
-    logger.debug(f"{cmdline} # in {cwd}")
+    if verbose:
+        logger.info(f"{cmdline} # in {cwd}")
 
     shell = isinstance(cmd, str)
 


### PR DESCRIPTION
closes #3008 
-  `run_proc()` was not checking verbosity and using DEBUG (which is a bit confusing, because verbosity is set to 1 by default in many constructors which I used to think meant `LEVEL==DEBUG`, but now realize it means `LEVEL==INFO`).

- `utils.shell` can use `printv()` with color support as long as it gets called from scripts and not API.