### PR TITLE
Implement -o flag for a few functions

### DIFF
--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -96,7 +96,7 @@ def get_parser():
         default=os.getcwd())
     optional.add_argument(
         "-o",
-        metavar=Metavar.str,
+        metavar=Metavar.file,
         help='Output filename. Example: spinal_seg.nii.gz '),
     optional.add_argument(
         "-r",

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -95,6 +95,10 @@ def get_parser():
         action=ActionCreateFolder,
         default=os.getcwd())
     optional.add_argument(
+        "-o",
+        metavar=Metavar.str,
+        help='Output filename. Example: spinal_seg.nii.gz '),
+    optional.add_argument(
         "-r",
         type=int,
         help="Remove temporary files.",
@@ -165,6 +169,11 @@ def main():
     else:
         manual_centerline_fname = None
 
+    if args.o is not None:
+        fname_out = args.o
+    else:
+        fname_out = extract_fname(fname_image)[1] + '_seg' + extract_fname(fname_image)[2]
+
     threshold = args.thr
     if threshold is not None:
         if threshold > 1.0 or (threshold < 0.0 and threshold != -1.0):
@@ -192,8 +201,7 @@ def main():
                                      threshold_seg=threshold, remove_temp_files=remove_temp_files, verbose=verbose)
 
     # Save segmentation
-    fname_seg = os.path.abspath(os.path.join(output_folder, extract_fname(fname_image)[1] + '_seg' +
-                                             extract_fname(fname_image)[2]))
+    fname_seg = os.path.abspath(os.path.join(output_folder, fname_out))
     im_seg.save(fname_seg)
 
     # Generate QC report

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -172,7 +172,8 @@ def main():
     if args.o is not None:
         fname_out = args.o
     else:
-        fname_out = extract_fname(fname_image)[1] + '_seg' + extract_fname(fname_image)[2]
+        path, file_name, ext = extract_fname(fname_image)
+        fname_out = file_name + '_seg' + ext
 
     threshold = args.thr
     if threshold is not None:

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -89,11 +89,11 @@ def get_parser():
         action=ActionCreateFolder,
         default=os.getcwd())
     optional.add_argument(
-        "-o",
+        '-o',
         metavar=Metavar.file,
         help='Output filename. Example: spinal_seg.nii.gz '),
     optional.add_argument(
-        "-r",
+        '-r',
         type=int,
         help="Remove temporary files.",
         choices=(0, 1),

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -75,7 +75,7 @@ def get_parser():
     optional.add_argument(
         "-o",
         metavar=Metavar.file,
-        help='Output filename. Example: spinal_seg.nii.gz '),
+        help='Output filename. Example: pmj.nii.gz '),
     optional.add_argument(
         '-qc',
         metavar=Metavar.str,

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -73,6 +73,10 @@ def get_parser():
         action=ActionCreateFolder,
         required=False)
     optional.add_argument(
+        "-o",
+        metavar=Metavar.file,
+        help='Output filename. Example: spinal_seg.nii.gz '),
+    optional.add_argument(
         '-qc',
         metavar=Metavar.str,
         help='The path where the quality control generated content will be saved.',
@@ -101,7 +105,7 @@ def get_parser():
 
 
 class DetectPMJ:
-    def __init__(self, fname_im, contrast, fname_seg, path_out, verbose):
+    def __init__(self, fname_im, contrast, fname_seg, path_out, verbose, fname_out):
 
         self.fname_im = fname_im
         self.contrast = contrast
@@ -124,7 +128,7 @@ class DetectPMJ:
 
         self.threshold = -0.75 if self.contrast == 't1' else 0.8  # detection map threshold, depends on the contrast
 
-        self.fname_out = extract_fname(self.fname_im)[1] + '_pmj.nii.gz'
+        self.fname_out = fname_out
 
         self.fname_qc = 'qc_pmj.png'
 
@@ -283,6 +287,10 @@ def main():
             os.makedirs(path_results)
     else:
         path_results = '.'
+    if arguments.o is not None:
+        fname_o = arguments.o
+    else:
+        fname_o = extract_fname(fname_in)[1] + '_pmj.nii.gz'
 
     path_qc = arguments.qc
 
@@ -297,7 +305,8 @@ def main():
                          contrast=contrast,
                          fname_seg=fname_seg,
                          path_out=path_results,
-                         verbose=verbose)
+                         verbose=verbose,
+                         fname_out=fname_o)
 
     # run the extraction
     fname_out, tmp_dir = detector.apply()

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -68,7 +68,7 @@ def get_parser():
         action=ActionCreateFolder,
         required=False)
     optional.add_argument(
-        "-o",
+        '-o',
         metavar=Metavar.file,
         help='Output filename. Example: pmj.nii.gz '),
     optional.add_argument(
@@ -322,4 +322,3 @@ def main(argv=None):
 if __name__ == "__main__":
     init_sct()
     main(sys.argv[1:])
-

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -211,6 +211,10 @@ def get_parser():
         help="Output folder."
     )
     optional.add_argument(
+        "-o",
+        metavar=Metavar.file,
+        help='Output filename. Example: spinal_seg.nii.gz '),
+    optional.add_argument(
         '-down',
         metavar=Metavar.int,
         type=int,
@@ -447,6 +451,11 @@ def propseg(img_input, options_dict):
     if not os.path.exists(folder_output):
         os.makedirs(folder_output)
 
+    if arguments.o is not None:
+        fname_out = arguments.o
+    else:
+        fname_out = os.path.basename(add_suffix(fname_data, "_seg"))
+
     if arguments.down is not None:
         cmd += ["-down", str(arguments.down)]
     if arguments.up is not None:
@@ -620,7 +629,7 @@ def propseg(img_input, options_dict):
         sys.exit(1)
 
     # build output filename
-    fname_seg = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_seg")))
+    fname_seg = os.path.join(folder_output,fname_out)
     fname_centerline = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_centerline")))
     # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
     if rescale_header is not 1:

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -214,6 +214,7 @@ def get_parser():
         "-o",
         metavar=Metavar.file,
         help='Output filename. Example: spinal_seg.nii.gz '),
