### PR TITLE
Add improvements to recent tensorflow-tensorboard fix

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -533,16 +533,18 @@ print info "Installing Python dependencies..."
 # Check if a frozen version of the requirements exist (for release only)
 if [[ -f "requirements-freeze.txt" ]]; then
   print info "Using requirements-freeze.txt (release installation)"
-  pip install -r requirements-freeze.txt
+  export REQUIREMENTS_FILE="requirements-freeze.txt"
 else
   # Not a package
   print info "Using requirements.txt (git installation)"
-  pip install -r requirements.txt
-  yes | pip uninstall tensorflow-tensorboard
-  yes | pip uninstall tensorboard
-  pip install tensorboard
-
+  export REQUIREMENTS_FILE="requirements.txt"
 fi
+pip install -r REQUIREMENTS_FILE &&
+  # `tensorflow-tensorboard` is installed by `tensorflow==1.5.0` but is not needed,
+  # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
+  # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.
+  # See https://github.com/neuropoly/spinalcordtoolbox/issues/3035 for more info.
+  yes | pip uninstall tensorflow-tensorboard
 if [[ $? != 0 ]]; then
   die "Failed running pip install: $?"
 fi

--- a/install_sct
+++ b/install_sct
@@ -539,7 +539,7 @@ else
   print info "Using requirements.txt (git installation)"
   export REQUIREMENTS_FILE="requirements.txt"
 fi
-pip install -r REQUIREMENTS_FILE &&
+pip install -r $REQUIREMENTS_FILE &&
   # `tensorflow-tensorboard` is installed by `tensorflow==1.5.0` but is not needed,
   # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
   # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.

--- a/install_sct
+++ b/install_sct
@@ -544,7 +544,9 @@ pip install -r $REQUIREMENTS_FILE &&
   # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
   # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.
   # See https://github.com/neuropoly/spinalcordtoolbox/issues/3035 for more info.
-  yes | pip uninstall tensorflow-tensorboard
+  yes | pip uninstall tensorflow-tensorboard &&
+  yes | pip uninstall tensorboard &&
+  pip install tensorboard
 if [[ $? != 0 ]]; then
   die "Failed running pip install: $?"
 fi


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] ~~I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution~~ N/A
- [ ] ~~I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages~~ N/A

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

PR #3034 was included in #3041 to fix #3035. But, on closer inspection, I noticed some issues:
* The fix was only applied to the dev install, not the release install.
    * Solution: Use a variable to store the name of the requirements file, then have the pip install be done in a single command for both types of installation.
* The fix used multiple separate commands, which invalidates the `$?` status check.
    * Solution: Use `&&` to group commands, so that `$?` remains a valid check. 
    * _["Commands separated by a double ampersand && are to be run synchronously, with each one running only if the last did not fail (a fail is interpreted as returning a non-zero return status)."](https://bashitout.com/2013/05/18/Ampersands-on-the-command-line.html)_
* The fix missed a comment that had been mentioned in #3034 but left out of #3041.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3035.