### PR TITLE
Add slightly modified PR template from shimming-toolbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@
 
 - [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
 - [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
-- [ ] I've updated the documentation and/or added correct docstrings
+- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages
 
 ## Description
 <!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - [ ] I've given this PR a concise, self-descriptive, and meaningful title
 - [ ] I've linked relevant issues in the PR body
-- [ ] I've applied the relevant labels to this PR
+- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
 - [ ] I've assigned a reviewer
 
 <!--- For the title, please observe the following rules:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
+-->
+
 ## Checklist
 
 #### GitHub
@@ -7,7 +10,7 @@
 - [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
 - [ ] I've assigned a reviewer
 
-<!--- For the title, please observe the following rules:
+<!-- For the title, please observe the following rules:
 	- Provide a concise and self-descriptive title
 	- Do not include the applicable issue number in the title, do it in the PR body
 	- If the PR is not ready for review, convert it to a draft.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@
 - [ ] I've added relevant tests for my contribution
 - [ ] I've updated the documentation and/or added correct docstrings
 - [ ] I've assigned a reviewer
+- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
 
 <!--- For the title, please observe the following rules:
 	- Provide a concise and self-descriptive title

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@
 #### PR contents
 
 - [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
-- [ ] I've added relevant tests for my contribution
+- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
 - [ ] I've updated the documentation and/or added correct docstrings
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,20 @@
-Hi, thank you for submitting a Pull Request, please take some time to consider the guidelines:
-https://github.com/neuropoly/spinalcordtoolbox/blob/master/CONTRIBUTING.rst#when-submitting-your-pull-request
-prior to documenting/reviewing the PR and deleting this blurb when about to submit the PR.
+## Checklist
+
+- [ ] I've given this PR a concise, self-descriptive, and meaningful title
+- [ ] I've linked relevant issues in the PR body
+- [ ] I've applied the relevant labels to this PR
+- [ ] I've added relevant tests for my contribution
+- [ ] I've updated the documentation and/or added correct docstrings
+- [ ] I've assigned a reviewer
+
+<!--- For the title, please observe the following rules:
+	- Provide a concise and self-descriptive title
+	- Do not include the applicable issue number in the title, do it in the PR body
+	- If the PR is not ready for review, convert it to a draft.
+-->
+
+## Description
+<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
+
+## Linked issues
+<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,23 @@
 ## Checklist
 
+#### GitHub
+
 - [ ] I've given this PR a concise, self-descriptive, and meaningful title
 - [ ] I've linked relevant issues in the PR body
 - [ ] I've applied the relevant labels to this PR
-- [ ] I've added relevant tests for my contribution
-- [ ] I've updated the documentation and/or added correct docstrings
 - [ ] I've assigned a reviewer
-- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
 
 <!--- For the title, please observe the following rules:
 	- Provide a concise and self-descriptive title
 	- Do not include the applicable issue number in the title, do it in the PR body
 	- If the PR is not ready for review, convert it to a draft.
 -->
+
+#### PR contents
+
+- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
+- [ ] I've added relevant tests for my contribution
+- [ ] I've updated the documentation and/or added correct docstrings
 
 ## Description
 <!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->


### PR DESCRIPTION
### Related Issues/PRs

Fixes #3027.

### Description

~~Mirror of [`shimming-toolbox/pull_request_template.md`](https://github.com/shimming-toolbox/shimming-toolbox/blob/master/.github/pull_request_template.md).~~

Some changes have been made, mainly:
* Adding additional checklist items to ensure internal documentation is followed.
* Adding links to relevant internal documentation pages.
* Grouping checklist items by type.