### PR TITLE
Update -create-viewer argument to use parse_num_list function

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -104,8 +104,9 @@ def get_parser():
     func_group.add_argument(
         '-create-viewer',
         metavar=Metavar.list,
-        help="Manually label from a GUI a list of labels IDs, either created from an interval "
-             "(Example 2:5 which is equivalent to 2,3,4,5) or separated with ',' (Example: 2,3,4,5)"
+        help="Manually label from a GUI a list of labels IDs. Provide a comma-separated list"
+             "containing individual values and/or intervals. Example: '-create-viewer 1:4,6,8'
+             "will allow you to add labels [1,2,3,4,6,8] using the GUI."
     )
 
     func_group.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -27,7 +27,7 @@ import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv,parse_num_list
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv, parse_num_list
 from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -27,7 +27,7 @@ import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv,parse_num_list
 from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 
@@ -104,7 +104,6 @@ def get_parser():
     func_group.add_argument(
         '-create-viewer',
         metavar=Metavar.list,
-        type=list_type(',', int),
         help="Manually label from a GUI a list of labels IDs, separated with ','. Example: 2,3,4,5"
     )
 
@@ -293,9 +292,9 @@ def main(args=None):
         msg = "" if arguments.msg is None else f"{arguments.msg}\n"
         if arguments.ilabel is not None:
             input_labels_img = Image(arguments.ilabel)
-            out = launch_manual_label_gui(img, input_labels_img, arguments.create_viewer, msg)
+            out = launch_manual_label_gui(img, input_labels_img, parse_num_list(arguments.create_viewer), msg)
         else:
-            out = launch_sagittal_viewer(img, arguments.create_viewer, msg)
+            out = launch_sagittal_viewer(img, parse_num_list(arguments.create_viewer), msg)
 
     printv("Generating output files...")
     out.save(path=output_fname, dtype=dtype)

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -104,8 +104,8 @@ def get_parser():
     func_group.add_argument(
         '-create-viewer',
         metavar=Metavar.list,
-        help="Manually label from a GUI a list of labels IDs. List of lables car either be a slice (e.g, 2:5)"
-             "or separated by ',' (e.g, 2,3,4,5)"
+        help="Manually label from a GUI a list of labels IDs, either created from an interval "
+             "(Example 2:5 which is equivalent to 2,3,4,5) or separated with ',' (Example: 2,3,4,5)"
     )
 
     func_group.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -104,7 +104,8 @@ def get_parser():
     func_group.add_argument(
         '-create-viewer',
         metavar=Metavar.list,
-        help="Manually label from a GUI a list of labels IDs, separated with ','. Example: 2,3,4,5"
+        help="Manually label from a GUI a list of labels IDs. List of lables car either be a slice (e.g, 2:5)"
+             "or separated by ',' (e.g, 2,3,4,5)"
     )
 
     func_group.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -104,7 +104,7 @@ def get_parser():
     func_group.add_argument(
         '-create-viewer',
         metavar=Metavar.list,
-        help="Manually label from a GUI a list of labels IDs. Provide a comma-separated list"
+        help="Manually label from a GUI a list of labels IDs. Provide a comma-separated list "
              "containing individual values and/or intervals. Example: '-create-viewer 1:4,6,8' "
              "will allow you to add labels [1,2,3,4,6,8] using the GUI."
     )

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -105,7 +105,7 @@ def get_parser():
         '-create-viewer',
         metavar=Metavar.list,
         help="Manually label from a GUI a list of labels IDs. Provide a comma-separated list"
-             "containing individual values and/or intervals. Example: '-create-viewer 1:4,6,8'
+             "containing individual values and/or intervals. Example: '-create-viewer 1:4,6,8' "
              "will allow you to add labels [1,2,3,4,6,8] using the GUI."
     )
 


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR aims at enabling the use of ':' ( e.g., 2:5 for 2,3,4,5) for the `-create-viewer` option in `sct_label_utils`. This is using the [`parse_num_list`](https://github.com/neuropoly/spinalcordtoolbox/blob/cab82fd13425515a8568225dbe7fc003d9be2b1f/spinalcordtoolbox/utils.py#L357-L370) function. 

## Linked issues
Fix #1476 