+
     optional.add_argument(
         '-down',
         metavar=Metavar.int,

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -434,18 +434,18 @@ def propseg(img_input, options_dict):
 
     # Starting building the command
     cmd = ['isct_propseg', '-t', contrast_type_propseg]
-    
-    folder_output = './'
-    cmd += ['-o', folder_output]
-    if not os.path.isdir(folder_output) and os.path.exists(folder_output):
-        logger.error("output directory %s is not a valid directory" % folder_output)
-    if not os.path.exists(folder_output):
-        os.makedirs(folder_output)
 
     if arguments.o is not None:
         fname_out = arguments.o
     else:
         fname_out = os.path.basename(add_suffix(fname_data, "_seg"))
+    
+    folder_output = os.path.dirname(fname_out)
+    cmd += ['-o', folder_output]
+    if not os.path.isdir(folder_output) and os.path.exists(folder_output):
+        logger.error("output directory %s is not a valid directory" % folder_output)
+    if not os.path.exists(folder_output):
+        os.makedirs(folder_output)
 
     if arguments.down is not None:
         cmd += ["-down", str(arguments.down)]

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -203,8 +203,8 @@ def get_parser():
     optional.add_argument(
         '-o',
         metavar=Metavar.file,
-        help='Output filename. Example: spinal_seg.nii.gz '),
-
+        help='Output filename. Example: spinal_seg.nii.gz '
+        )
     optional.add_argument(
         '-down',
         metavar=Metavar.int,

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -201,12 +201,6 @@ def get_parser():
         help="Show this help message and exit."
     )
     optional.add_argument(
-        '-ofolder',
-        metavar=Metavar.folder,
-        action=ActionCreateFolder,
-        help="Output folder."
-    )
-    optional.add_argument(
         '-o',
         metavar=Metavar.file,
         help='Output filename. Example: spinal_seg.nii.gz '),
@@ -440,11 +434,8 @@ def propseg(img_input, options_dict):
 
     # Starting building the command
     cmd = ['isct_propseg', '-t', contrast_type_propseg]
-
-    if arguments.ofolder is not None:
-        folder_output = arguments.ofolder
-    else:
-        folder_output = './'
+    
+    folder_output = './'
     cmd += ['-o', folder_output]
     if not os.path.isdir(folder_output) and os.path.exists(folder_output):
         logger.error("output directory %s is not a valid directory" % folder_output)

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -207,7 +207,7 @@ def get_parser():
         help="Output folder."
     )
     optional.add_argument(
-        "-o",
+        '-o',
         metavar=Metavar.file,
         help='Output filename. Example: spinal_seg.nii.gz '),
 
