### PR TITLE
sct_run_batch: handle the case of unexecutable script

### DIFF
--- a/scripts/sct_run_batch.py
+++ b/scripts/sct_run_batch.py
@@ -38,6 +38,7 @@ from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
 from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__
 from spinalcordtoolbox.utils.fs import Tee
 
+from stat import S_IEXEC
 
 def get_parser():
     parser = argparse.ArgumentParser(
@@ -351,14 +352,20 @@ def main(argv):
     print("git origin: {}".format(__get_git_origin(path_to_git_folder=os.path.dirname(script))))
     print("Copying script to output folder...")
     try:
-        shutil.copy(args.script, args.path_output)
-        print("{} -> {}".format(args.script, os.path.abspath(args.path_output)))
+        # Copy the script and record the new location
+        script_copy = os.path.abspath(shutil.copy(script, args.path_output))
+        print("{} -> {}".format(script, script_copy))
+        script = script_copy
     except shutil.SameFileError:
         print("Input and output folder are the same. Skipping copy.")
         pass
     except IsADirectoryError:
         print("Input folder is a directory (not a file). Skipping copy.")
         pass
+
+    print("Setting execute permissions for script file {} ...".format(args.script))
+    script_stat = os.stat(script)
+    os.chmod(script, script_stat.st_mode | S_IEXEC)
 
     # Display data version info
     print("\nDATA")

--- a/unit_testing/test_sct_run_batch.py
+++ b/unit_testing/test_sct_run_batch.py
@@ -5,6 +5,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from textwrap import dedent
 
 from spinalcordtoolbox import __sct_dir__
+from spinalcordtoolbox.utils.sys import sct_test_path
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
 
 import sct_run_batch
@@ -58,3 +59,25 @@ def test_only_one_include():
             sct_run_batch.main(['-include', 'arg', '-include-list',
                                 'arg2', '-path-data', data, '-path-out', out
                                 , '-script', out])
+
+def test_non_executable_task():
+    data_path = sct_test_path()
+    with \
+        NamedTemporaryFile('w', suffix='.sh') as script,\
+            TemporaryDirectory() as out:
+
+        script_text = """
+        #!/bin/bash
+        echo $SUBJECT
+        """
+        script.write(dedent(script_text)[1:]) #indexing removes beginning newline
+        script.flush()
+
+        assert not os.access(script.name, os.X_OK), "Script already executable"
+
+        sct_run_batch.main(['-include', '^t.*',
+                            '-subject-prefix', '',
+                            '-path-data', data_path, '-path-out', out,
+                            '-script', script.name,
+                            '-continue-on-error', 0])
+


### PR DESCRIPTION
Either sets the script itself to executable if the output directory is the current working directory, or sets the output directory copy to executable and uses that.

This should resolve #3030.

Potential improvement:
Right now, `sct_run_batch` copies the user's script to the output directory, in the event the current working directory is the output directory there is no copy made. In this case I opted to modify the original script, which is perhaps distasteful, but I feel it is relatively harmless. If others disagree, we could make a copy with a suffix and modify the permissions on that.


