### PR TITLE
Add missing type information to argument in sct_process_segmentation

### DIFF
--- a/scripts/sct_process_segmentation.py
+++ b/scripts/sct_process_segmentation.py
@@ -84,6 +84,8 @@ def get_parser():
     )
     optional.add_argument(
         '-append',
+        metavar=Metavar.int,
+        type=int,
         choices=[0, 1],
         default=0,
         help="Append results as a new line in the output csv file instead of overwriting it."


### PR DESCRIPTION
### Relates Issues/PRs

Fixes #3038 

### Description

Fixes bug where an int arg value (e.g. 1) is parsed a str ('1').