@@ -684,4 +684,3 @@ def main(argv=None):
 if __name__ == "__main__":
     init_sct()
     main(sys.argv[1:])
-

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -630,7 +630,7 @@ def propseg(img_input, options_dict):
         sys.exit(1)
 
     # build output filename
-    fname_seg = os.path.join(folder_output,fname_out)
+    fname_seg = os.path.join(folder_output, fname_out)
     fname_centerline = os.path.join(folder_output, os.path.basename(add_suffix(fname_data, "_centerline")))
     # in case header was rescaled, we need to update the output file names by removing the "_rescaled"
     if rescale_header is not 1:

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -102,7 +102,7 @@ def get_parser():
     optional.add_argument(
         "-o",
         metavar=Metavar.file,
-        help='Output filename. Example: smooth_sc.nii.gz '),
+        help='Output filename. Example: smooth_sc.nii '),
     optional.add_argument(
         '-r',
         choices=[0, 1],
@@ -140,7 +140,7 @@ def main(args=None):
     if arguments.o is not None:
         fname_out = arguments.o
     else:
-        fname_out = extract_fname(fname_anat)[1] + '_smooth.nii.gz'
+        fname_out = extract_fname(fname_anat)[1] + '_smooth.nii'
     init_sct(log_level=verbose, update=True)  # Update log level
 
     # Display arguments

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -137,7 +137,7 @@ def main(argv=None):
     fname_anat = arguments.i
     fname_centerline = arguments.s
     param.algo_fitting = arguments.algo_fitting
-    
+
     if arguments.smooth is not None:
         sigma = arguments.smooth
     remove_temp_files = arguments.r
@@ -145,7 +145,6 @@ def main(argv=None):
         fname_out = arguments.o
     else:
         fname_out = extract_fname(fname_anat)[1] + '_smooth.nii'
-    init_sct(log_level=verbose, update=True)  # Update log level
 
 
     # Display arguments

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -100,6 +100,10 @@ def get_parser():
         help=f"Algorithm for curve fitting. For more information, see sct_straighten_spinalcord."
     )
     optional.add_argument(
+        "-o",
+        metavar=Metavar.file,
+        help='Output filename. Example: smooth_sc.nii.gz '),
+    optional.add_argument(
         '-r',
         choices=[0, 1],
         default=1,
@@ -133,6 +137,10 @@ def main(args=None):
         sigma = arguments.smooth
     remove_temp_files = arguments.r
     verbose = int(arguments.v)
+    if arguments.o is not None:
+        fname_out = arguments.o
+    else:
+        fname_out = extract_fname(fname_anat)[1] + '_smooth.nii.gz'
     init_sct(log_level=verbose, update=True)  # Update log level
 
     # Display arguments
@@ -235,7 +243,7 @@ def main(args=None):
     # Generate output file
     printv('\nGenerate output file...')
     generate_output_file(os.path.join(path_tmp, "anat_rpi_straight_smooth_curved_nonzero.nii"),
-                         file_anat + '_smooth' + ext_anat)
+                         fname_out)
 
     # Remove temporary files
     if remove_temp_files == 1:
@@ -246,7 +254,7 @@ def main(args=None):
     elapsed_time = time.time() - start_time
     printv('\nFinished! Elapsed time: ' + str(int(np.round(elapsed_time))) + 's\n')
 
-    display_viewer_syntax([file_anat, file_anat + '_smooth'], verbose=verbose)
+    display_viewer_syntax([fname_anat, fname_out], verbose=verbose)
 
 
 # START PROGRAM

--- a/unit_testing/cli/test_cli_sct_deepseg_sc.py
+++ b/unit_testing/cli/test_cli_sct_deepseg_sc.py
@@ -1,6 +1,8 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
+import os
+import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +14,11 @@ def test_sct_deepseg_sc_backwards_compat(script_runner):
     logger.debug(f"{ret.stderr}")
     assert ret.success
     assert ret.stderr == ''
+
+
+def test_sct_deepseg_sc_o_flag():
+    command = 'sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o test_seg.nii.gz'
+    subprocess.check_output(command, shell=True)
+    assert os.path.isfile('test_seg.nii.gz')
+    os.remove('test_seg.nii.gz')
+

