### PR TITLE
Pin onnxruntime==1.4.0 to avoid libomp issue on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,27 +103,14 @@ matrix:
       # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode12.2
-      addons:
-        homebrew:
-          packages:
-            - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.14 (Mojave)"
       if: branch = release or type = cron
       os: osx
       osx_image: xcode11.3
-      addons:
-        homebrew:
-          packages:
-            - libomp  # Needed for onnxruntime Python package, see issue #2930
     - name: "OSX 10.13 (High Sierra)"
       if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
-      addons:
-        homebrew:
-          packages:
-            - libomp  # Needed for onnxruntime Python package, see issue #2930
-          update: true  # Fixes issue w/outdated Homebrew in older MacOS images
     - name: "Windows Server, 1809"
       # runs on all branches
       language: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,10 @@ Keras==2.1.5
 matplotlib
 nibabel
 numpy
+# onnxruntime>=1.5.1 requires `brew install libomp` on macOS.
+# So, pin to 1.4.0 to avoid having to ask users to install libomp.
+# ivadomed==2.5.0 would also do this, but #3035 is preventing that.
+onnxruntime==1.4.0
 pandas
 psutil
 pyqt5==5.11.3


### PR DESCRIPTION
### Related Issues/PRs

Fixes #3033.
Alternate solution compared to #3034.

### Description

I believe #3034 is the better long-term solution. But, that PR is blocked by #3035. 

Because of the urgent need for a patch, this PR applies a quicker solution that is easier to test/verify. 