### PR TITLE
Add script to automate requirements-freeze.txt generation

### DIFF
--- a/install/generate-requirements-freeze.sh
+++ b/install/generate-requirements-freeze.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# generate-requirements-freeze.sh: Automate steps for generating
+# requirements-freeze.txt for a release
+
+# Generate initial requirements-freeze.txt file
+source "$SCT_DIR"/python/etc/profile.d/conda.sh
+conda activate venv_sct
+pip freeze |
+  # Exclude SCT itself (not needed in requirements.txt)
+  grep -v "-e git+https://github.com/neuropoly/spinalcordtoolbox.git" |
+  # Exclude torch-related lines (these will be re-added from requirements.txt)
+  grep -v "torch" > "$SCT_DIR"/requirements-freeze.txt
+conda deactivate
+
+# Copy over torch-related lines
+echo "# Platform-specific torch requirements (See SCT Issue #2745)" \
+  >> "$SCT_DIR"/requirements-freeze.txt
+grep "torch" "$SCT_DIR"/requirements.txt >> "$SCT_DIR"/requirements-freeze.txt
+


### PR DESCRIPTION
### Related Issues/PRs

Fixes #3040 
Successor to #2745

### Description

A quick little script to automate the following steps from the [Creating a new release](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release) dev Wiki page:

> - Freeze the requirements:
>     ~~~
>     source ${SCT_DIR}/python/etc/profile.d/conda.sh
>     conda activate venv_sct
>     pip freeze > requirements-freeze.txt
>     conda deactivate
>     ~~~
> - Edit the generated `requirements-freeze.txt` file:
>   - Remove the line that says: `-e git+https://github.com/neuropoly/spinalcordtoolbox.git@...`
>   - Manually-copy the platform-dependent lines (related to Pytorch) from `requirements.txt` to `requirements-freeze.txt`, to avoid [this issue](https://github.com/neuropoly/spinalcordtoolbox/issues/2745). Example of lines:
>     ~~~
>     -f https://download.pytorch.org/whl/cpu/torch_stable.html
>     torch==1.5.0+cpu; sys_platform != "darwin"
>     torch==1.5.0; sys_platform == "darwin"
>     torchvision==0.6.0+cpu; sys_platform != "darwin"
>     torchvision==0.6.0; sys_platform == "darwin"
>     ~~~