### PR TITLE
sct_label_utils.py: Clarify -create-seg usage description

### DIFF
--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -96,11 +96,11 @@ def get_parser():
         metavar=Metavar.list,
         type=list_type(':', list_type(',', int)),
         help="R|Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
-             "specified using the form 'v1,v2' where 'v1' is value of the slice index along the superior-inferior "
+             "specified using the form 'v1,v2' where 'v1' is value of the slice index along the inferior-superior "
              "axis, and 'v2' is the value of the label. Separate each label with ':'. \n"
-             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at S-I slice indices 5, 14, and 23.\n"
-             "You can also choose a S-I axis value of '-1' to automatically select the mid-point in the "
-             "superior-inferior direction. For example, if you know that the C2-C3 disc is centered in the S-I "
+             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at I-S slice indices 5, 14, and 23.\n"
+             "You can also choose a I-S axis value of '-1' to automatically select the mid-point in the "
+             "inferior-superior direction. For example, if you know that the C2-C3 disc is centered in the I-S "
              "direction, then you can enter '-1,3' for that label instead."
     )
     func_group.add_argument(

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -98,8 +98,8 @@ def get_parser():
         help="R|Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
              "specified using the form 'v1,v2' where 'v1' is value of the slice index along the inferior-superior "
              "axis, and 'v2' is the value of the label. Separate each label with ':'. \n"
-             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at I-S slice indices 5, 14, and 23.\n"
-             "You can also choose a I-S axis value of '-1' to automatically select the mid-point in the "
+             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at the axial slices 5, 14, and 23 (starting from the most inferior slice)Z.\n"
+             "You can also choose a slice value of '-1' to automatically select the mid-point in the "
              "inferior-superior direction. For example, if you know that the C2-C3 disc is centered in the I-S "
              "direction, then you can enter '-1,3' for that label instead."
     )

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -95,10 +95,13 @@ def get_parser():
         '-create-seg',
         metavar=Metavar.list,
         type=list_type(':', list_type(',', int)),
-        help="R|Create labels along cord segmentation (or centerline) defined by '-i'. First value is 'z', second is "
-             "the value of the label. Separate labels with ':'. Example: 5,1:14,2:23,3. \n"
-             "To select the mid-point in the superior-inferior direction, set z to '-1'. For example if you know that "
-             "C2-C3 disc is centered in the S-I direction, then enter: -1,3"
+        help="R|Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
+             "specified using the form 'v1,v2' where 'v1' is value of the slice index along the superior-inferior "
+             "axis, and 'v2' is the value of the label. Separate each label with ':'. \n"
+             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at S-I slice indices 5, 14, and 23.\n"
+             "You can also choose a S-I axis value of '-1' to automatically select the mid-point in the "
+             "superior-inferior direction. For example, if you know that the C2-C3 disc is centered in the S-I "
+             "direction, then you can enter '-1,3' for that label instead."
     )
     func_group.add_argument(
         '-create-viewer',

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -98,7 +98,7 @@ def get_parser():
         help="R|Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
              "specified using the form 'v1,v2' where 'v1' is value of the slice index along the inferior-superior "
              "axis, and 'v2' is the value of the label. Separate each label with ':'. \n"
-             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at the axial slices 5, 14, and 23 (starting from the most inferior slice)Z.\n"
+             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at the axial slices 5, 14, and 23 (starting from the most inferior slice).\n"
              "You can also choose a slice value of '-1' to automatically select the mid-point in the "
              "inferior-superior direction. For example, if you know that the C2-C3 disc is centered in the I-S "
              "direction, then you can enter '-1,3' for that label instead."


### PR DESCRIPTION
### Related Issues/PRs

Fixes #2424.

### Description

* Remove reference to 'z axis' in order to make it explicitly clear that the user is specifying slice indexes along the S-I axis.
* Clarify wording regarding the form of the  ':'/',' delimiting.
* Clarify wording in examples.

Old wording:

```
Create labels along cord segmentation (or centerline) defined by '-i'.
First value is 'z', second is the value of the label. Separate labels
with ':'. Example: 5,1:14,2:23,3.
To select the mid-point in the superior-inferior direction, set z to
'-1'. For example if you know that C2-C3 disc is centered in the S-I
direction, then enter: -1,3
```

New wording:

```
Create labels on a cord segmentation (or centerline) image defined by
'-i'. Each label should be specified using the form 'v1,v2' where 'v1' is
value of the slice index along the superior-inferior axis, and 'v2' is the
value of the label. Separate each label with ':'.
Example: '-create-seg 5,1:14,2:23,3' adds three labels at S-I slice
indices 5, 14, and 23.
You can also choose a S-I axis value of '-1' to automatically select the
mid-point in the superior-inferior direction. For example, if you know
that the C2-C3 disc is centered in the S-I direction, then you can enter
'-1,3' for that label instead.
```