### PR TITLE
Display command when scripts are called from the command-line

### DIFF
--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -80,6 +80,14 @@ def init_sct(log_level=1, update=False):
         # Display SCT version
         logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
 
+        # Display command (Only if called from CLI: check for .py in first arg)
+        # Use next(iter()) to not fail on empty list (vs. sys.argv[0])
+        if '.py' in next(iter(sys.argv), None):
+            script = os.path.basename(sys.argv[0]).strip(".py")
+            arguments = ' '.join(sys.argv[1:])
+            logger.info(f"Command run: {script} {arguments}\n"
+                        f"--\n")
+
 
 def add_elapsed_time_counter():
     class Timer():

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -85,7 +85,7 @@ def init_sct(log_level=1, update=False):
         if '.py' in next(iter(sys.argv), None):
             script = os.path.basename(sys.argv[0]).strip(".py")
             arguments = ' '.join(sys.argv[1:])
-            logger.info(f"Command run: {script} {arguments}\n"
+            logger.info(f"{script} {arguments}\n"
                         f"--\n")
 
 


### PR DESCRIPTION
### Related issues/PRs

Fixes #2388.

### Description

This PR causes the command to be output when scripts are called from the command line. It does not add this output when scripts are called internally using `<sct_script>.main()`.

#### Sample output (`sct_create_mask -i mt/mt1.nii.gz -p coord,15x17 -size 10 -r 0`)

Before 

```sh
--
Spinal Cord Toolbox (git-master-c29d6c332662ae8fad0954f70991f35078d5c399)

Creating temporary folder (/tmp/sct-20201108124345.693440-create_mask-gcnlyd6q)

# Rest of program output goes here

Process finished with exit code 0
```

After

```sh
--
Spinal Cord Toolbox (git-jn/2388-display-script-command-245baf340bb9d07ade29aa2f708cbedeb0b06502)

Command run: sct_create_mask -i mt/mt1.nii.gz -p coord,15x17 -size 10 -r 0
--

Creating temporary folder (/tmp/sct-20201108124257.376323-create_mask-radd3pxn)

# Rest of program output goes here

Process finished with exit code 0
```