### PR TITLE
Travis: Add 10.15 (Catalina), update 10.14 (Mojave) image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ matrix:
     - name: "OSX 10.14 (Mojave)"
       if: branch = release or type = cron
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       addons:
         homebrew:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,17 @@ matrix:
       name: "Ubuntu 16.04 (Xenial)"
       if: branch = release or type = cron
       dist: xenial
+    - name: "OSX 10.15 (Catalina)"
+      # runs on all branches
+      os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
+      osx_image: xcode12.2
+#      addons:
+#        homebrew:
+#          packages:
+#            - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.14 (Mojave)"
       if: branch = release or type = cron
-      os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
+      os: osx
       osx_image: xcode11.2
       addons:
         homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,10 +103,10 @@ matrix:
       # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode12.2
-#      addons:
-#        homebrew:
-#          packages:
-#            - libomp  # Needed for onnxruntime Python package, see issue #2930
+      addons:
+        homebrew:
+          packages:
+            - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.14 (Mojave)"
       if: branch = release or type = cron
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
       if: branch = release or type = cron
       dist: xenial
     - name: "OSX 10.14 (Mojave)"
-      # runs on all branches
+      if: branch = release or type = cron
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode11.2
       addons:


### PR DESCRIPTION
### Related issues/PRs

Fixes #2692.

### Description

* Adds 10.15 job to all builds.
* Moves 10.14 job to just release/cron.
* Updates 10.14 image from [`xcode11.2` to `xcode11.3`](https://docs.travis-ci.com/user/reference/osx/)