--- a/unit_testing/cli/test_cli_sct_deepseg_sc.py
+++ b/unit_testing/cli/test_cli_sct_deepseg_sc.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 import os
 import subprocess
-from spinalcordtoolbox.scripts import sct_deepseg_sc as sct_deepseg_sc
+from spinalcordtoolbox.scripts import sct_deepseg_sc
 
 logger = logging.getLogger(__name__)
 

--- a/unit_testing/cli/test_cli_sct_deepseg_sc.py
+++ b/unit_testing/cli/test_cli_sct_deepseg_sc.py
@@ -18,7 +18,8 @@ def test_sct_deepseg_sc_backwards_compat(script_runner):
 
 
 def test_sct_deepseg_sc_o_flag(tmp_path):
-    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o""" + str(os.path.join(str(tmp_path), 'test_seg.nii.gz'))
-    sct_deepseg_sc.main(command.split())
+    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-o',
+            str(os.path.join(str(tmp_path), 'test_seg.nii.gz'))]
+    sct_deepseg_sc.main(argv)
     assert os.path.isfile(os.path.join(str(tmp_path), 'test_seg.nii.gz'))
 

--- a/unit_testing/cli/test_cli_sct_deepseg_sc.py
+++ b/unit_testing/cli/test_cli_sct_deepseg_sc.py
@@ -3,6 +3,7 @@ import pytest
 import logging
 import os
 import subprocess
+from spinalcordtoolbox.scripts import sct_deepseg_sc as sct_deepseg_sc
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ def test_sct_deepseg_sc_backwards_compat(script_runner):
 
 
 def test_sct_deepseg_sc_o_flag(tmp_path):
-    command = """sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o""" + os.path.join(tmp_path, 'test_seg.nii.gz')
-    subprocess.check_output(command, shell=True)
-    assert os.path.isfile(os.path.join(tmp_path, 'test_seg.nii.gz'))
+    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o""" + str(os.path.join(str(tmp_path), 'test_seg.nii.gz'))
+    sct_deepseg_sc.main(command.split())
+    assert os.path.isfile(os.path.join(str(tmp_path), 'test_seg.nii.gz'))
 

--- a/unit_testing/cli/test_cli_sct_deepseg_sc.py
+++ b/unit_testing/cli/test_cli_sct_deepseg_sc.py
@@ -16,9 +16,8 @@ def test_sct_deepseg_sc_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 
-def test_sct_deepseg_sc_o_flag():
-    command = 'sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o test_seg.nii.gz'
+def test_sct_deepseg_sc_o_flag(tmp_path):
+    command = """sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o""" + os.path.join(tmp_path, 'test_seg.nii.gz')
     subprocess.check_output(command, shell=True)
-    assert os.path.isfile('test_seg.nii.gz')
-    os.remove('test_seg.nii.gz')
+    assert os.path.isfile(os.path.join(tmp_path, 'test_seg.nii.gz'))
 

--- a/unit_testing/cli/test_cli_sct_deepseg_sc.py
+++ b/unit_testing/cli/test_cli_sct_deepseg_sc.py
@@ -2,7 +2,6 @@ from pytest_console_scripts import script_runner
 import pytest
 import logging
 import os
-import subprocess
 from spinalcordtoolbox.scripts import sct_deepseg_sc
 
 logger = logging.getLogger(__name__)
@@ -22,4 +21,3 @@ def test_sct_deepseg_sc_o_flag(tmp_path):
             str(os.path.join(str(tmp_path), 'test_seg.nii.gz'))]
     sct_deepseg_sc.main(argv)
     assert os.path.isfile(os.path.join(str(tmp_path), 'test_seg.nii.gz'))
-

--- a/unit_testing/cli/test_cli_sct_detect_pmj.py
+++ b/unit_testing/cli/test_cli_sct_detect_pmj.py
@@ -1,6 +1,8 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
+import os
+import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +14,9 @@ def test_sct_detect_pmj_backwards_compat(script_runner):
     logger.debug(f"{ret.stderr}")
     assert ret.success
     assert ret.stderr == ''
+
+def test_sct_detect_pmj_o_flag():
+    command = 'sct_detect_pmj -i sct_testing_data/template/template//PAM50_small_t2.nii.gz -igt sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz  -c t2 -o test_pmj.nii.gz'
+    subprocess.check_output(command, shell=True)
+    assert os.path.isfile('test_pmj.nii.gz')
+    os.remove('test_pmj.nii.gz')

