### PR TITLE
Change default option values to None

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
 Keras==2.1.5
-ivadomed==2.6.0
+ivadomed==2.6.1
 matplotlib
 nibabel
 numpy

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -76,6 +76,7 @@ def get_parser():
     misc.add_argument(
         "-thr",
         type=float,
+        dest='binarize_prediction',
         help="Binarize segmentation with specified threshold. Set to 0 for no thresholding (i.e., soft segmentation). "
              "Default value is model-specific and was set during optimization "
              "(more info at https://github.com/sct-pipeline/deepseg-threshold).",
@@ -89,21 +90,22 @@ def get_parser():
         default=1)
     misc.add_argument(
         "-largest",
+        dest='keep_largest',
         type=int,
         help="Keep the largest connected-objects from the output segmentation. Specify the number of objects to keep."
              "To keep all objects, set to 0",
-        default=0)
+        default=None)
     misc.add_argument(
         "-fill-holes",
         type=int,
         help="Fill small holes in the segmentation.",
         choices=(0, 1),
-        default=0)
+        default=None)
     misc.add_argument(
         "-remove-small",
         type=str,
         help="Minimal object size to keep with unit (mm3 or vox). Example: 1mm3, 5vox.",
-        default='0vox')
+        default=None)
 
     misc = parser.add_argument_group('\nMISC')
     misc.add_argument(
@@ -146,12 +148,15 @@ def main(argv):
     # Check if all input images are provided
     required_contrasts = deepseg.models.get_required_contrasts(args.task)
     if len(args.i) != len(required_contrasts):
-        parser.error("{} input files found. Please provide all required input files for the task {}, i.e. contrasts: {}."
-                     .format(len(args.i), args.task, ', '.join(required_contrasts)))
+        parser.error(
+            "{} input files found. Please provide all required input files for the task {}, i.e. contrasts: {}."
+            .format(len(args.i), args.task, ', '.join(required_contrasts)))
 
     # Check modality order
     if len(args.i) > 1 and args.c is None:
-        parser.error("Please specify the order in which you put the contrasts in the input images (-i) with flag -c, e.g., -c t1 t2")
+        parser.error(
+            "Please specify the order in which you put the contrasts in the input images (-i) with flag -c, e.g.,"
+            " -c t1 t2")
 
     # Get pipeline model names
     name_models = deepseg.models.TASKS[args.task]['models']

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -81,7 +81,7 @@ def get_parser():
              "Default value is model-specific and was set during optimization "
              "(more info at https://github.com/sct-pipeline/deepseg-threshold).",
         metavar=Metavar.float,
-        default=0.9)
+        default=None)
     misc.add_argument(
         "-r",
         type=int,

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -104,7 +104,10 @@ def get_parser():
     misc.add_argument(
         "-remove-small",
         type=str,
-        help="Minimal object size to keep with unit (mm3 or vox). Example: 1mm3, 5vox.",
+        nargs="+",
+        help="Minimal object size to keep with unit (mm3 or vox). A single value can be provided or one value per "
+             "prediction class. Single value example: 1mm3, 5vox. Multiple values example: 10 20 10vox (remove objects "
+             "smaller than 10 voxels for class 1 and 3, and smaller than 20 voxels for class 2).",
         default=None)
 
     misc = parser.add_argument_group('\nMISC')

--- a/unit_testing/test_deepseg.py
+++ b/unit_testing/test_deepseg.py
@@ -52,7 +52,7 @@ def test_segment_nifti(fname_image, fname_seg_manual, fname_out, task,
     Uses the locally-installed sct_testing_data
     """
     fname_out = str(tmp_path/fname_out)  # tmp_path for automatic cleanup
-    sct_deepseg.main(['-i', fname_image, '-task', task, '-o', fname_out])
+    sct_deepseg.main(['-i', fname_image, '-task', task, '-o', fname_out, '-thr', str(0.9)])
     # TODO: implement integrity test (for now, just checking if output segmentation file exists)
     # Make sure output file exists
     assert os.path.isfile(fname_out)


### PR DESCRIPTION
Change default values to None for postprocessing steps (`-remove-small`, `-fill-holes`, `-largest`, `-thr`). When no values are set, the postprocessing values in the configuration file of each model will be applied. The user has the option to overwrite the postprocessing steps by using the corresponding flag. The old behavior with a default values were overwriting the values set in the configuration file.

Other change:
- `-remove-small` is now compatible with multiclass models. One or more threshold values can be set for this postprocessing. If more than one value is used, each threshold is associated with its corresponding output class. The order of the output class will be specified in the task description. 

- Destination parameters now match the postprocessing name in ivadomed (`thr` became `binarize_prediction` and `largest` became `keep_largest`)


ivadomed sister PRs: https://github.com/ivadomed/ivadomed/pull/549 (change in postprocessing behavior) and https://github.com/ivadomed/ivadomed/pull/570 (-remove-small compatible with multiclass). 
