### PR TITLE
Bump ivadomed version to 2.5.0

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -537,6 +537,10 @@ else
   # Not a package
   print info "Using requirements.txt (git installation)"
   pip install -r requirements.txt
+  yes | pip uninstall tensorflow-tensorboard
+  yes | pip uninstall tensorboard
+  pip install tensorboard
+
 fi
 if [[ $? != 0 ]]; then
   die "Failed running pip install: $?"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ scipy
 scikit-image
 scikit-learn
 tensorflow==1.5.0
-tensorboard==2.3.0
 # PyTorch's Linux/Windows distribution is very large due to its GPU support,
 # but we only need that for training models. For users, use the CPU-only version
 # (only available directly from the PyTorch project).
@@ -37,3 +36,4 @@ transforms3d
 urllib3[secure]
 pytest_console_scripts
 pytest-xdist
+tensorboard==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ futures
 # h5py is pinned to minor than 3 due to issues with Keras/TF
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
-ivadomed==2.4.0
+ivadomed==2.5.0
 Keras==2.1.5
 matplotlib
 nibabel

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ futures
 # h5py is pinned to minor than 3 due to issues with Keras/TF
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
-ivadomed==2.5.0
 Keras==2.1.5
+ivadomed==2.5.0
 matplotlib
 nibabel
 numpy
@@ -21,6 +21,7 @@ scipy
 scikit-image
 scikit-learn
 tensorflow==1.5.0
+tensorboard==2.3.0
 # PyTorch's Linux/Windows distribution is very large due to its GPU support,
 # but we only need that for training models. For users, use the CPU-only version
 # (only available directly from the PyTorch project).

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,3 @@ transforms3d
 urllib3[secure]
 pytest_console_scripts
 pytest-xdist
-tensorboard==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
 Keras==2.1.5
-ivadomed==2.5.0
+ivadomed==2.6.0
 matplotlib
 nibabel
 numpy

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -15,7 +15,7 @@ import argparse
 import os
 import sys
 
-import ivadomed as imed
+from ivadomed import inference as imed_inference
 import nibabel as nib
 
 import spinalcordtoolbox as sct
@@ -145,7 +145,7 @@ def main(argv):
 
         # Call segment_nifti
         options = {**vars(args), "fname_prior": fname_prior}
-        nii_seg = imed.inference.segment_volume(path_model, args.i, options=options)
+        nii_seg = imed_inference.segment_volume(path_model, args.i, options=options)
 
         # Save output seg
         if 'o' in options and options['o'] is not None:

--- a/scripts/sct_deepseg.py
+++ b/scripts/sct_deepseg.py
@@ -145,7 +145,7 @@ def main(argv):
 
         # Call segment_nifti
         options = {**vars(args), "fname_prior": fname_prior}
-        nii_seg = imed.utils.segment_volume(path_model, args.i, options=options)
+        nii_seg = imed.inference.segment_volume(path_model, args.i, options=options)
 
         # Save output seg
         if 'o' in options and options['o'] is not None:


### PR DESCRIPTION
This PR aims at bumping ivadomed version to 2.5.0. 
This should fix this [reported issue](https://forum.spinalcordmri.org/t/installation-validation-failed-installation-failed/570) by pinning `onnxruntime` to version 1.4.0 
Changes made: 
* update requirements.txt
* Change function call in `scripts/sct_deepseg.py`

fix #3033 