--- a/unit_testing/cli/test_cli_sct_detect_pmj.py
+++ b/unit_testing/cli/test_cli_sct_detect_pmj.py
@@ -17,6 +17,8 @@ def test_sct_detect_pmj_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 def test_sct_detect_pmj_o_flag(tmp_path):
-    command = '-i sct_testing_data/template/template//PAM50_small_t2.nii.gz -igt sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz  -c t2 -o' + os.path.join(str(tmp_path), 'test_pmj.nii.gz')
-    sct_detect_pmj.main(command.split())
+    argv = ['-i', 'sct_testing_data/template/template//PAM50_small_t2.nii.gz', '-igt',
+            'sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz',
+            '-c', 't2', '-o', os.path.join(str(tmp_path), 'test_pmj.nii.gz')]
+    sct_detect_pmj.main(argv)
     assert os.path.isfile(os.path.join(str(tmp_path), 'test_pmj.nii.gz'))

--- a/unit_testing/cli/test_cli_sct_detect_pmj.py
+++ b/unit_testing/cli/test_cli_sct_detect_pmj.py
@@ -3,6 +3,7 @@ import pytest
 import logging
 import os
 import subprocess
+from spinalcordtoolbox.scripts import sct_detect_pmj as sct_detect_pmj
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,6 @@ def test_sct_detect_pmj_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 def test_sct_detect_pmj_o_flag(tmp_path):
-    command = 'sct_detect_pmj -i sct_testing_data/template/template//PAM50_small_t2.nii.gz -igt sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz  -c t2 -o' + os.path.join(tmp_path, 'test_pmj.nii.gz')
-    subprocess.check_output(command, shell=True)
-    assert os.path.isfile(os.path.join(tmp_path, 'test_pmj.nii.gz'))
+    command = '-i sct_testing_data/template/template//PAM50_small_t2.nii.gz -igt sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz  -c t2 -o' + os.path.join(str(tmp_path), 'test_pmj.nii.gz')
+    sct_detect_pmj.main(command.split())
+    assert os.path.isfile(os.path.join(str(tmp_path), 'test_pmj.nii.gz'))

--- a/unit_testing/cli/test_cli_sct_detect_pmj.py
+++ b/unit_testing/cli/test_cli_sct_detect_pmj.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 import os
 import subprocess
-from spinalcordtoolbox.scripts import sct_detect_pmj as sct_detect_pmj
+from spinalcordtoolbox.scripts import sct_detect_pmj
 
 logger = logging.getLogger(__name__)
 

--- a/unit_testing/cli/test_cli_sct_detect_pmj.py
+++ b/unit_testing/cli/test_cli_sct_detect_pmj.py
@@ -2,7 +2,6 @@ from pytest_console_scripts import script_runner
 import pytest
 import logging
 import os
-import subprocess
 from spinalcordtoolbox.scripts import sct_detect_pmj
 
 logger = logging.getLogger(__name__)

--- a/unit_testing/cli/test_cli_sct_detect_pmj.py
+++ b/unit_testing/cli/test_cli_sct_detect_pmj.py
@@ -15,8 +15,7 @@ def test_sct_detect_pmj_backwards_compat(script_runner):
     assert ret.success
     assert ret.stderr == ''
 
-def test_sct_detect_pmj_o_flag():
-    command = 'sct_detect_pmj -i sct_testing_data/template/template//PAM50_small_t2.nii.gz -igt sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz  -c t2 -o test_pmj.nii.gz'
+def test_sct_detect_pmj_o_flag(tmp_path):
+    command = 'sct_detect_pmj -i sct_testing_data/template/template//PAM50_small_t2.nii.gz -igt sct_testing_data/template/template/PAM50_small_t2_pmj_manual.nii.gz  -c t2 -o' + os.path.join(tmp_path, 'test_pmj.nii.gz')
     subprocess.check_output(command, shell=True)
-    assert os.path.isfile('test_pmj.nii.gz')
-    os.remove('test_pmj.nii.gz')
+    assert os.path.isfile(os.path.join(tmp_path, 'test_pmj.nii.gz'))

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -18,6 +18,6 @@ def test_sct_propseg_backwards_compat(script_runner):
 
 
 def test_sct_propseg_o_flag(tmp_path):
