### PR TITLE
Fix version parsing to support Big Sur (11.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,10 @@ matrix:
       if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
+    # Enable just to check that install dies midway"
+    - name: "OSX 10.12 (Sierra)"
+      os: osx
+      osx_image: xcode9.2
     - name: "Windows Server, 1809"
       # runs on all branches
       language: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,10 +111,6 @@ matrix:
       if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
-    # Enable just to check that install dies midway"
-    - name: "OSX 10.12 (Sierra)"
-      os: osx
-      osx_image: xcode9.2
     - name: "Windows Server, 1809"
       # runs on all branches
       language: bash

--- a/install_sct
+++ b/install_sct
@@ -32,7 +32,7 @@ DATA_DIR="data"
 PYTHON_DIR="python"
 BIN_DIR="bin"
 # Misc
-OSXVERSUPPORTED=12  # minimum version of OSX supported
+OSXVERSUPPORTED=13  # minimum version of OSX supported
 
 
 # ======================================================================================================================

--- a/install_sct
+++ b/install_sct
@@ -121,9 +121,9 @@ function fetch_os_type() {
   OSver="unknown"  # default value
   uname_output=`uname -a`
   echo $uname_output
-  # OSX
+  # macOS
   if echo $uname_output | grep -i darwin >/dev/null 2>&1; then
-    # Fetch OSX version
+    # Fetch macOS version
     sw_vers_output=`sw_vers | grep -e ProductVersion`
     echo "$sw_vers_output"
     OSver=$(echo $sw_vers_output | cut -c 17-)
@@ -149,7 +149,7 @@ function fetch_os_type() {
   elif echo $uname_output | grep -i linux >/dev/null 2>&1; then
     OS=linux
   else
-    die "Sorry, the installer only supports Linux and OSX, quitting installer"
+    die "Sorry, the installer only supports Linux and macOS, quitting installer"
   fi
 }
 

--- a/install_sct
+++ b/install_sct
@@ -131,8 +131,7 @@ function fetch_os_type() {
     macOSminor=$(echo $OSver | cut -f 2 -d '.')
     # Make sure OSver is supported
     if [[ "${macOSmajor}" = 10 ]] && [[ "${macOSminor}" < "${MACOSSUPPORTED}" ]]; then
-      die "Sorry, this version of macOS (10.$macOSminor) is not supported.
-           The minimum version is 10.$MACOSMINORSUPPORTED."
+      die "Sorry, this version of macOS (10.$macOSminor) is not supported. The minimum version is 10.$MACOSSUPPORTED."
     fi
     # Fix for non-English Unicode systems on MAC
     if [[ -z $LC_ALL ]]; then

--- a/install_sct
+++ b/install_sct
@@ -31,8 +31,7 @@ SCRIPT_DIR="scripts"
 DATA_DIR="data"
 PYTHON_DIR="python"
 BIN_DIR="bin"
-# Misc
-OSXVERSUPPORTED=13  # minimum version of OSX supported
+MACOSSUPPORTED=13  # Minimum version of macOS 10 supported
 
 
 # ======================================================================================================================
@@ -127,10 +126,13 @@ function fetch_os_type() {
     # Fetch OSX version
     sw_vers_output=`sw_vers | grep -e ProductVersion`
     echo "$sw_vers_output"
-    OSver=`echo $sw_vers_output | cut -c 20- | cut -c -2`
-    # Make sure OSver us supported
-    if (("$OSver" < "$OSXVERSUPPORTED")); then
-      die "Sorry, this version of OSX (10.$OSver) is no more supported. The minimum version is 10.$OSXVERSUPPORTED".
+    OSver=$(echo $sw_vers_output | cut -c 17-)
+    macOSmajor=$(echo $OSver | cut -f 1 -d '.')
+    macOSminor=$(echo $OSver | cut -f 2 -d '.')
+    # Make sure OSver is supported
+    if [[ "${macOSmajor}" = 10 ]] && [[ "${macOSminor}" < "${MACOSSUPPORTED}" ]]; then
+      die "Sorry, this version of macOS (10.$macOSminor) is not supported.
+           The minimum version is 10.$MACOSMINORSUPPORTED."
     fi
     # Fix for non-English Unicode systems on MAC
     if [[ -z $LC_ALL ]]; then


### PR DESCRIPTION
### Related Issues/PRs

Fixes #3048.
Partially addresses #2820.

### Description

This PR uses `'.'` delimiting rather than relying on character counts to fix version parsing issue in `install_sct`. 

This PR includes 2 smaller changes that overlap with the above change: 
* It updates the minimum supported OSX version, as that was not done in #2946 when it should have been.
* It updates instances of "OSX" to the more accurate term "macOS" within `install_sct`.