### PR TITLE
sct_label_utils.py: Add message for generated files

### DIFF
--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -19,7 +19,6 @@
 import os
 import sys
 import argparse
-import logging
 from typing import Sequence
 
 import numpy as np
@@ -30,8 +29,6 @@ from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv
 from spinalcordtoolbox.utils.shell import display_viewer_syntax
-
-logger = logging.getLogger(__name__)
 
 
 def get_parser():
@@ -297,7 +294,7 @@ def main(args=None):
         else:
             out = launch_sagittal_viewer(img, arguments.create_viewer, msg)
 
-    logger.info("Generating output files...")
+    printv("Generating output files...")
     out.save(path=output_fname, dtype=dtype)
     display_viewer_syntax([input_filename, output_fname])
 

--- a/scripts/sct_label_utils.py
+++ b/scripts/sct_label_utils.py
@@ -29,6 +29,7 @@ from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv
+from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +297,9 @@ def main(args=None):
         else:
             out = launch_sagittal_viewer(img, arguments.create_viewer, msg)
 
+    logger.info("Generating output files...")
     out.save(path=output_fname, dtype=dtype)
+    display_viewer_syntax([input_filename, output_fname])
 
     if arguments.qc is not None:
         generate_qc(fname_in1=input_filename, fname_seg=output_fname, args=args,


### PR DESCRIPTION
### Related issues/PRs

Fixes #3024.

### Description

Note that this will apply to all functions in `sct_label_utils` and not just `-create-seg`, which was mentioned in the original issue.

Example output:

```
--
Spinal Cord Toolbox (git-jn/3024-label-utils-message-54bc53942ef9ae5c521399d24c416e359e6432d9)

sct_label_utils -i T1_seg.nii.gz -create-seg 0,14:106,8
--

Generating output files...

Done! To view results, type:
fsleyes T1_seg.nii.gz labels.nii.gz &
```

I've used both the input and output images so that users can toggle on and off and view differences/overlays.