-    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o """ +os.path.join(str(tmp_path), "test_seg.nii.gz")
+    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o """ + os.path.join(str(tmp_path), "test_seg.nii.gz")
     sct_propseg.main(command.split())
     assert os.path.isfile(os.path.join(str(tmp_path), "test_seg.nii.gz"))

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -3,6 +3,7 @@ import pytest
 import logging
 import subprocess
 import os
+from spinalcordtoolbox.scripts import sct_propseg as sct_propseg
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,6 @@ def test_sct_propseg_backwards_compat(script_runner):
 
 
 def test_sct_propseg_o_flag(tmp_path):
-    command = """sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o """ + os.path.join(tmp_path, "test_seg.nii.gz")
-    subprocess.check_output(command, shell=True)
-    assert os.path.isfile(os.path.join(tmp_path, "test_seg.nii.gz"))
+    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o """ +os.path.join(str(tmp_path), "test_seg.nii.gz")
+    sct_propseg.main(command.split())
+    assert os.path.isfile(os.path.join(str(tmp_path), "test_seg.nii.gz"))

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -17,8 +17,7 @@ def test_sct_propseg_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 
-def test_sct_propseg_o_flag():
-    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-o', 'test_seg.nii.gz']
+def test_sct_propseg_o_flag(tmp_path):
+    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-o', os.path.join(str(tmp_path), 'test_seg.nii.gz')]
     sct_propseg.main(argv)
-    assert os.path.isfile("test_seg.nii.gz")
-    os.remove("test_seg.nii.gz")
+    assert os.path.isfile(os.path.join(str(tmp_path), 'test_seg.nii.gz'))

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 import subprocess
 import os
-from spinalcordtoolbox.scripts import sct_propseg as sct_propseg
+from spinalcordtoolbox.scripts import sct_propseg
 
 logger = logging.getLogger(__name__)
 

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -16,8 +16,7 @@ def test_sct_propseg_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 
-def test_sct_propseg_o_flag():
-    command = 'sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o test_seg.nii.gz'
+def test_sct_propseg_o_flag(tmp_path):
+    command = """sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o """ + os.path.join(tmp_path, "test_seg.nii.gz")
     subprocess.check_output(command, shell=True)
-    assert os.path.isfile('test_seg.nii.gz')
-    os.remove('test_seg.nii.gz')
+    assert os.path.isfile(os.path.join(tmp_path, "test_seg.nii.gz"))

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -1,6 +1,8 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
+import subprocess
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +14,10 @@ def test_sct_propseg_backwards_compat(script_runner):
     logger.debug(f"{ret.stderr}")
     assert ret.success
     assert ret.stderr == ''
+
+
+def test_sct_propseg_o_flag():
+    command = 'sct_deepseg_sc -i sct_testing_data/t2/t2.nii.gz -c t2 -o test_seg.nii.gz'
+    subprocess.check_output(command, shell=True)
+    assert os.path.isfile('test_seg.nii.gz')
+    os.remove('test_seg.nii.gz')

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -18,7 +18,7 @@ def test_sct_propseg_backwards_compat(script_runner):
 
 
 def test_sct_propseg_o_flag():
-    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o test_seg.nii.gz"""
-    sct_propseg.main(command.split())
+    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-c', 't2', '-o', 'test_seg.nii.gz']
+    sct_propseg.main(argv)
     assert os.path.isfile("test_seg.nii.gz")
     os.remove("test_seg.nii.gz")

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -1,7 +1,6 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
-import subprocess
 import os
 from spinalcordtoolbox.scripts import sct_propseg
 

--- a/unit_testing/cli/test_cli_sct_propseg.py
+++ b/unit_testing/cli/test_cli_sct_propseg.py
@@ -17,7 +17,8 @@ def test_sct_propseg_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 
-def test_sct_propseg_o_flag(tmp_path):
-    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o """ + os.path.join(str(tmp_path), "test_seg.nii.gz")
+def test_sct_propseg_o_flag():
+    command = """-i sct_testing_data/t2/t2.nii.gz -c t2 -o test_seg.nii.gz"""
     sct_propseg.main(command.split())
-    assert os.path.isfile(os.path.join(str(tmp_path), "test_seg.nii.gz"))
+    assert os.path.isfile("test_seg.nii.gz")
+    os.remove("test_seg.nii.gz")

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -18,6 +18,7 @@ def test_sct_smooth_spinalcord_backwards_compat(script_runner):
 
 
 def test_sct_smooth_spinalcord_o_flag(tmp_path):
-    command = '-i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o' + os.path.join(str(tmp_path), "test_smooth.nii")
-    sct_smooth_spinalcord.main(command.split())
+    argv = ['-i', 'sct_testing_data/t2/t2.nii.gz', '-s', 'sct_testing_data/t2/t2_seg-manual.nii.gz',
+               '-o', os.path.join(str(tmp_path), "test_smooth.nii")]
+    sct_smooth_spinalcord.main(argv)
     assert os.path.isfile(os.path.join(str(tmp_path), "test_smooth.nii"))

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -16,8 +16,7 @@ def test_sct_smooth_spinalcord_backwards_compat(script_runner):
     assert ret.stderr == ''
 
 
-def test_sct_smooth_spinalcord_o_flag():
-    command = 'sct_smooth_spinalcord -i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o test_smooth.nii.gz'
+def test_sct_smooth_spinalcord_o_flag(tmp_path):
+    command = '-i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o' + os.path.join(tmp_path, "test_smooth.nii")
     subprocess.check_output(command, shell=True)
-    assert os.path.isfile('test_smooth.nii.gz')
-    os.remove('test_smooth.nii.gz')
+    assert os.path.isfile(os.path.join(tmp_path, "test_smooth.nii"))

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -3,6 +3,7 @@ import pytest
 import logging
 import subprocess
 import os
+from spinalcordtoolbox.scripts import sct_smooth_spinalcord as sct_smooth_spinalcord
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,6 @@ def test_sct_smooth_spinalcord_backwards_compat(script_runner):
 
 
 def test_sct_smooth_spinalcord_o_flag(tmp_path):
-    command = 'sct_smooth_spinalcord -i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o' + os.path.join(tmp_path, "test_smooth.nii")
-    subprocess.check_output(command, shell=True)
-    assert os.path.isfile(os.path.join(tmp_path, "test_smooth.nii"))
+    command = '-i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o' + os.path.join(str(tmp_path), "test_smooth.nii")
+    sct_smooth_spinalcord.main(command.split())
+    assert os.path.isfile(os.path.join(str(tmp_path), "test_smooth.nii"))

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -1,7 +1,6 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
-import subprocess
 import os
 from spinalcordtoolbox.scripts import sct_smooth_spinalcord
 

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 import subprocess
 import os
-from spinalcordtoolbox.scripts import sct_smooth_spinalcord as sct_smooth_spinalcord
+from spinalcordtoolbox.scripts import sct_smooth_spinalcord
 
 logger = logging.getLogger(__name__)
 

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -1,6 +1,8 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
+import subprocess
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +14,10 @@ def test_sct_smooth_spinalcord_backwards_compat(script_runner):
     logger.debug(f"{ret.stderr}")
     assert ret.success
     assert ret.stderr == ''
+
+
+def test_sct_smooth_spinalcord_o_flag():
+    command = 'sct_smooth_spinalcord -i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o test_smooth.nii.gz'
+    subprocess.check_output(command, shell=True)
+    assert os.path.isfile('test_smooth.nii.gz')
+    os.remove('test_smooth.nii.gz')

--- a/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
+++ b/unit_testing/cli/test_cli_sct_smooth_spinalcord.py
@@ -17,6 +17,6 @@ def test_sct_smooth_spinalcord_backwards_compat(script_runner):
 
 
 def test_sct_smooth_spinalcord_o_flag(tmp_path):
-    command = '-i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o' + os.path.join(tmp_path, "test_smooth.nii")
+    command = 'sct_smooth_spinalcord -i sct_testing_data/t2/t2.nii.gz -s sct_testing_data/t2/t2_seg-manual.nii.gz -o' + os.path.join(tmp_path, "test_smooth.nii")
     subprocess.check_output(command, shell=True)
     assert os.path.isfile(os.path.join(tmp_path, "test_smooth.nii"))


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR aims at adding the `-o` flag on a few function in sct:
- [x] sct_deepseg_sc
- [x] sct_detect_pmj
- [x] sct_propseg
- [x] sct_smooth_spinalcord

## Linked issues
fix #1802
fix #897
