### PR TITLE
Refactor CLI init steps to be consistent across scripts

### DIFF
--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -385,7 +385,7 @@ def moco_wrapper(param):
         if not param.fname_bvals == '':
             # if bvals file is provided
             args += ['-bval', param.fname_bvals]
-        fname_b0, fname_b0_mean, fname_dwi, fname_dwi_mean = sct_dmri_separate_b0_and_dwi.main(args=args)
+        fname_b0, fname_b0_mean, fname_dwi, fname_dwi_mean = sct_dmri_separate_b0_and_dwi.main(argv=args)
     else:
         fname_moco_mean = add_suffix(im_moco.absolutepath, '_mean')
         im_moco.mean(dim=3).save(fname_moco_mean)
@@ -638,7 +638,7 @@ def moco(param):
                 # copy transformation
                 copy(file_mat[iz][gT[index_good]] + 'Warp.nii.gz', file_mat[iz][fT[it]] + 'Warp.nii.gz')
                 # apply transformation
-                sct_apply_transfo.main(args=['-i', file_data_splitZ_splitT[fT[it]],
+                sct_apply_transfo.main(argv=['-i', file_data_splitZ_splitT[fT[it]],
                                              '-d', file_target,
                                              '-w', file_mat[iz][fT[it]] + 'Warp.nii.gz',
                                              '-o', file_data_splitZ_splitT_moco[fT[it]],
@@ -758,7 +758,7 @@ def register(param, file_src, file_dest, file_mat, file_out, im_mask=None):
             status, output = run_proc(cmd, verbose=1 if param.verbose == 2 else 0, env=env, **kw)
 
     elif param.todo == 'apply':
-        sct_apply_transfo.main(args=['-i', file_src,
+        sct_apply_transfo.main(argv=['-i', file_src,
                                      '-d', file_dest,
                                      '-w', file_mat + param.suffix_mat,
                                      '-o', file_out_concat,

--- a/spinalcordtoolbox/scripts/msct_gmseg_utils.py
+++ b/spinalcordtoolbox/scripts/msct_gmseg_utils.py
@@ -501,7 +501,7 @@ def apply_transfo(im_src, im_dest, warp, interp='spline', rm_tmp=True):
     im_dest.save(fname_dest)
     # apply warping field
     fname_src_reg = add_suffix(fname_src, '_reg')
-    sct_apply_transfo.main(args=['-i', fname_src,
+    sct_apply_transfo.main(argv=['-i', fname_src,
                                  '-d', fname_dest,
                                  '-w', warp,
                                  '-x', interp])

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -100,8 +100,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -95,12 +95,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -22,7 +22,7 @@ from skimage.measure import label
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
@@ -511,17 +511,16 @@ class AnalyzeLeion:
         os.chdir(self.tmp_dir)  # go to tmp directory
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     fname_mask = arguments.m
     fname_sc = arguments.s
@@ -547,10 +546,6 @@ def main(args=None):
     else:
         rm_tmp = True
 
-    # Verbosity
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
-
     # create the Lesion constructor
     lesion_obj = AnalyzeLeion(fname_mask=fname_mask,
                               fname_sc=fname_sc,
@@ -575,4 +570,4 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -102,12 +102,13 @@ def get_parser():
         choices=(0, 1),
         default=int(Param().rm_tmp))
     optional.add_argument(
-        "-v",
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended.",
-        required=False,
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1, 2),
-        default=Param().verbose)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -107,8 +107,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -18,7 +18,7 @@ from skimage.feature import greycomatrix, greycoprops
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like
 from spinalcordtoolbox.utils.shell import Metavar, ActionCreateFolder, SmartFormatter
-from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc
+from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
@@ -309,17 +309,16 @@ class ParamGLCM(object):
         self.angle = '0,45,90,135'  # Rotation angles for co-occurrence matrix
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # create param object
     param = Param()
@@ -348,8 +347,6 @@ def main(args=None):
         param.dim = arguments.dim
     if arguments.r is not None:
         param.rm_tmp = bool(arguments.r)
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     # create the GLCM constructor
     glcm = ExtractGLCM(param=param, param_glcm=param_glcm)
@@ -366,4 +363,4 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -24,7 +24,7 @@ from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import cubic_to_point
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, get_interpolation, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, copy
 
 from spinalcordtoolbox.scripts import sct_image
@@ -336,25 +336,16 @@ class Transform:
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
     """
     Entry point for sct_apply_transfo
-    :param args: list of input arguments. For parameters -w and -winv, args list should include a nested list for every
-    item. Example: args=['-i', 'file.nii', '-w', ['warp1.nii', 'warp2.nii']]
+    :param argv: list of input arguments.
     :return:
     """
-
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
-    else:
-        # flatten the list of input arguments because -w and -winv carry a nested list
-        lst = []
-        for line in args:
-            lst.append(line) if isinstance(line, str) else lst.extend(line)
-        args = lst
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     input_filename = arguments.i
     fname_dest = arguments.d
@@ -368,15 +359,12 @@ def main(args=None):
     transform.output_filename = arguments.o
     transform.interp = arguments.x
     transform.remove_temp_files = arguments.r
-    transform.verbose = arguments.v
-    init_sct(log_level=transform.verbose, update=True)  # Update log level
+    transform.verbose = verbose
 
     transform.apply()
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -114,8 +114,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -109,12 +109,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
-        help="Verbose: 0: nothing, 1: classic, 2: expended.",
-        required=False,
+        '-v',
+        metavar=Metavar.int,
         type=int,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1, 2))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -28,15 +28,7 @@ import psutil
 import requirements
 
 from spinalcordtoolbox.utils.shell import SmartFormatter
-from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__
-
-
-# DEFAULT PARAMETERS
-class Param:
-    # The constructor
-    def __init__(self):
-        self.create_log_file = 0
-        self.complete_test = 0
+from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__, set_global_loglevel
 
 
 class bcolors:
@@ -210,7 +202,12 @@ def get_parser():
     return parser
 
 
-def main():
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = complete_test = arguments.complete
+    set_global_loglevel(verbose=verbose)
+
     print("SCT info:")
     print("- version: {}".format(__version__))
     print("- path: {0}".format(__sct_dir__))
@@ -218,17 +215,7 @@ def main():
     # initialization
     install_software = 0
     e = 0
-    complete_test = param.complete_test
     os_running = 'not identified'
-
-    # Check input parameters
-    parser = get_parser()
-    arguments = parser.parse_args()
-    if arguments.complete:
-        complete_test = 1
-
-    # use variable "verbose" when calling run for more clarity
-    verbose = complete_test
 
     # complete test
     if complete_test:
@@ -362,7 +349,4 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    # initialize parameters
-    param = Param()
-    # call main function
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -127,8 +127,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -16,7 +16,7 @@ import os
 import argparse
 
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 
 # DEFAULT PARAMETERS
@@ -134,9 +134,12 @@ def get_parser():
 
 # main
 #=======================================================================================================================
-def main():
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # Initialization
     param = Param()
     input_t1 = arguments.t1
@@ -144,7 +147,6 @@ def main():
     input_tr_min = 500
     input_tr_max = 3500
     input_tr = None
-    verbose = 1
     fname_output_file = arguments.o
     if arguments.ofig is not None:
         input_fname_output = arguments.ofig
@@ -153,8 +155,6 @@ def main():
         input_tr_max = arguments.b[1]
     if arguments.tr is not None:
         input_tr = arguments.tr
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     graph = ErnstAngle(input_t1, tr=input_tr, fname_output=input_fname_output)
     if input_tr is not None:
@@ -181,4 +181,5 @@ def main():
 #=======================================================================================================================
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -122,12 +122,13 @@ def get_parser():
         metavar=Metavar.str,
         default="ernst_angle.png")
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended (graph)",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like, change_orientation
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname
 
 # TODO: display results ==> not only max : with a violin plot of h1 and h2 distribution ? see dev/straightening --> seaborn.violinplot
@@ -494,12 +494,12 @@ def get_parser():
     return parser
 
 
-########################################################################################################################
-# ------------------------------------------------------  MAIN ------------------------------------------------------- #
-########################################################################################################################
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
-if __name__ == "__main__":
-    init_sct()
     param = Param()
     input_fname = None
     if param.debug:
@@ -521,8 +521,7 @@ if __name__ == "__main__":
             resample_to = arguments.resampling
         if arguments.o is not None:
             output_fname = arguments.o
-        param.verbose = arguments.v
-        init_sct(log_level=param.verbose, update=True)  # Update log level
+        param.verbose = verbose
 
         tmp_dir = tmp_create()
         im1_name = "im1.nii.gz"
@@ -564,3 +563,8 @@ if __name__ == "__main__":
         res_fic.close()
 
         # printv('Total time: ', time.time() - now)
+
+
+if __name__ == "__main__":
+    init_sct()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -484,12 +484,13 @@ def get_parser():
         required=False,
         default='hausdorff_distance.txt')
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -489,8 +489,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -61,12 +61,13 @@ def get_parser():
         action="help",
         help="Show this help message and exit")
     optional.add_argument(
-        "-v",
-        help="Verbose: 0: nothing, 1: classic, 2: expended.",
-        required=False,
+        '-v',
+        metavar=Metavar.int,
         type=int,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1, 2))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -14,7 +14,7 @@ import sys
 import os
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 
 
 # PARSER
@@ -60,6 +60,13 @@ def get_parser():
         "--help",
         action="help",
         help="Show this help message and exit")
+    optional.add_argument(
+        "-v",
+        help="Verbose: 0: nothing, 1: classic, 2: expended.",
+        required=False,
+        type=int,
+        default=1,
+        choices=(0, 1, 2))
 
     return parser
 
@@ -70,11 +77,12 @@ def mscc(di, da, db):
 
 # MAIN
 # ==========================================================================================
-def main():
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-    # initialization
-    verbose = 1
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # Get parser info
     di = arguments.di
     da = arguments.da
@@ -87,9 +95,7 @@ def main():
     printv('\nMSCC = ' + str(MSCC) + '\n', verbose, 'info')
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -66,8 +66,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -15,7 +15,7 @@ import sys
 import os
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, printv, set_global_loglevel
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.qmri.mt import compute_mtr
 
@@ -71,23 +71,25 @@ def get_parser():
     return parser
 
 
-def main():
-    # Check input parameters
+def main(argv=None):
     parser = get_parser()
-    args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-    fname_mtr = args.o
-    verbose = args.v
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
+    fname_mtr = arguments.o
 
     # compute MTR
     printv('\nCompute MTR...', verbose)
-    nii_mtr = compute_mtr(nii_mt1=Image(args.mt1), nii_mt0=Image(args.mt0), threshold_mtr=args.thr)
+    nii_mtr = compute_mtr(nii_mt1=Image(arguments.mt1), nii_mt0=Image(arguments.mt0), threshold_mtr=arguments.thr)
 
     # save MTR file
     nii_mtr.save(fname_mtr, dtype='float32')
 
-    display_viewer_syntax([args.mt0, args.mt1, fname_mtr])
+    display_viewer_syntax([arguments.mt0, arguments.mt1, fname_mtr])
 
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -61,8 +61,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
     optional.add_argument(
         '-o',

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -57,10 +57,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1, 2),
-        help='Verbose: 0 = nothing, 1 = classic, 2 = expended',
-        default=1
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
     optional.add_argument(
         '-o',

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -115,11 +115,13 @@ def get_parser():
         help="Output file for T1map",
         default="t1map.nii.gz")
     optional.add_argument(
-        "-v",
-        help="Verbose: 0 = no verbosity, 1 = verbose (default).",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -21,12 +21,12 @@ import os
 import argparse
 import json
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, display_viewer_syntax
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, display_viewer_syntax, set_global_loglevel
 from spinalcordtoolbox.qmri.mt import compute_mtsat
 from spinalcordtoolbox.image import Image, splitext
 
 
-def get_parser(argv):
+def get_parser():
     parser = argparse.ArgumentParser(
         description='Compute MTsat and T1map. '
                     'Reference: Helms G, Dathe H, Kallenberg K, Dechent P. High-resolution maps of magnetization '
@@ -162,51 +162,52 @@ def fetch_metadata(fname_json, field):
         return metadata[field]
 
 
-def main(argv):
-    parser = get_parser(argv)
-    args = parser.parse_args(argv if argv else ['--help'])
-    verbose = args.v
-    init_sct(log_level=verbose, update=True)  # Update log level
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     printv('Load data...', verbose)
-    nii_mt = Image(args.mt)
-    nii_pd = Image(args.pd)
-    nii_t1 = Image(args.t1)
-    if args.b1map is None:
+    nii_mt = Image(arguments.mt)
+    nii_pd = Image(arguments.pd)
+    nii_t1 = Image(arguments.t1)
+    if arguments.b1map is None:
         nii_b1map = None
     else:
-        nii_b1map = Image(args.b1map)
+        nii_b1map = Image(arguments.b1map)
 
-    if args.trmt is None:
-        args.trmt = fetch_metadata(get_json_file_name(args.mt, check_exist=True), 'RepetitionTime')
-    if args.trpd is None:
-        args.trpd = fetch_metadata(get_json_file_name(args.pd, check_exist=True), 'RepetitionTime')
-    if args.trt1 is None:
-        args.trt1 = fetch_metadata(get_json_file_name(args.t1, check_exist=True), 'RepetitionTime')
-    if args.famt is None:
-        args.famt = fetch_metadata(get_json_file_name(args.mt, check_exist=True), 'FlipAngle')
-    if args.fapd is None:
-        args.fapd = fetch_metadata(get_json_file_name(args.pd, check_exist=True), 'FlipAngle')
-    if args.fat1 is None:
-        args.fat1 = fetch_metadata(get_json_file_name(args.t1, check_exist=True), 'FlipAngle')
+    if arguments.trmt is None:
+        arguments.trmt = fetch_metadata(get_json_file_name(arguments.mt, check_exist=True), 'RepetitionTime')
+    if arguments.trpd is None:
+        arguments.trpd = fetch_metadata(get_json_file_name(arguments.pd, check_exist=True), 'RepetitionTime')
+    if arguments.trt1 is None:
+        arguments.trt1 = fetch_metadata(get_json_file_name(arguments.t1, check_exist=True), 'RepetitionTime')
+    if arguments.famt is None:
+        arguments.famt = fetch_metadata(get_json_file_name(arguments.mt, check_exist=True), 'FlipAngle')
+    if arguments.fapd is None:
+        arguments.fapd = fetch_metadata(get_json_file_name(arguments.pd, check_exist=True), 'FlipAngle')
+    if arguments.fat1 is None:
+        arguments.fat1 = fetch_metadata(get_json_file_name(arguments.t1, check_exist=True), 'FlipAngle')
 
     # compute MTsat
     nii_mtsat, nii_t1map = compute_mtsat(nii_mt, nii_pd, nii_t1,
-                                         args.trmt, args.trpd, args.trt1,
-                                         args.famt, args.fapd, args.fat1,
+                                         arguments.trmt, arguments.trpd, arguments.trt1,
+                                         arguments.famt, arguments.fapd, arguments.fat1,
                                          nii_b1map=nii_b1map)
 
     # Output MTsat and T1 maps
     printv('Generate output files...', verbose)
-    nii_mtsat.save(args.omtsat)
-    nii_t1map.save(args.ot1map)
+    nii_mtsat.save(arguments.omtsat)
+    nii_t1map.save(arguments.ot1map)
 
-    display_viewer_syntax([args.omtsat, args.ot1map],
+    display_viewer_syntax([arguments.omtsat, arguments.ot1map],
                               colormaps=['gray', 'gray'],
                               minmax=['-10,10', '0, 3'],
                               opacities=['1', '1'],
                               verbose=verbose)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+    init_sct()
     main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -120,8 +120,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -82,10 +82,12 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         '-v',
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
+        metavar=Metavar.int,
         type=int,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -19,7 +19,7 @@ import argparse
 import numpy as np
 
 from spinalcordtoolbox.image import Image, empty_like, add_suffix
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, parse_num_list, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, parse_num_list, init_sct, printv, set_global_loglevel
 
 
 # PARAMETERS
@@ -102,14 +102,16 @@ def weighted_avg_and_std(values, weights):
     return (average, np.sqrt(variance))
 
 
-def main():
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # Default params
     param = Param()
 
     # Get parser info
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     fname_data = arguments.i
     if arguments.m is not None:
         fname_mask = arguments.m
@@ -120,8 +122,6 @@ def main():
         index_vol_user = arguments.vol
     else:
         index_vol_user = ''
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     # Check parameters
     if method == 'diff':
@@ -189,9 +189,6 @@ def main():
         printv('\nSNR_' + method + ' = ' + str(snr_roi) + '\n', type='info')
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -86,8 +86,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -63,8 +63,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -16,15 +16,8 @@ import sys
 import os
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 import spinalcordtoolbox.image as image
-
-
-# DEFAULT PARAMETERS
-class Param:
-    # The constructor
-    def __init__(self):
-        self.verbose = 1
 
 
 # PARSER
@@ -64,6 +57,13 @@ def get_parser():
         required=False,
         choices=(0, 1),
         default=1)
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
+        required=False,
+        choices=(0, 1, 2),
+        default=1)
 
     return parser
 
@@ -82,17 +82,17 @@ def convert(fname_in, fname_out, squeeze_data=True, dtype=None, verbose=1):
     img.save(fname_out, mutable=True, verbose=verbose)
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
     :param args:
     :return:
     """
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # Building the command, do sanity checks
     fname_in = arguments.i
     fname_out = arguments.o
@@ -102,11 +102,6 @@ def main(args=None):
     convert(fname_in, fname_out, squeeze_data=squeeze_data)
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # initialize parameters
-    param = Param()
-    # call main function
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -58,12 +58,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -25,7 +25,7 @@ from scipy import ndimage
 
 from spinalcordtoolbox.image import Image, empty_like
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, check_file_exist, extract_fname, rmtree, copy
 from spinalcordtoolbox.labels import create_labels
 from spinalcordtoolbox.types import Coordinate
@@ -123,17 +123,16 @@ def get_parser():
     return parser
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     param = Param()
     param.fname_data = os.path.abspath(arguments.i)
@@ -150,9 +149,6 @@ def main(args=None):
         param.fname_out = os.path.abspath(arguments.o)
     if arguments.r is not None:
         param.remove_temp_files = arguments.r
-
-    param.verbose = arguments.v
-    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # run main program
     create_mask(param)
@@ -355,4 +351,4 @@ def create_mask2d(param, center, shape, size, im_data):
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -118,8 +118,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -113,12 +113,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended ",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -127,12 +127,13 @@ def get_parser():
         metavar=Metavar.int,
     )
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="0: Verbose off | 1: Verbose on",
-        choices=(0, 1),
-        default=1
-    )
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -14,7 +14,7 @@ import argparse
 
 from spinalcordtoolbox.cropping import ImageCropper, BoundingBox
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
 
 
 def get_parser():
@@ -137,22 +137,20 @@ def get_parser():
     return parser
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # initialize ImageCropper
     cropper = ImageCropper(Image(arguments.i))
-    cropper.verbose = arguments.v
-    init_sct(log_level=cropper.verbose, update=True)  # Update log level
+    cropper.verbose = verbose
 
     # Switch across cropping methods
     if arguments.g:
@@ -183,4 +181,5 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -132,8 +132,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -112,11 +112,13 @@ def get_parser():
 
     misc = parser.add_argument_group('\nMISC')
     misc.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = no verbosity, 1 = verbose.",
-        choices=(0, 1),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
     misc.add_argument(
         "-h",
         "--help",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -25,7 +25,7 @@ import spinalcordtoolbox.deepseg as deepseg
 import spinalcordtoolbox.deepseg.models
 
 from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 logger = logging.getLogger(__name__)
 
@@ -121,40 +121,42 @@ def get_parser():
     return parser
 
 
-def main(argv):
+def main(argv=None):
     parser = get_parser()
-    args = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # Deal with task
-    if args.list_tasks:
+    if arguments.list_tasks:
         deepseg.models.display_list_tasks()
 
-    if args.install_task is not None:
-        for name_model in deepseg.models.TASKS[args.install_task]['models']:
+    if arguments.install_task is not None:
+        for name_model in deepseg.models.TASKS[arguments.install_task]['models']:
             deepseg.models.install_model(name_model)
         exit(0)
 
     # Deal with input/output
-    for file in args.i:
+    for file in arguments.i:
         if not os.path.isfile(file):
             parser.error("This file does not exist: {}".format(file))
 
     # Check if at least a model or task has been specified
-    if args.task is None:
+    if arguments.task is None:
         parser.error("You need to specify a task.")
 
     # Check if all input images are provided
-    required_contrasts = deepseg.models.get_required_contrasts(args.task)
-    if len(args.i) != len(required_contrasts):
+    required_contrasts = deepseg.models.get_required_contrasts(arguments.task)
+    if len(arguments.i) != len(required_contrasts):
         parser.error("{} input files found. Please provide all required input files for the task {}, i.e. contrasts: {}."
-                     .format(len(args.i), args.task, ', '.join(required_contrasts)))
+                     .format(len(arguments.i), arguments.task, ', '.join(required_contrasts)))
 
     # Check modality order
-    if len(args.i) > 1 and args.c is None:
+    if len(arguments.i) > 1 and arguments.c is None:
         parser.error("Please specify the order in which you put the contrasts in the input images (-i) with flag -c, e.g., -c t1 t2")
 
     # Get pipeline model names
-    name_models = deepseg.models.TASKS[args.task]['models']
+    name_models = deepseg.models.TASKS[arguments.task]['models']
 
     # Run pipeline by iterating through the models
     fname_prior = None
@@ -174,21 +176,21 @@ def main(argv):
                 parser.error("The input model is invalid: {}".format(path_model))
 
         # Order input images
-        if args.c is not None:
+        if arguments.c is not None:
             input_filenames = []
             for required_contrast in deepseg.models.MODELS[name_model]['contrasts']:
-                for provided_contrast, input_filename in zip(args.c, args.i):
+                for provided_contrast, input_filename in zip(arguments.c, arguments.i):
                     if required_contrast == provided_contrast:
                         input_filenames.append(input_filename)
         else:
-            input_filenames = args.i
+            input_filenames = arguments.i
 
         # Call segment_nifti
-        options = {**vars(args), "fname_prior": fname_prior}
+        options = {**vars(arguments), "fname_prior": fname_prior}
         nii_lst, target_lst = imed_inference.segment_volume(path_model, input_filenames, options=options)
 
         # Delete intermediate outputs
-        if fname_prior and os.path.isfile(fname_prior) and args.r:
+        if fname_prior and os.path.isfile(fname_prior) and arguments.r:
             logger.info("Remove temporary files...")
             os.remove(fname_prior)
 
@@ -218,9 +220,9 @@ def main(argv):
         fname_prior = fname_seg
 
     for output_filename in output_filenames:
-        display_viewer_syntax([args.i[0], output_filename], colormaps=['gray', 'red'], opacities=['', '0.7'])
+        display_viewer_syntax([arguments.i[0], output_filename], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     init_sct()
     main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -117,8 +117,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
     misc.add_argument(
         "-h",
         "--help",

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -12,7 +12,7 @@ import sys
 import os
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
 from spinalcordtoolbox.image import add_suffix
 from spinalcordtoolbox.reports.qc import generate_qc
 
@@ -91,9 +91,12 @@ def get_parser():
     return parser
 
 
-def run_main():
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     input_filename = arguments.i
     if arguments.o is not None:
         output_filename = arguments.o
@@ -103,8 +106,6 @@ def run_main():
     use_tta = arguments.t
     model_name = arguments.m
     threshold = arguments.thr
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     if threshold > 1.0 or threshold < 0.0:
         raise RuntimeError("Threshold should be between 0.0 and 1.0.")
@@ -133,6 +134,7 @@ def run_main():
                               verbose=verbose)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     init_sct()
-    run_main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -87,8 +87,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -82,11 +82,13 @@ def get_parser():
              "provides non-deterministic results.",
         metavar='')
     misc.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = no verbosity, 1 = verbose.",
-        choices=(0, 1),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -17,7 +17,7 @@ import sys
 import argparse
 
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
@@ -109,35 +109,35 @@ def get_parser():
     return parser
 
 
-def main():
+def main(argv=None):
     """Main function."""
     parser = get_parser()
-    args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
-    fname_image = args.i
-    contrast_type = args.c
+    fname_image = arguments.i
+    contrast_type = arguments.c
 
-    ctr_algo = args.centerline
+    ctr_algo = arguments.centerline
 
-    brain_bool = bool(args.brain)
-    if args.brain is None and contrast_type in ['t2s', 't2_ax']:
+    brain_bool = bool(arguments.brain)
+    if arguments.brain is None and contrast_type in ['t2s', 't2_ax']:
         brain_bool = False
 
-    output_folder = args.ofolder
+    output_folder = arguments.ofolder
 
-    if ctr_algo == 'file' and args.file_centerline is None:
+    if ctr_algo == 'file' and arguments.file_centerline is None:
         printv('Please use the flag -file_centerline to indicate the centerline filename.', 1, 'error')
         sys.exit(1)
 
-    if args.file_centerline is not None:
-        manual_centerline_fname = args.file_centerline
+    if arguments.file_centerline is not None:
+        manual_centerline_fname = arguments.file_centerline
         ctr_algo = 'file'
     else:
         manual_centerline_fname = None
 
-    remove_temp_files = args.r
-    verbose = args.v
-    init_sct(log_level=verbose, update=True)  # Update log level
+    remove_temp_files = arguments.r
 
     algo_config_stg = '\nMethod:'
     algo_config_stg += '\n\tCenterline algorithm: ' + str(ctr_algo)
@@ -173,4 +173,5 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -95,11 +95,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="1: Display on (default), 0: Display off, 2: Extended",
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
     optional.add_argument(
         '-igt',
         metavar=Metavar.str,

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -100,8 +100,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
     optional.add_argument(
         '-igt',
         metavar=Metavar.str,

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -106,8 +106,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
     optional.add_argument(
         '-qc',
         metavar=Metavar.str,

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -101,11 +101,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="1: display on (default), 0: display off, 2: extended",
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
     optional.add_argument(
         '-qc',
         metavar=Metavar.str,

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -16,7 +16,7 @@ import sys
 import argparse
 
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import Image, check_dim
 from spinalcordtoolbox.deepseg_sc.core import deep_segmentation_spinalcord
@@ -127,57 +127,57 @@ def get_parser():
     return parser
 
 
-def main():
+def main(argv=None):
     """Main function."""
     parser = get_parser()
-    args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
-    fname_image = os.path.abspath(args.i)
-    contrast_type = args.c
+    fname_image = os.path.abspath(arguments.i)
+    contrast_type = arguments.c
 
-    ctr_algo = args.centerline
+    ctr_algo = arguments.centerline
 
-    if args.brain is None:
+    if arguments.brain is None:
         if contrast_type in ['t2s', 'dwi']:
             brain_bool = False
         if contrast_type in ['t1', 't2']:
             brain_bool = True
     else:
-        brain_bool = bool(args.brain)
+        brain_bool = bool(arguments.brain)
 
-    if bool(args.brain) and ctr_algo == 'svm':
+    if bool(arguments.brain) and ctr_algo == 'svm':
         printv('Please only use the flag "-brain 1" with "-centerline cnn".', 1, 'warning')
         sys.exit(1)
 
-    kernel_size = args.kernel
+    kernel_size = arguments.kernel
     if kernel_size == '3d' and contrast_type == 'dwi':
         kernel_size = '2d'
         printv('3D kernel model for dwi contrast is not available. 2D kernel model is used instead.',
                    type="warning")
 
-    if ctr_algo == 'file' and args.file_centerline is None:
+    if ctr_algo == 'file' and arguments.file_centerline is None:
         printv('Please use the flag -file_centerline to indicate the centerline filename.', 1, 'warning')
         sys.exit(1)
 
-    if args.file_centerline is not None:
-        manual_centerline_fname = args.file_centerline
+    if arguments.file_centerline is not None:
+        manual_centerline_fname = arguments.file_centerline
         ctr_algo = 'file'
     else:
         manual_centerline_fname = None
 
-    threshold = args.thr
+    threshold = arguments.thr
     if threshold is not None:
         if threshold > 1.0 or (threshold < 0.0 and threshold != -1.0):
             raise SyntaxError("Threshold should be between 0 and 1, or equal to -1 (no threshold)")
 
-    remove_temp_files = args.r
-    verbose = args.v
-    init_sct(log_level=verbose, update=True)  # Update log level
+    remove_temp_files = arguments.r
 
-    path_qc = args.qc
-    qc_dataset = args.qc_dataset
-    qc_subject = args.qc_subject
-    output_folder = args.ofolder
+    path_qc = arguments.qc
+    qc_dataset = arguments.qc_dataset
+    qc_subject = arguments.qc_subject
+    output_folder = arguments.ofolder
 
     # check if input image is 2D or 3D
     check_dim(fname_image, dim_lst=[2, 3])
@@ -205,4 +205,4 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -82,11 +82,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
+        '-v',
+        metavar=Metavar.int,
         type=int,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1, 2))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -87,8 +87,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -8,7 +8,7 @@ from time import time
 import numpy as np
 import nibabel as nib
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, extract_fname
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, extract_fname, set_global_loglevel
 
 
 # DEFAULT PARAMETERS
@@ -91,7 +91,24 @@ def get_parser():
     return parser
 
 
-def main(file_to_denoise, param, output_file_name):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
+    parameter = arguments.p
+    remove_temp_files = arguments.r
+    noise_threshold = arguments.d
+
+    file_to_denoise = arguments.i
+    output_file_name = arguments.o
+    std_noise = arguments.std
+
+    param = Param()
+    param.verbose = verbose
+    param.remove_temp_files = remove_temp_files
+    param.parameter = parameter
 
     path, file, ext = extract_fname(file_to_denoise)
 
@@ -179,23 +196,5 @@ def main(file_to_denoise, param, output_file_name):
 # =======================================================================================================================
 if __name__ == "__main__":
     init_sct()
-    parser = get_parser()
-    # initialize parameters
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    main(sys.argv[1:])
 
-    parameter = arguments.p
-    remove_temp_files = arguments.r
-    noise_threshold = arguments.d
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
-
-    file_to_denoise = arguments.i
-    output_file_name = arguments.o
-    std_noise = arguments.std
-
-    param = Param()
-    param.verbose = verbose
-    param.remove_temp_files = remove_temp_files
-    param.parameter = parameter
-
-    main(file_to_denoise, param, output_file_name)

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -95,8 +95,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -90,12 +90,13 @@ def get_parser():
         default=1,
         choices=(0, 1))
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
@@ -257,9 +257,11 @@ class DetectPMJ:
         os.chdir(self.tmp_dir)  # go to tmp directory
 
 
-def main():
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # Set param arguments ad inputted by user
     fname_in = arguments.i
@@ -289,9 +291,6 @@ def main():
     # Remove temp folder
     rm_tmp = bool(arguments.r)
 
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
-
     # Initialize DetectPMJ
     detector = DetectPMJ(fname_im=fname_in,
                          contrast=contrast,
@@ -317,4 +316,5 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -93,11 +93,12 @@ def get_parser():
         choices=(0, 1))
     optional.add_argument(
         '-v',
+        metavar=Metavar.int,
         type=int,
-        help='Verbose.',
-        required=False,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -15,7 +15,7 @@ import os
 import argparse
 
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 from spinalcordtoolbox.image import add_suffix
 
@@ -102,16 +102,14 @@ def get_parser():
     return parser
 
 
-if __name__ == "__main__":
-    init_sct()
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     fname_input1 = arguments.i
     fname_input2 = arguments.d
-
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     tmp_dir = tmp_create()  # create tmp directory
     tmp_dir = os.path.abspath(tmp_dir)
@@ -177,3 +175,8 @@ if __name__ == "__main__":
         rmtree(tmp_dir)
 
     printv(output, verbose)
+
+
+if __name__ == "__main__":
+    init_sct()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -97,8 +97,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -18,13 +18,15 @@ import os
 import math
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 
 
-def main():
-    # Initialization
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     GYRO = float(42.576 * 10 ** 6)  # gyromagnetic ratio (in Hz.T^-1)
     gradamp = []
     bigdelta = []
@@ -85,6 +87,13 @@ def get_parser():
         "--help",
         action="help",
         help="Show this help message and exit")
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
+        required=False,
+        choices=(0, 1, 2),
+        default=1)
 
     return parser
 
@@ -94,5 +103,5 @@ def get_parser():
 # =======================================================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -93,8 +93,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -88,12 +88,13 @@ def get_parser():
         action="help",
         help="Show this help message and exit")
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -75,12 +75,13 @@ def get_parser():
         required=False,
         default='dti_')
     optional.add_argument(
-        "-v",
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        required=False,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1, 2))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -80,8 +80,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -14,19 +14,11 @@ import os
 import sys
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
-
-
-class Param:
-    def __init__(self):
-        self.verbose = 1
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 
 
 def get_parser():
-    param = Param()
-
     # Initialize the parser
-
     parser = argparse.ArgumentParser(
         description='Compute Diffusion Tensor Images (DTI) using dipy.',
         formatter_class=SmartFormatter,
@@ -87,7 +79,7 @@ def get_parser():
         help="Verbose. 0: nothing. 1: basic. 2: extended.",
         type=int,
         required=False,
-        default=param.verbose,
+        default=1,
         choices=(0, 1, 2))
 
     return parser
@@ -95,7 +87,12 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # initialization
     file_mask = ''
 
@@ -110,17 +107,15 @@ def main(args=None):
     evecs = arguments.evecs
     if arguments.m is not None:
         file_mask = arguments.m
-    param.verbose = arguments.v
-    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # compute DTI
-    if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):
+    if not compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask, verbose):
         printv('ERROR in compute_dti()', 1, 'error')
 
 
 # compute_dti
 # ==========================================================================================
-def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask):
+def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_mask, verbose):
     """
     Compute DTI.
     :param fname_in: input 4d file.
@@ -145,13 +140,13 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
 
     # mask and crop the data. This is a quick way to avoid calculating Tensors on the background of the image.
     if not file_mask == '':
-        printv('Open mask file...', param.verbose)
+        printv('Open mask file...', verbose)
         # open mask file
         nii_mask = Image(file_mask)
         mask = nii_mask.data
 
     # fit tensor model
-    printv('Computing tensor using "' + method + '" method...', param.verbose)
+    printv('Computing tensor using "' + method + '" method...', verbose)
     import dipy.reconst.dti as dti
     if method == 'standard':
         tenmodel = dti.TensorModel(gtab)
@@ -169,7 +164,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
             tenfit = dti_restore.fit(data, mask)
 
     # Compute metrics
-    printv('Computing metrics...', param.verbose)
+    printv('Computing metrics...', verbose)
     # FA
     nii.data = tenfit.fa
     nii.save(prefix + 'FA.nii.gz', dtype='float32')
@@ -195,11 +190,7 @@ def compute_dti(fname_in, fname_bvals, fname_bvecs, prefix, method, evecs, file_
     return True
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # initialize parameters
-    param = Param()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -95,8 +95,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -15,7 +15,7 @@ import argparse
 import numpy as np
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.image import Image, concat_data
 
 
@@ -89,21 +89,27 @@ def get_parser():
         action='help',
         help="Show this help message and exit",
     )
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
+        required=False,
+        choices=(0, 1, 2),
+        default=1)
 
     return parser
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
-    # get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # check number of input args
     if not len(arguments.i) == len(arguments.order):
@@ -151,5 +157,5 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -90,12 +90,13 @@ def get_parser():
         help="Show this help message and exit",
     )
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -14,7 +14,7 @@ import os
 import sys
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, set_global_loglevel
 
 
 def get_parser():
@@ -44,16 +44,25 @@ def get_parser():
         "-o",
         help='Output file with bvals merged. Example: dmri_b700_b2000_concat.bval',
         metavar=Metavar.file)
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
+        required=False,
+        choices=(0, 1, 2),
+        default=1)
 
     return parser
 
 
 # MAIN
 # ==========================================================================================
-def main():
-    # Get parser info
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     fname_bval_list = arguments.i
     # Build fname_out
     if arguments.o is not None:
@@ -81,9 +90,6 @@ def main():
     new_f.close()
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -50,8 +50,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -45,12 +45,13 @@ def get_parser():
         help='Output file with bvals merged. Example: dmri_b700_b2000_concat.bval',
         metavar=Metavar.file)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -14,7 +14,7 @@ import sys
 import os
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, set_global_loglevel
 
 
 def get_parser():
@@ -47,16 +47,25 @@ def get_parser():
         "-o",
         metavar=Metavar.file,
         help='Output file with bvecs concatenated. Example: dmri_b700_b2000_concat.bvec')
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
+        required=False,
+        choices=(0, 1, 2),
+        default=1)
 
     return parser
 
 
 # MAIN
 # ==========================================================================================
-def main():
-    # Get parser info
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     fname_bvecs_list = arguments.i
     # Build fname_out
     if arguments.o is not None:
@@ -103,9 +112,7 @@ def main():
     new_f.close()
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -53,8 +53,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -48,12 +48,13 @@ def get_parser():
         metavar=Metavar.file,
         help='Output file with bvecs concatenated. Example: dmri_b700_b2000_concat.bvec')
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -17,7 +17,7 @@ import argparse
 import matplotlib.pyplot as plt
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 
 bzero = 0.0001  # b-zero threshold
 
@@ -65,11 +65,12 @@ def plot_2dscatter(fig_handle=None, subplot=None, x=None, y=None, xlabel='X', yl
 # ==========================================================================================
 
 
-def main():
-
-    # Get parser info
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     fname_bvecs = arguments.bvec
 
     # Read bvecs
@@ -133,9 +134,7 @@ def main():
     plt.show()
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -134,11 +134,13 @@ def get_parser():
         help="Remove temporary files. 0 = no, 1 = yes"
     )
     optional.add_argument(
-        "-v",
-        choices=('0', '1', '2'),
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expanded",
-    )
+        '-v',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
     return parser
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -31,7 +31,7 @@ import os
 import argparse
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, set_global_loglevel
 
 
 def get_parser():
@@ -142,14 +142,16 @@ def get_parser():
     return parser
 
 
-def main():
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # initialization
     param = ParamMoco(is_diffusion=True, group_size=3, metric='MI', smooth='1')
 
     # Fetch user arguments
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     param.fname_data = arguments.i
     param.fname_bvecs = os.path.abspath(arguments.bvec)
     param.fname_bvals = arguments.bval
@@ -161,10 +163,6 @@ def main():
     param.remove_temp_files = arguments.r
     if arguments.param is not None:
         param.update(arguments.param)
-    param.verbose = int(arguments.v)
-
-    # Update log level
-    init_sct(log_level=param.verbose, update=True)
 
     # run moco
     moco_wrapper(param)
@@ -172,4 +170,5 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -139,8 +139,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
     return parser
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -108,8 +108,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
     return parser
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 
 from spinalcordtoolbox.scripts.sct_image import split_data, concat_data
@@ -113,21 +113,18 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # initialize parameters
     param = Param()
-    # call main function
-    parser = get_parser()
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     fname_data = arguments.i
     fname_bvecs = arguments.bvec
     average = arguments.a
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
     remove_temp_files = arguments.r
     path_out = arguments.ofolder
 
@@ -309,8 +306,7 @@ def identify_b0(fname_bvecs, fname_bvals, bval_min, verbose):
     return index_b0, index_dwi, nb_b0, nb_dwi
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -104,10 +104,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=('0', '1'),
-        default=param_default.verbose,
-        help='Verbose. 0 = nothing, 1 = expanded',
-    )
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
     return parser
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -64,8 +64,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -60,9 +60,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = basic, 2 = extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -26,7 +26,7 @@ import os
 import sys
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, printv, set_global_loglevel
 
 
 def get_parser():
@@ -70,18 +70,14 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
-
+def main(argv=None):
     parser = get_parser()
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     fname_in = arguments.bvec
     fname_out = arguments.o
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     # get bvecs in proper orientation
     from dipy.io import read_bvals_bvecs
@@ -105,9 +101,7 @@ def main(args=None):
     printv('Created file:\n--> ' + fname_out + '\n', verbose, 'info')
 
 
-# Start program
-# =======================================================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -133,9 +133,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -16,10 +16,88 @@ import argparse
 
 from spinalcordtoolbox.download import install_data
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 
-def get_parser(dict_url):
+# Dictionary containing list of URLs for data names.
+# Mirror servers are listed in order of decreasing priority.
+# If exists, favour release artifact straight from github
+DICT_URL = {
+    "sct_example_data": [
+        "https://github.com/sct-data/sct_example_data/releases/download/r20180525/20180525_sct_example_data.zip",
+        "https://osf.io/kjcgs/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip",
+    ],
+    "sct_testing_data": [
+        "https://github.com/sct-data/sct_testing_data/releases/download/r20201030/sct_testing_data-r20201030.zip",
+        "https://osf.io/download/5f9c271187b7df04593b03e0/"],
+    "PAM50": [
+        "https://github.com/sct-data/PAM50/releases/download/r20201104/PAM50-r20201104.zip",
+        "https://osf.io/download/5fa21326a5bb9d00610a5a21/"],
+    "MNI-Poly-AMU": [
+        "https://github.com/sct-data/MNI-Poly-AMU/releases/download/r20170310/20170310_MNI-Poly-AMU.zip",
+        "https://osf.io/sh6h4/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip",
+    ],
+    "gm_model": [
+        "https://osf.io/ugscu/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip",
+    ],
+    "optic_models": [
+        "https://github.com/sct-data/optic_models/releases/download/r20170413/20170413_optic_models.zip",
+        "https://osf.io/g4fwn/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip",
+    ],
+    "pmj_models": [
+        "https://github.com/sct-data/pmj_models/releases/download/r20170922/20170922_pmj_models.zip",
+        "https://osf.io/4gufr/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip",
+    ],
+    "binaries_linux": [
+        "https://osf.io/cs6zt/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20200801_sct_binaries_linux.tar.gz",
+    ],
+    "binaries_osx": [
+        "https://osf.io/874cy?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20200801_sct_binaries_osx.tar.gz",
+    ],
+    "course_hawaii17": "https://osf.io/6exht/?action=download",
+    "course_paris18": [
+        "https://osf.io/9bmn5/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip",
+    ],
+    "course_london19": [
+        "https://osf.io/4q3u7/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip",
+    ],
+    "course_beijing19": [
+        "https://osf.io/ef4xz/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip",
+    ],
+    "deepseg_gm_models": [
+        "https://github.com/sct-data/deepseg_gm_models/releases/download/r20180205/20180205_deepseg_gm_models.zip",
+        "https://osf.io/b9y4x/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip",
+    ],
+    "deepseg_sc_models": [
+        "https://github.com/sct-data/deepseg_sc_models/releases/download/r20180610/20180610_deepseg_sc_models.zip",
+        "https://osf.io/avf97/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip",
+    ],
+    "deepseg_lesion_models": [
+        "https://github.com/sct-data/deepseg_lesion_models/releases/download/r20180613/20180613_deepseg_lesion_models.zip",
+        "https://osf.io/eg7v9/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip",
+    ],
+    "c2c3_disc_models": [
+        "https://github.com/sct-data/c2c3_disc_models/releases/download/r20190117/20190117_c2c3_disc_models.zip",
+        "https://osf.io/t97ap/?action=download",
+        "https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip",
+    ],
+}
+
+
+def get_parser():
     parser = argparse.ArgumentParser(
         description="Download binaries from the web.",
         formatter_class=SmartFormatter,
@@ -30,7 +108,7 @@ def get_parser(dict_url):
     mandatory.add_argument(
         '-d',
         required=True,
-        choices=list(dict_url.keys()),
+        choices=list(DICT_URL.keys()),
         help=f"Name of the dataset."
     )
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
@@ -63,107 +141,25 @@ def get_parser(dict_url):
     return parser
 
 
-def main(args=None):
-
-    # Dictionary containing list of URLs for data names.
-    # Mirror servers are listed in order of decreasing priority.
-    # If exists, favour release artifact straight from github
-    dict_url = {
-        "sct_example_data": [
-            "https://github.com/sct-data/sct_example_data/releases/download/r20180525/20180525_sct_example_data.zip",
-            "https://osf.io/kjcgs/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180525_sct_example_data.zip",
-        ],
-        "sct_testing_data": [
-            "https://github.com/sct-data/sct_testing_data/releases/download/r20201030/sct_testing_data-r20201030.zip",
-            "https://osf.io/download/5f9c271187b7df04593b03e0/"],
-        "PAM50": [
-            "https://github.com/sct-data/PAM50/releases/download/r20201104/PAM50-r20201104.zip", 
-            "https://osf.io/download/5fa21326a5bb9d00610a5a21/"],
-        "MNI-Poly-AMU": [
-            "https://github.com/sct-data/MNI-Poly-AMU/releases/download/r20170310/20170310_MNI-Poly-AMU.zip",
-            "https://osf.io/sh6h4/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20170310_MNI-Poly-AMU.zip",
-        ],
-        "gm_model": [
-            "https://osf.io/ugscu/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20160922_gm_model.zip",
-        ],
-        "optic_models": [
-            "https://github.com/sct-data/optic_models/releases/download/r20170413/20170413_optic_models.zip",
-            "https://osf.io/g4fwn/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20170413_optic_models.zip",
-        ],
-        "pmj_models": [
-            "https://github.com/sct-data/pmj_models/releases/download/r20170922/20170922_pmj_models.zip",
-            "https://osf.io/4gufr/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20170922_pmj_models.zip",
-        ],
-        "binaries_linux": [
-            "https://osf.io/cs6zt/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200801_sct_binaries_linux.tar.gz",
-        ],
-        "binaries_osx": [
-            "https://osf.io/874cy?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20200801_sct_binaries_osx.tar.gz",
-        ],
-        "course_hawaii17": "https://osf.io/6exht/?action=download",
-        "course_paris18": [
-            "https://osf.io/9bmn5/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180612_sct_course-paris18.zip",
-        ],
-        "course_london19": [
-            "https://osf.io/4q3u7/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20190121_sct_course-london19.zip",
-        ],
-        "course_beijing19": [
-            "https://osf.io/ef4xz/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20190802_sct_course-beijing19.zip",
-        ],
-        "deepseg_gm_models": [
-            "https://github.com/sct-data/deepseg_gm_models/releases/download/r20180205/20180205_deepseg_gm_models.zip",
-            "https://osf.io/b9y4x/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180205_deepseg_gm_models.zip",
-        ],
-        "deepseg_sc_models": [
-            "https://github.com/sct-data/deepseg_sc_models/releases/download/r20180610/20180610_deepseg_sc_models.zip",
-            "https://osf.io/avf97/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180610_deepseg_sc_models.zip",
-        ],
-        "deepseg_lesion_models": [
-            "https://github.com/sct-data/deepseg_lesion_models/releases/download/r20180613/20180613_deepseg_lesion_models.zip",
-            "https://osf.io/eg7v9/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20180613_deepseg_lesion_models.zip",
-        ],
-        "c2c3_disc_models": [
-            "https://github.com/sct-data/c2c3_disc_models/releases/download/r20190117/20190117_c2c3_disc_models.zip",
-            "https://osf.io/t97ap/?action=download",
-            "https://www.neuro.polymtl.ca/_media/downloads/sct/20190117_c2c3_disc_models.zip",
-        ],
-    }
-
-    parser = get_parser(dict_url)
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     data_name = arguments.d
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
     if arguments.o is not None:
         dest_folder = arguments.o
     else:
         dest_folder = os.path.join(os.path.abspath(os.curdir), data_name)
 
-    url = dict_url[data_name]
+    url = DICT_URL[data_name]
     install_data(url, dest_folder, keep=arguments.k)
 
     printv('Done!\n', verbose)
-    return 0
 
 
 if __name__ == "__main__":
     init_sct()
-    res = main()
-    raise SystemExit(res)
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -137,8 +137,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -210,9 +210,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=("0", "1"),
-        default="1",
-        help="Verbose. 0 = nothing, 1 = expanded"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     advanced = parser.add_argument_group("\nFOR ADVANCED USERS")

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -214,8 +214,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     advanced = parser.add_argument_group("\nFOR ADVANCED USERS")

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -27,7 +27,7 @@ from spinalcordtoolbox.metadata import read_label_file
 from spinalcordtoolbox.aggregate_slicewise import check_labels, extract_metric, save_as_csv, Metric, LabelStruc
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, list_type, parse_num_list, display_open
-from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__
+from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import check_file_exist, extract_fname, get_absolute_path
 
 
@@ -48,7 +48,7 @@ class Param:
 class _ListLabelsAction(argparse.Action):
     """This class makes it possible to call the flag '-list-labels' without the need to input the required '-i'."""
     def __call__(self, parser, namespace, values, option_string=None):
-        file_label = os.path.join(namespace.f, param_default.file_info_label)
+        file_label = os.path.join(namespace.f, Param().file_info_label)
         check_file_exist(file_label, 0)
         with open(file_label, 'r') as default_info_label:
             label_references = default_info_label.read()
@@ -264,31 +264,34 @@ def get_parser():
     return parser
 
 
-def main(fname_data, path_label, method, slices, levels, fname_output, labels_user, append_csv,
-         fname_vertebral_labeling="", perslice=1, perlevel=1, verbose=1, combine_labels=True):
-    """
-    Extract metrics from MRI data based on mask (could be single file of folder to atlas)
-    :param fname_data: data to extract metric from
-    :param path_label: mask: could be single file or folder to atlas (which contains info_label.txt)
-    :param method {'wa', 'bin', 'ml', 'map'}
-    :param slices. Slices of interest. Accepted format:
-           "0,1,2,3": slices 0,1,2,3
-           "0:3": slices 0,1,2,3
-    :param levels: Vertebral levels to extract metrics from. Should be associated with a template
-           (e.g. PAM50/template/) or a specified file: fname_vertebral_labeling. Same format as slices_of_interest.
-    :param fname_output:
-    :param labels_user:
-    :param append_csv: Append to csv file
-    :param fname_normalizing_label:
-    :param fname_vertebral_labeling: vertebral labeling to be used with vertebral_levels
-    :param perslice: if user selected several slices, then the function outputs a metric within each slice
-           instead of a single average output.
-    :param perlevel: if user selected several levels, then the function outputs a metric within each vertebral level
-           instead of a single average output.
-    :param verbose
-    :param combine_labels: bool: Combine labels into a single value
-    :return:
-    """
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
+    param_default = Param()
+
+    overwrite = 0  # TODO: Not used. Why?
+    fname_data = get_absolute_path(arguments.i)
+    path_label = arguments.f
+    method = arguments.method
+    fname_output = arguments.o
+    append_csv = arguments.append
+    combine_labels = arguments.combine
+    labels_user = arguments.l
+    adv_param_user = arguments.param  # TODO: Not used. Why?
+    slices = parse_num_list(arguments.z)
+    levels = parse_num_list(arguments.vert)
+    fname_vertebral_labeling = arguments.vertfile
+    perslice = arguments.perslice
+    perlevel = arguments.perlevel
+    fname_normalizing_label = arguments.norm_file  # TODO: Not used. Why?
+    normalization_method = arguments.norm_method  # TODO: Not used. Why?
+    label_to_fix = arguments.fix_label  # TODO: Not used. Why?
+    fname_output_metric_map = arguments.output_map  # TODO: Not used. Why?
+    fname_mask_weight = arguments.mask_weighted  # TODO: Not used. Why?
+    discard_negative_values = int(arguments.discard_neg_val)  # TODO: Not used. Why?
 
     # check if path_label is a file (e.g., single binary mask) instead of a folder (e.g., SCT atlas structure which
     # contains info_label.txt file)
@@ -356,7 +359,7 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
         labels_tmp[i_label] = np.expand_dims(im_label.data, 3)  # TODO: generalize to 2D input label
     labels = np.concatenate(labels_tmp[:], 3)  # labels: (x,y,z,label)
     # Load vertebral levels
-    if vertebral_levels:
+    if levels:
         im_vertebral_labeling = Image(fname_vertebral_labeling).change_orientation("RPI")
     else:
         im_vertebral_labeling = None
@@ -388,39 +391,6 @@ def main(fname_data, path_label, method, slices, levels, fname_output, labels_us
 
 
 if __name__ == "__main__":
-
     init_sct()
+    main(sys.argv[1:])
 
-    param_default = Param()
-
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-
-    overwrite = 0  # TODO: Not used. Why?
-    fname_data = get_absolute_path(arguments.i)
-    path_label = arguments.f
-    method = arguments.method
-    fname_output = arguments.o
-    append_csv = arguments.append
-    combine_labels = arguments.combine
-    labels_user = arguments.l
-    adv_param_user = arguments.param  # TODO: Not used. Why?
-    slices_of_interest = arguments.z
-    vertebral_levels = arguments.vert
-    fname_vertebral_labeling = arguments.vertfile
-    perslice = arguments.perslice
-    perlevel = arguments.perlevel
-    fname_normalizing_label = arguments.norm_file  # TODO: Not used. Why?
-    normalization_method = arguments.norm_method  # TODO: Not used. Why?
-    label_to_fix = arguments.fix_label  # TODO: Not used. Why?
-    fname_output_metric_map = arguments.output_map  # TODO: Not used. Why?
-    fname_mask_weight = arguments.mask_weighted  # TODO: Not used. Why?
-    discard_negative_values = int(arguments.discard_neg_val)  # TODO: Not used. Why?
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
-
-    # call main function
-    main(fname_data=fname_data, path_label=path_label, method=method, slices=parse_num_list(slices_of_interest),
-         levels=parse_num_list(vertebral_levels), fname_output=fname_output, labels_user=labels_user,
-         append_csv=append_csv, fname_vertebral_labeling=fname_vertebral_labeling, perslice=perslice,
-         perlevel=perlevel, verbose=verbose, combine_labels=combine_labels)

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -17,16 +17,14 @@ import argparse
 import logging
 
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
 from spinalcordtoolbox.flattening import flatten_sagittal
 
 logger = logging.getLogger(__name__)
 
+
 # Default parameters
-
-
 class Param:
-    # The constructor
     def __init__(self):
         self.debug = 0
         self.interp = 'sinc'  # final interpolation
@@ -34,7 +32,7 @@ class Param:
         self.verbose = 1
 
 
-def main(fname_anat, fname_centerline, verbose):
+def main(argv=None):
     """
     Main function
     :param fname_anat:
@@ -42,6 +40,14 @@ def main(fname_anat, fname_centerline, verbose):
     :param verbose:
     :return:
     """
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
+    fname_anat = arguments.i
+    fname_centerline = arguments.s
+
     # load input images
     im_anat = Image(fname_anat)
     im_centerline = Image(fname_centerline)
@@ -88,7 +94,7 @@ def get_parser():
     optional.add_argument(
         '-v',
         choices=['0', '1', '2'],
-        default=str(param_default.verbose),
+        default=str(Param().verbose),
         help="Verbosity. 0: no verbose (default), 1: min verbose, 2: verbose + figures"
     )
 
@@ -97,16 +103,5 @@ def get_parser():
 
 if __name__ == "__main__":
     init_sct()
-    # initialize parameters
-    param = Param()
-    param_default = Param()
+    main(sys.argv[1:])
 
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-    fname_anat = arguments.i
-    fname_centerline = arguments.s
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
-
-    # call main function
-    main(fname_anat, fname_centerline, verbose)

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -97,8 +97,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -93,9 +93,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default=str(Param().verbose),
-        help="Verbosity. 0: no verbose (default), 1: min verbose, 2: verbose + figures"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -87,9 +87,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbosity. 0: None, 1: Verbose"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
     optional.add_argument(
         '-o',

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -19,7 +19,7 @@ import argparse
 import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
 
 
 class Param:
@@ -102,29 +102,26 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
-
+def main(argv=None):
     parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     param = Param()
 
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     fname_src = arguments.i
     if arguments.o is not None:
         fname_dst = arguments.o
     else:
         fname_dst = add_suffix(fname_src, "_tsnr")
 
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
-
     # call main function
     tsnr = Tsnr(param=param, fmri=fname_src, out=fname_dst)
     tsnr.compute()
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    param = Param()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -91,8 +91,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
     optional.add_argument(
         '-o',

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -115,8 +115,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -111,9 +111,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = basic, 2 = extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -16,7 +16,7 @@ import os
 import argparse
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, set_global_loglevel
 
 
 def get_parser():
@@ -119,14 +119,16 @@ def get_parser():
     return parser
 
 
-def main():
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # initialization
     param = ParamMoco(group_size=1, metric='MeanSquares', smooth='0')
 
     # Fetch user arguments
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
     param.fname_data = arguments.i
     param.path_out = arguments.ofolder
     param.remove_temp_files = arguments.r
@@ -137,10 +139,6 @@ def main():
         param.fname_mask = arguments.m
     if arguments.param is not None:
         param.update(arguments.param)
-    param.verbose = int(arguments.v)
-
-    # Update log level
-    init_sct(log_level=param.verbose, update=True)
 
     # run moco
     moco_wrapper(param)
@@ -148,4 +146,5 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -99,8 +99,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
     optional.add_argument(
         "-qc",

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -10,7 +10,7 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
@@ -95,8 +95,10 @@ def get_parser():
     )
     optional.add_argument(
         "-v",
-        choices=['0', '1'],
-        default='1',
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1],
+        default=1,
         help="Verbose. 1: display on, 0: display off (default)"
     )
     optional.add_argument(
@@ -118,10 +120,11 @@ def get_parser():
     return parser
 
 
-def run_main():
-    init_sct()
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # Input filename
     fname_input_data = arguments.i
@@ -152,9 +155,6 @@ def run_main():
     else:
         path_data, file_data, ext_data = extract_fname(fname_data)
         file_output = os.path.join(path_data, file_data + '_centerline')
-
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     if method == 'viewer':
         # Manual labeling of cord centerline
@@ -192,5 +192,7 @@ def run_main():
     display_viewer_syntax([fname_input_data, file_output + '.nii.gz'], colormaps=['gray', 'red'], opacities=['', '0.7'])
 
 
-if __name__ == '__main__':
-    run_main()
+if __name__ == "__main__":
+    init_sct()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -94,12 +94,13 @@ def get_parser():
         help="File name of ground-truth centerline or segmentation (binary nifti)."
     )
     optional.add_argument(
-        "-v",
+        '-v',
         metavar=Metavar.int,
         type=int,
-        choices=[0, 1],
+        choices=[0, 1, 2],
         default=1,
-        help="Verbose. 1: display on, 0: display off (default)"
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
     optional.add_argument(
         "-qc",

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -149,11 +149,13 @@ def get_parser():
     misc = parser.add_argument_group('Misc')
     misc.add_argument(
         '-v',
+        metavar=Metavar.int,
         type=int,
-        help='Verbose. 0: nothing. 1: basic. 2: extended.',
-        required=False,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1, 2))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+    )
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -20,7 +20,7 @@ from nibabel.processing import resample_from_to
 
 from spinalcordtoolbox.image import Image, concat_data, add_suffix, change_orientation, concat_warp2d, split_img_data, pad_image
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, rmtree
 
 
@@ -158,25 +158,23 @@ def get_parser():
     return parser
 
 
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # initializations
     output_type = None
     dim_list = ['x', 'y', 'z', 't']
 
-    # Get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
-    parser = get_parser()
-    arguments = parser.parse_args(args=args)
     fname_in = arguments.i
     n_in = len(fname_in)
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     if arguments.o is not None:
         fname_out = arguments.o
@@ -533,4 +531,5 @@ def visualize_warp(fname_warp, fname_grid=None, step=3, rm_tmp=True):
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -153,8 +153,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -196,8 +196,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -27,7 +27,8 @@ import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv, parse_num_list
+from spinalcordtoolbox.utils import (Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv,
+                                     parse_num_list, set_global_loglevel)
 from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 
@@ -222,15 +223,11 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
     parser = get_parser()
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-
-    verbosity = arguments.v
-    init_sct(log_level=verbosity, update=True)  # Update log level
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     input_filename = arguments.i
     output_fname = arguments.o
@@ -253,7 +250,7 @@ def main(args=None):
     elif arguments.cubic_to_point:
         out = sct_labels.cubic_to_point(img)
     elif arguments.display:
-        display_voxel(img, verbosity)
+        display_voxel(img, verbose)
         return
     elif arguments.increment:
         out = sct_labels.increment_z_inverse(img)
@@ -303,7 +300,7 @@ def main(args=None):
     display_viewer_syntax([input_filename, output_fname])
 
     if arguments.qc is not None:
-        generate_qc(fname_in1=input_filename, fname_seg=output_fname, args=args,
+        generate_qc(fname_in1=input_filename, fname_seg=output_fname, args=argv,
                     path_qc=os.path.abspath(arguments.qc), dataset=arguments.qc_dataset,
                     subject=arguments.qc_subject, process='sct_label_utils')
 
@@ -392,5 +389,5 @@ def launch_manual_label_gui(img: Image, input_labels_img: Image, labels: Sequenc
 
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -192,11 +192,12 @@ def get_parser():
 
     optional.add_argument(
         '-v',
-        choices=[0, 1, 2],
-        default=1,
         metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     optional.add_argument(

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -205,8 +205,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
     optional.add_argument(
         '-qc',

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -24,7 +24,7 @@ from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import create_labels_along_segmentation
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, cache_signature, cache_valid, cache_save, \
     copy, extract_fname, rmtree
 
@@ -218,7 +218,11 @@ def get_parser():
     return parser
 
 
-def main(args=None):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # initializations
     initz = ''
@@ -226,13 +230,6 @@ def main(args=None):
     fname_initlabel = ''
     file_labelz = 'labelz.nii.gz'
     param = Param()
-
-    # check user arguments
-    parser = get_parser()
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     fname_in = os.path.abspath(arguments.i)
     fname_seg = os.path.abspath(arguments.s)
@@ -268,8 +265,6 @@ def main(args=None):
         fname_initlabel = os.path.abspath(arguments.initlabel)
     if arguments.param is not None:
         param.update(arguments.param[0])
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
     remove_temp_files = arguments.r
     laplacian = arguments.laplacian
 
@@ -300,7 +295,7 @@ def main(args=None):
         # apply straightening
         s, o = run_proc(['sct_apply_transfo', '-i', 'data.nii', '-w', 'warp_curve2straight.nii.gz', '-d', 'straight_ref.nii.gz', '-o', 'data_straight.nii'])
     else:
-        sct_straighten_spinalcord.main(args=[
+        sct_straighten_spinalcord.main(argv=[
             '-i', 'data.nii',
             '-s', 'segmentation.nii',
             '-r', str(remove_temp_files),
@@ -451,7 +446,7 @@ def main(args=None):
         qc_dataset = arguments.qc_dataset
         qc_subject = arguments.qc_subject
         labeled_seg_file = os.path.join(path_output, file_seg + '_labeled' + ext_seg)
-        generate_qc(fname_in, fname_seg=labeled_seg_file, args=args, path_qc=os.path.abspath(path_qc),
+        generate_qc(fname_in, fname_seg=labeled_seg_file, args=argv, path_qc=os.path.abspath(path_qc),
                     dataset=qc_dataset, subject=qc_subject, process='sct_label_vertebrae')
 
     display_viewer_syntax([fname_in, fname_seg_labeled], colormaps=['', 'subcortical'], opacities=['1', '0.5'])
@@ -459,5 +454,5 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -193,9 +193,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
     optional.add_argument(
         '-qc',

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import spinalcordtoolbox.math as sct_math
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
@@ -246,23 +246,21 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     dim_list = ['x', 'y', 'z', 't']
 
-    # Get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
-    parser = get_parser()
-    arguments = parser.parse_args(args=args)
     fname_in = arguments.i
     fname_out = arguments.o
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
     output_type = arguments.type
 
     # Open file(s)
@@ -509,4 +507,5 @@ def compute_similarity(img1: Image, img2: Image, fname_out: str, metric: str, me
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -239,8 +239,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -233,13 +233,14 @@ def get_parser():
         help='Output type.',
         choices=('uint8', 'int16', 'int32', 'float32', 'complex64', 'float64', 'int8', 'uint16', 'uint32', 'int64',
                  'uint64'))
-    misc.add_argument(
-        "-v",
+    optional.add_argument(
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing. 1: basic. 2: extended.",
-        required=False,
+        choices=[0, 1, 2],
         default=1,
-        choices=(0, 1, 2))
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -92,13 +92,14 @@ def get_parser():
         required=False,
         default=Param().rm_tmp,
         choices=(0, 1))
-    misc.add_argument(
-        "-v",
+    optional.add_argument(
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
-        required=False,
-        choices=(0, 1, 2),
-        default=str(Param().verbose))
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree
 
 from spinalcordtoolbox.scripts import sct_maths
@@ -141,7 +141,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
     for fname_src in list_fname_src:
 
         # apply transformation src --> dest
-        sct_apply_transfo.main(args=[
+        sct_apply_transfo.main(argv=[
             '-i', fname_src,
             '-d', fname_dest,
             '-w', list_fname_warp[i_file],
@@ -149,13 +149,13 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
             '-o', 'src_' + str(i_file) + '_template.nii.gz',
             '-v', str(param.verbose)])
         # create binary mask from input file by assigning one to all non-null voxels
-        sct_maths.main(args=[
+        sct_maths.main(argv=[
             '-i', fname_src,
             '-bin', str(param.almost_zero),
             '-o', 'src_' + str(i_file) + 'native_bin.nii.gz'])
 
         # apply transformation to binary mask to compute partial volume
-        sct_apply_transfo.main(args=[
+        sct_apply_transfo.main(argv=[
             '-i', 'src_' + str(i_file) + 'native_bin.nii.gz',
             '-d', fname_dest,
             '-w', list_fname_warp[i_file],
@@ -182,13 +182,14 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
 
 # MAIN
 # ==========================================================================================
-def main():
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     # create param objects
     param = Param()
-
-    # get parser
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     # set param arguments ad inputted by user
     list_fname_src = arguments.i
@@ -202,8 +203,6 @@ def main():
         param.interp = arguments.x
     if arguments.r is not None:
         param.rm_tmp = arguments.r
-    param.verbose = arguments.v
-    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     # check if list of input files and warping fields have same length
     assert len(list_fname_src) == len(list_fname_warp), "ERROR: list of files are not of the same length"
@@ -219,4 +218,5 @@ def main():
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -98,8 +98,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -176,9 +176,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbosity. 1: display on, 0: display off (default)"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -180,8 +180,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -29,7 +29,7 @@ from spinalcordtoolbox.process_seg import compute_shape
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, parse_num_list, display_open
-from spinalcordtoolbox.utils.sys import init_sct
+from spinalcordtoolbox.utils.sys import init_sct, set_global_loglevel
 from spinalcordtoolbox.utils.fs import get_absolute_path
 
 
@@ -264,12 +264,11 @@ def _make_figure(metric, fit_results):
     return fname_img
 
 
-def main(args=None):
+def main(argv=None):
     parser = get_parser()
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # Initialization
     slices = ''
@@ -311,9 +310,6 @@ def main(args=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
 
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
-
     # update fields
     metrics_agg = {}
     if not file_out:
@@ -350,5 +346,4 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    # call main function
     main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -340,7 +340,7 @@ def main(argv=None):
 
     # QC report (only show CSA for clarity)
     if path_qc is not None:
-        generate_qc(fname_segmentation, args=args, path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
+        generate_qc(fname_segmentation, args=arguments, path_qc=os.path.abspath(path_qc), dataset=qc_dataset,
                     subject=qc_subject, path_img=_make_figure(metrics_agg_merged, fit_results),
                     process='sct_process_segmentation')
 

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -232,9 +232,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 1: display on, 0: display off (default)"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
     optional.add_argument(
         '-mesh',

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -236,8 +236,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
     optional.add_argument(
         '-mesh',

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -23,7 +23,7 @@ from scipy import ndimage as ndi
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, mv, copy
 from spinalcordtoolbox.centerline import optic
 from spinalcordtoolbox.reports.qc import generate_qc
@@ -455,7 +455,6 @@ def propseg(img_input, options_dict):
     remove_temp_files = arguments.r
 
     verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
     # Update for propseg binary
     if verbose > 0:
         cmd += ["-verbose"]
@@ -654,7 +653,12 @@ def propseg(img_input, options_dict):
     return Image(fname_seg)
 
 
-def main(arguments):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     fname_input_data = os.path.abspath(arguments.i)
     img_input = Image(fname_input_data)
     img_seg = propseg(img_input, arguments)
@@ -670,7 +674,5 @@ def main(arguments):
 
 if __name__ == "__main__":
     init_sct()
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-    res = main(arguments)
-    raise SystemExit(res)
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -8,9 +8,10 @@
 #
 # About the license: see the file LICENSE.TXT
 
+import sys
 import argparse
 
-from spinalcordtoolbox.utils import init_sct
+from spinalcordtoolbox.utils import init_sct, set_global_loglevel
 
 
 def get_parser():
@@ -62,26 +63,30 @@ def get_parser():
     return parser
 
 
-def main(args):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     from spinalcordtoolbox.reports.qc import generate_qc
-
     # Build args list (for display)
-    args_disp = '-i ' + args.i
-    if args.d:
-        args_disp += ' -d ' + args.d
-    if args.s:
-        args_disp += ' -s ' + args.s
-    generate_qc(fname_in1=args.i,
-                fname_in2=args.d,
-                fname_seg=args.s,
+    args_disp = '-i ' + arguments.i
+    if arguments.d:
+        args_disp += ' -d ' + arguments.d
+    if arguments.s:
+        args_disp += ' -s ' + arguments.s
+    generate_qc(fname_in1=arguments.i,
+                fname_in2=arguments.d,
+                fname_seg=arguments.s,
                 args=args_disp,
-                path_qc=args.qc,
-                dataset=args.qc_dataset,
-                subject=args.qc_subject,
-                process=args.p)
+                path_qc=arguments.qc,
+                dataset=arguments.qc_dataset,
+                subject=arguments.qc_subject,
+                process=arguments.p)
 
 
-if __name__ == '__main__':
-    arguments = get_parser().parse_args()
-    init_sct(log_level=2 if arguments.v else 1)
-    main(arguments)
+if __name__ == "__main__":
+    init_sct()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -41,22 +41,21 @@ import numpy as np
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.registration.register import Paramreg, ParamregMultiStep
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import check_dim
 
 from spinalcordtoolbox.scripts.sct_register_to_template import register_wrapper
 
+# Default registration parameters
+step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5',
+                 slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
+step1 = Paramreg(step='1', type='im')
+paramregmulti = ParamregMultiStep([step0, step1])
 
-def get_parser(paramregmulti=None):
+
+def get_parser():
     # Initialize the parser
-
-    if paramregmulti is None:
-        step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5',
-                         slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
-        step1 = Paramreg(step='1', type='im')
-        paramregmulti = ParamregMultiStep([step0, step1])
-
     parser = argparse.ArgumentParser(
         description="This program co-registers two 3D volumes. The deformation is non-rigid and is constrained along "
                     "Z direction (i.e., axial plane). Hence, this function assumes that orientation of the destination "
@@ -298,9 +297,11 @@ class Param:
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
-    if args is None:
-        args = sys.argv[1:]
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # initialize parameters
     param = Param()
@@ -315,17 +316,6 @@ def main(args=None):
     generate_warpinv = 1
 
     start_time = time.time()
-
-    # get default registration parameters
-    # step1 = Paramreg(step='1', type='im', algo='syn', metric='MI', iter='5', shrink='1', smooth='0', gradStep='0.5')
-    step0 = Paramreg(step='0', type='im', algo='syn', metric='MI', iter='0', shrink='1', smooth='0', gradStep='0.5',
-                     slicewise='0', dof='Tx_Ty_Tz_Rx_Ry_Rz')  # only used to put src into dest space
-    step1 = Paramreg(step='1', type='im')
-    paramregmulti = ParamregMultiStep([step0, step1])
-
-    parser = get_parser(paramregmulti=paramregmulti)
-
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     # get arguments
     fname_src = arguments.i
@@ -371,8 +361,6 @@ def main(args=None):
     identity = arguments.identity
     interp = arguments.x
     remove_temp_files = arguments.r
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     # printv(arguments)
     printv('\nInput parameters:')
@@ -427,7 +415,7 @@ def main(args=None):
 
     if path_qc is not None:
         if fname_dest_seg:
-            generate_qc(fname_src2dest, fname_in2=fname_dest, fname_seg=fname_dest_seg, args=args,
+            generate_qc(fname_src2dest, fname_in2=fname_dest, fname_seg=fname_dest_seg, args=argv,
                         path_qc=os.path.abspath(path_qc), dataset=qc_dataset, subject=qc_subject,
                         process='sct_register_multimodal')
         else:
@@ -438,9 +426,6 @@ def main(args=None):
     display_viewer_syntax([fname_dest, fname_src2dest], verbose=verbose)
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -277,9 +277,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose. 0: nothing, 1: basic, 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -281,8 +281,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -269,9 +269,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default=param.verbose,
-        help="Verbose. 0: nothing. 1: basic. 2: extended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -279,17 +279,14 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # initializations
     param = Param()
-
-    # check user arguments
-    parser = get_parser()
-    if args:
-        arguments = parser.parse_args(args)
-    else:
-        arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     fname_data = arguments.i
     fname_seg = arguments.s
@@ -316,8 +313,6 @@ def main(args=None):
     contrast_template = arguments.c
     ref = arguments.ref
     param.remove_temp_files = arguments.r
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
     param.verbose = verbose  # TODO: not clean, unify verbose or param.verbose in code, but not both
     param_centerline = ParamCenterline(
         algo_fitting=arguments.centerline_algo,
@@ -516,7 +511,7 @@ def main(args=None):
             copy(fn_warp_straight2curve, 'warp_straight2curve.nii.gz')
             copy(fn_straight_ref, 'straight_ref.nii.gz')
             # apply straightening
-            sct_apply_transfo.main(args=[
+            sct_apply_transfo.main(argv=[
                 '-i', ftmp_seg,
                 '-w', 'warp_curve2straight.nii.gz',
                 '-d', 'straight_ref.nii.gz',
@@ -565,7 +560,7 @@ def main(args=None):
 
             # Apply straightening to labels
             printv('\nApply straightening to labels...', verbose)
-            sct_apply_transfo.main(args=[
+            sct_apply_transfo.main(argv=[
                 '-i', ftmp_label,
                 '-o', add_suffix(ftmp_label, '_straight'),
                 '-d', add_suffix(ftmp_seg, '_straight'),
@@ -593,13 +588,13 @@ def main(args=None):
 
         # Apply transformation
         printv('\nApply transformation...', verbose)
-        sct_apply_transfo.main(args=[
+        sct_apply_transfo.main(argv=[
             '-i', ftmp_data,
             '-o', add_suffix(ftmp_data, '_straightAffine'),
             '-d', ftmp_template,
             '-w', 'warp_curve2straightAffine.nii.gz'])
         ftmp_data = add_suffix(ftmp_data, '_straightAffine')
-        sct_apply_transfo.main(args=[
+        sct_apply_transfo.main(argv=[
             '-i', ftmp_seg,
             '-o', add_suffix(ftmp_seg, '_straightAffine'),
             '-d', ftmp_template,
@@ -766,7 +761,7 @@ def main(args=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
     if param.path_qc is not None:
-        generate_qc(fname_data, fname_in2=fname_template2anat, fname_seg=fname_seg, args=args,
+        generate_qc(fname_data, fname_in2=fname_template2anat, fname_seg=fname_seg, args=argv,
                     path_qc=os.path.abspath(param.path_qc), dataset=qc_dataset, subject=qc_subject,
                     process='sct_register_to_template')
     display_viewer_syntax([fname_data, fname_template2anat], verbose=verbose)
@@ -1027,12 +1022,16 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         if (not same_space and i_step > 0) or (same_space and i_step > 1):
             printv('\nApply transformation from previous step', param.verbose)
             for ifile in range(len(src)):
-                sct_apply_transfo.main(args=[
-                    '-i', src[ifile],
-                    '-d', dest[ifile],
-                    '-w', warp_forward,
-                    '-o', add_suffix(src[ifile], '_reg'),
-                    '-x', interp_step[ifile]])
+                argv = ['-i', src[ifile],
+                        '-d', dest[ifile],
+                        '-o', add_suffix(src[ifile], '_reg'),
+                        '-x', interp_step[ifile],
+                        '-w']
+                if type(warp_forward) is list:
+                    argv.extend(warp_forward)
+                else:
+                    argv.append(warp_forward)
+                sct_apply_transfo.main(argv=argv)
                 src[ifile] = add_suffix(src[ifile], '_reg')
 
         # register src --> dest
@@ -1086,14 +1085,14 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
     # TODO: make the following code optional (or move it to sct_register_multimodal)
     # Apply warping field to src data
     printv('\nApply transfo source --> dest...', param.verbose)
-    sct_apply_transfo.main(args=[
+    sct_apply_transfo.main(argv=[
         '-i', 'src.nii',
         '-d', 'dest.nii',
         '-w', 'warp_src2dest.nii.gz',
         '-o', 'src_reg.nii',
         '-x', interp])
     printv('\nApply transfo dest --> source...', param.verbose)
-    sct_apply_transfo.main(args=[
+    sct_apply_transfo.main(argv=[
         '-i', 'dest.nii',
         '-d', 'src.nii',
         '-w', 'warp_dest2src.nii.gz',
@@ -1280,9 +1279,7 @@ def register(src, dest, step, param):
     return warp_forward, warp_inverse
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -273,8 +273,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -1022,16 +1022,13 @@ def register_wrapper(fname_src, fname_dest, param, paramregmulti, fname_src_seg=
         if (not same_space and i_step > 0) or (same_space and i_step > 1):
             printv('\nApply transformation from previous step', param.verbose)
             for ifile in range(len(src)):
-                argv = ['-i', src[ifile],
-                        '-d', dest[ifile],
-                        '-o', add_suffix(src[ifile], '_reg'),
-                        '-x', interp_step[ifile],
-                        '-w']
-                if type(warp_forward) is list:
-                    argv.extend(warp_forward)
-                else:
-                    argv.append(warp_forward)
-                sct_apply_transfo.main(argv=argv)
+                sct_apply_transfo.main(argv=[
+                    '-i', src[ifile],
+                    '-d', dest[ifile],
+                    '-o', add_suffix(src[ifile], '_reg'),
+                    '-x', interp_step[ifile],
+                    '-w'] + warp_forward
+                )
                 src[ifile] = add_suffix(src[ifile], '_reg')
 
         # register src --> dest

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -106,8 +106,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -102,9 +102,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended."
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -16,7 +16,7 @@ import os
 import sys
 import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv
+from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
 import spinalcordtoolbox.resampling
 
 
@@ -110,9 +110,12 @@ def get_parser():
     return parser
 
 
-def run_main():
+def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     param.fname_data = arguments.i
     arg = 0
     if arguments.f is not None:
@@ -143,8 +146,6 @@ def run_main():
             param.interpolation = int(arguments.x)
         else:
             param.interpolation = arguments.x
-    param.verbose = int(arguments.v)
-    init_sct(log_level=param.verbose, update=True)  # Update log level
 
     spinalcordtoolbox.resampling.resample_file(param.fname_data, param.fname_out, param.new_size, param.new_size_type,
                                                param.interpolation, param.verbose, fname_ref=param.ref)
@@ -152,4 +153,5 @@ def run_main():
 
 if __name__ == "__main__":
     init_sct()
-    run_main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -149,8 +149,8 @@ def get_parser():
                         action='store_true',
                         help='Create zip archive of output folders log/, qc/ and results/.')
     parser.add_argument('-v', metavar=Metavar.int, type=int, choices=[0, 1, 2], default=1,
-                        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-                        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+                        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+                        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -35,10 +35,11 @@ import yaml
 import psutil
 
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
-from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__
+from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import Tee
 
 from stat import S_IEXEC
+
 
 def get_parser():
     parser = argparse.ArgumentParser(
@@ -147,6 +148,8 @@ def get_parser():
     parser.add_argument('-zip',
                         action='store_true',
                         help='Create zip archive of output folders log/, qc/ and results/.')
+    parser.add_argument("-v", type=int, required=False, choices=(0, 1, 2), default=1,
+                        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",)
 
     return parser
 
@@ -220,19 +223,17 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
     return res
 
 
-def main(argv):
-    # Print the sct startup info
-    init_sct()
-
-    # Parse the command line arguments
+def main(argv=None):
     parser = get_parser()
-    args = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # See if there's a configuration file and import those options
-    if args.config is not None:
+    if arguments.config is not None:
         print('configuring')
-        with open(args.config, 'r') as conf:
-            _, ext = os.path.splitext(args.config)
+        with open(arguments.config, 'r') as conf:
+            _, ext = os.path.splitext(arguments.config)
             if ext == '.json':
                 config = json.load(conf)
             if ext == '.yml' or ext == '.yaml':
@@ -243,7 +244,7 @@ def main(argv):
             warnings.warn(UserWarning('Using the `-config|-c` flag with additional arguments is discouraged'))
 
         # Check for unsupported arguments
-        orig_keys = set(vars(args).keys())
+        orig_keys = set(vars(arguments).keys())
         config_keys = set(config.keys())
         if orig_keys != config_keys:
             for k in config_keys.difference(orig_keys):
@@ -255,18 +256,18 @@ def main(argv):
         parser.set_defaults(**config)
 
         # Reparse the arguments
-        args = parser.parse_args(argv)
+        arguments = parser.parse_args(argv)
 
     # Set up email notifications if desired
-    do_email = args.email_to is not None
+    do_email = arguments.email_to is not None
     if do_email:
-        email_to = args.email_to
-        if args.email_from is not None:
-            email_from = args.email_from
+        email_to = arguments.email_to
+        if arguments.email_from is not None:
+            email_from = arguments.email_from
         else:
-            email_from = args.email_to
+            email_from = arguments.email_to
 
-        smtp_host, smtp_port = args.email_host.split(":")
+        smtp_host, smtp_port = arguments.email_host.split(":")
         smtp_port = int(smtp_port)
         email_pass = getpass('Please input your email password:\n')
 
@@ -289,14 +290,14 @@ def main(argv):
                 send_notification('sct_run_batch: test notification', 'Looks good')
 
     # Set up output directories and create them if they don't already exist
-    path_output = os.path.abspath(os.path.expanduser(args.path_output))
+    path_output = os.path.abspath(os.path.expanduser(arguments.path_output))
     path_results = os.path.join(path_output, 'results')
     path_data_processed = os.path.join(path_output, 'data_processed')
     path_log = os.path.join(path_output, 'log')
     path_qc = os.path.join(path_output, 'qc')
-    path_segmanual = os.path.abspath(os.path.expanduser(args.path_segmanual))
-    script = os.path.abspath(os.path.expanduser(args.script))
-    path_data = os.path.abspath(os.path.expanduser(args.path_data))
+    path_segmanual = os.path.abspath(os.path.expanduser(arguments.path_segmanual))
+    script = os.path.abspath(os.path.expanduser(arguments.script))
+    path_data = os.path.abspath(os.path.expanduser(arguments.path_data))
 
     for pth in [path_output, path_results, path_data_processed, path_log, path_qc]:
         os.makedirs(pth, exist_ok=True)
@@ -306,7 +307,7 @@ def main(argv):
         raise FileNotFoundError('Couldn\'t find the script script at {}'.format(script))
 
     # Setup overall log
-    batch_log = open(os.path.join(path_log, args.batch_log), 'w')
+    batch_log = open(os.path.join(path_log, arguments.batch_log), 'w')
 
     # Duplicate init_sct message to batch_log
     print('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__), file=batch_log, flush=True)
@@ -334,7 +335,7 @@ def main(argv):
     print('OS: ' + os_running + ' (' + platform.platform() + ')')
 
     # Display number of CPU cores
-    print('CPU cores: Available: {} | Threads used by ITK Programs: {}'.format(multiprocessing.cpu_count(), args.itk_threads))
+    print('CPU cores: Available: {} | Threads used by ITK Programs: {}'.format(multiprocessing.cpu_count(), arguments.itk_threads))
 
     # Display RAM available
     print("RAM: Total {} MB | Available {} MB | Used {} MB".format(
@@ -346,7 +347,7 @@ def main(argv):
     # Log the current arguments (in yaml because it's cleaner)
     print('\nINPUT ARGUMENTS')
     print("---------------")
-    print(yaml.dump(vars(args)))
+    print(yaml.dump(vars(arguments)))
 
     # Display script version info
     print("SCRIPT")
@@ -356,7 +357,7 @@ def main(argv):
     print("Copying script to output folder...")
     try:
         # Copy the script and record the new location
-        script_copy = os.path.abspath(shutil.copy(script, args.path_output))
+        script_copy = os.path.abspath(shutil.copy(script, arguments.path_output))
         print("{} -> {}".format(script, script_copy))
         script = script_copy
     except shutil.SameFileError:
@@ -366,7 +367,7 @@ def main(argv):
         print("Input folder is a directory (not a file). Skipping copy.")
         pass
 
-    print("Setting execute permissions for script file {} ...".format(args.script))
+    print("Setting execute permissions for script file {} ...".format(arguments.script))
     script_stat = os.stat(script)
     os.chmod(script, script_stat.st_mode | S_IEXEC)
 
@@ -377,34 +378,34 @@ def main(argv):
     print("git origin: {}\n".format(__get_git_origin(path_to_git_folder=path_data)))
 
     # Find subjects and process inclusion/exclusions
-    subject_dirs = [f for f in os.listdir(path_data) if f.startswith(args.subject_prefix)]
+    subject_dirs = [f for f in os.listdir(path_data) if f.startswith(arguments.subject_prefix)]
 
     # Handle inclusion lists
-    assert not ((args.include is not None) and (args.include_list is not None)),\
+    assert not ((arguments.include is not None) and (arguments.include_list is not None)),\
         'Only one of `include` and `include-list` can be used'
 
-    if args.include is not None:
-        subject_dirs = [f for f in subject_dirs if re.search(args.include, f) is not None]
+    if arguments.include is not None:
+        subject_dirs = [f for f in subject_dirs if re.search(arguments.include, f) is not None]
 
-    if args.include_list is not None:
+    if arguments.include_list is not None:
         # TODO decide if we should warn users if one of their inclusions isn't around
-        subject_dirs = [f for f in subject_dirs if f in args.include_list]
+        subject_dirs = [f for f in subject_dirs if f in arguments.include_list]
 
     # Handle exclusions
-    assert not ((args.exclude is not None) and (args.exclude_list is not None)),\
+    assert not ((arguments.exclude is not None) and (arguments.exclude_list is not None)),\
         'Only one of `exclude` and `exclude-list` can be used'
 
-    if args.exclude is not None:
-        subject_dirs = [f for f in subject_dirs if re.search(args.exclude, f) is None]
+    if arguments.exclude is not None:
+        subject_dirs = [f for f in subject_dirs if re.search(arguments.exclude, f) is None]
 
-    if args.exclude_list is not None:
-        subject_dirs = [f for f in subject_dirs if f not in args.exclude_list]
+    if arguments.exclude_list is not None:
+        subject_dirs = [f for f in subject_dirs if f not in arguments.exclude_list]
 
     # Determine the number of jobs we can run simulataneously
-    if args.jobs < 1:
-        jobs = multiprocessing.cpu_count() + args.jobs
+    if arguments.jobs < 1:
+        jobs = multiprocessing.cpu_count() + arguments.jobs
     else:
-        jobs = args.jobs
+        jobs = arguments.jobs
 
     print("RUNNING")
     print("-------")
@@ -418,15 +419,15 @@ def main(argv):
         with multiprocessing.Pool(jobs) as p:
             run_single_dir = functools.partial(run_single,
                                                script=script,
-                                               script_args=args.script_args,
+                                               script_args=arguments.script_args,
                                                path_segmanual=path_segmanual,
                                                path_data=path_data,
                                                path_data_processed=path_data_processed,
                                                path_results=path_results,
                                                path_log=path_log,
                                                path_qc=path_qc,
-                                               itk_threads=args.itk_threads,
-                                               continue_on_error=args.continue_on_error)
+                                               itk_threads=arguments.itk_threads,
+                                               continue_on_error=arguments.continue_on_error)
             results = list(p.imap(run_single_dir, subject_dirs))
     except Exception as e:
         if do_email:
@@ -473,7 +474,7 @@ def main(argv):
     print('To open the Quality Control (QC) report on a web-browser, run the following:\n'
           '{} {}/index.html'.format(open_cmd, path_qc))
 
-    if args.zip:
+    if arguments.zip:
         file_zip = 'sct_run_batch_{}'.format(time.strftime('%Y%m%d%H%M%S'))
         path_tmp = os.path.join(tempfile.mkdtemp(), file_zip)
         os.makedirs(os.path.join(path_tmp, file_zip))
@@ -487,5 +488,6 @@ def main(argv):
     batch_log.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+    init_sct()
     main(sys.argv[1:])

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -148,8 +148,9 @@ def get_parser():
     parser.add_argument('-zip',
                         action='store_true',
                         help='Create zip archive of output folders log/, qc/ and results/.')
-    parser.add_argument("-v", type=int, required=False, choices=(0, 1, 2), default=1,
-                        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",)
+    parser.add_argument('-v', metavar=Metavar.int, type=int, choices=[0, 1, 2], default=1,
+                        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+                        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, list_type, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv
+from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, cache_save, cache_signature, cache_valid, copy, \
     extract_fname, rmtree
 
@@ -117,14 +117,15 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
 
     # Initialization
     param = Param()
     start_time = time.time()
-
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     fname_anat = arguments.i
     fname_centerline = arguments.s
@@ -132,8 +133,6 @@ def main(args=None):
     if arguments.smooth is not None:
         sigma = arguments.smooth
     remove_temp_files = arguments.r
-    verbose = int(arguments.v)
-    init_sct(log_level=verbose, update=True)  # Update log level
 
     # Display arguments
     printv('\nCheck input arguments...')
@@ -211,7 +210,7 @@ def main(args=None):
     # Smooth the straightened image along z
     printv('\nSmooth the straightened image...')
     sigma_smooth = ",".join([str(i) for i in sigma])
-    sct_maths.main(args=['-i', 'anat_rpi_straight.nii',
+    sct_maths.main(argv=['-i', 'anat_rpi_straight.nii',
                          '-smooth', sigma_smooth,
                          '-o', 'anat_rpi_straight_smooth.nii',
                          '-v', '0'])
@@ -249,8 +248,7 @@ def main(args=None):
     display_viewer_syntax([file_anat, file_anat + '_smooth'], verbose=verbose)
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -111,8 +111,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -107,9 +107,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1', '2'],
-        default='1',
-        help="Verbose: 0 = nothing, 1 = classic, 2 = expended"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -20,7 +20,7 @@ from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
-from spinalcordtoolbox.utils.sys import init_sct, printv
+from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 
 def get_parser():
@@ -192,17 +192,17 @@ def get_parser():
 
 # MAIN
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
     """
     Main function
-    :param args:
+    :param argv:
     :return:
     """
-    # Get parser args
-    if args is None:
-        args = None if sys.argv[1:] else ['--help']
     parser = get_parser()
-    arguments = parser.parse_args(args=args)
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.v
+    set_global_loglevel(verbose=verbose)
+
     input_filename = arguments.i
     centerline_file = arguments.s
 
@@ -231,8 +231,6 @@ def main(args=None):
     sc_straight.output_filename = arguments.o
     sc_straight.path_output = arguments.ofolder
     path_qc = arguments.qc
-    verbose = arguments.v
-    init_sct(log_level=verbose, update=True)  # Update log level
     sc_straight.verbose = verbose
 
     # if arguments.cpu_nb is not None:
@@ -282,4 +280,5 @@ def main(args=None):
 
 if __name__ == "__main__":
     init_sct()
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -185,8 +185,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -180,12 +180,13 @@ def get_parser():
         choices=(0, 1),
         default=1)
     optional.add_argument(
-        "-v",
+        '-v',
+        metavar=Metavar.int,
         type=int,
-        help="Verbose. 0: nothing, 1: basic, 2: extended.",
-        required=False,
-        choices=(0, 1, 2),
-        default=1)
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)")
 
     return parser
 

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -23,7 +23,7 @@ import signal
 import numpy as np
 from pandas import DataFrame
 
-from spinalcordtoolbox.utils import init_sct, run_proc, tmp_create, printv, rmtree, __sct_dir__
+from spinalcordtoolbox.utils import init_sct, run_proc, tmp_create, printv, rmtree, __sct_dir__, set_global_loglevel
 from spinalcordtoolbox.scripts import sct_download_data
 
 # FIXME
@@ -208,19 +208,14 @@ def process_function_multiproc(fname, param):
 
 # Main
 # ==========================================================================================
-def main(args=None):
+def main(argv=None):
+    parser = get_parser()
+    arguments = parser.parse_args(argv if argv else ['--help'])
+    verbose = arguments.verbose
+    set_global_loglevel(verbose=verbose)
 
     # initializations
     param = Param()
-
-    # check user arguments
-    if args is None:
-        args = sys.argv[1:]
-
-    # get parser info
-    parser = get_parser()
-
-    arguments = parser.parse_args(args)
 
     param.download = int(arguments.download)
     param.path_data = arguments.path
@@ -228,8 +223,7 @@ def main(args=None):
     param.remove_tmp_file = int(arguments.remove_temps)
     jobs = arguments.jobs
 
-    param.verbose = arguments.verbose
-    init_sct(log_level=param.verbose, update=True)  # Update log level
+    param.verbose = verbose
 
     start_time = time.time()
 
@@ -609,11 +603,7 @@ def update_param(param):
     return param
 
 
-# START PROGRAM
-# ==========================================================================================
 if __name__ == "__main__":
     init_sct()
-    # initialize parameters
-    param = Param()
-    # call main function
-    main()
+    main(sys.argv[1:])
+

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -224,9 +224,12 @@ def get_parser():
     )
     optional.add_argument(
         '-v',
-        choices=['0', '1'],
-        default='1',
-        help="Verbose. 0: nothing. 1: basic"
+        metavar=Metavar.int,
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
+        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
     )
 
     return parser

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -228,8 +228,8 @@ def get_parser():
         type=int,
         choices=[0, 1, 2],
         default=1,
-        # Values [0, 1, 2] map to log levels [WARNING, INFO, DEBUG]
-        help="Verbosity. 0: Minimal, 1: Default, 2: Expanded (Display figures)"
+        # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
 
     return parser

--- a/spinalcordtoolbox/utils/sys.py
+++ b/spinalcordtoolbox/utils/sys.py
@@ -38,15 +38,35 @@ if os.getenv('SENTRY_DSN', None):
     import raven
 
 
+def set_global_loglevel(verbose):
+    """
+    Use SCT's verbosity values to set the global logging level.
+
+    :verbosity: Verbosity value, typically from argparse (args.v). Values must adhere
+    one of two schemes:
+       - [0, 1, 2], which corresponds to [WARNING, INFO, DEBUG]. (Older scheme)
+       - [False, True], which corresponds to [INFO, DEBUG].      (Newer scheme)
+    """
+    dict_log_levels = {
+        '0': 'WARNING', '1': 'INFO', '2': 'DEBUG',  # Older scheme
+        'False': 'INFO', 'True': 'DEBUG',           # Newer scheme (See issue #2676)
+    }
+
+    if str(verbose) not in dict_log_levels.keys():
+        raise ValueError(f"Invalid verbosity level '{verbose}' does not map to a log level, so cannot set.")
+
+    log_level = dict_log_levels[str(verbose)]
+    # Set logging level for logger and increase level for global config (to avoid logging when calling child functions)
+    logger.setLevel(getattr(logging, log_level))
+    logging.root.setLevel(getattr(logging, log_level))
+
+
 # TODO: add test
-def init_sct(log_level=1, update=False):
+def init_sct():
     """
-    Initialize the sct for typical terminal usage
-    :param log_level: int: 0: warning, 1: info, 2: debug.
-    :param update: Bool: If True, only update logging log level. Otherwise, set logging + Sentry.
-    :return:
+    Initialize SCT for typical terminal usage, including logging initialization, Sentry
+    configuration, as well as a status message with the SCT version and the command run.
     """
-    dict_log_levels = {0: 'WARNING', 1: 'INFO', 2: 'DEBUG'}
 
     def _format_wrap(old_format):
         def _format(record):
@@ -60,33 +80,29 @@ def init_sct(log_level=1, update=False):
             return res
         return _format
 
-    # Set logging level for logger and increase level for global config (to avoid logging when calling child functions)
-    logger.setLevel(getattr(logging, dict_log_levels[log_level]))
-    logging.root.setLevel(getattr(logging, dict_log_levels[log_level]))
+    # Initialize logging
+    set_global_loglevel(verbose=False)  # False => "INFO". For "DEBUG", must be called again with verbose=True.
+    hdlr = logging.StreamHandler(sys.stdout)
+    fmt = logging.Formatter()
+    fmt.format = _format_wrap(fmt.format)
+    hdlr.setFormatter(fmt)
+    logging.root.addHandler(hdlr)
 
-    if not update:
-        # Initialize logging
-        hdlr = logging.StreamHandler(sys.stdout)
-        fmt = logging.Formatter()
-        fmt.format = _format_wrap(fmt.format)
-        hdlr.setFormatter(fmt)
-        logging.root.addHandler(hdlr)
+    # Sentry config
+    init_error_client()
+    if os.environ.get("SCT_TIMER", None) is not None:
+        add_elapsed_time_counter()
 
-        # Sentry config
-        init_error_client()
-        if os.environ.get("SCT_TIMER", None) is not None:
-            add_elapsed_time_counter()
+    # Display SCT version
+    logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
 
-        # Display SCT version
-        logger.info('\n--\nSpinal Cord Toolbox ({})\n'.format(__version__))
-
-        # Display command (Only if called from CLI: check for .py in first arg)
-        # Use next(iter()) to not fail on empty list (vs. sys.argv[0])
-        if '.py' in next(iter(sys.argv), None):
-            script = os.path.basename(sys.argv[0]).strip(".py")
-            arguments = ' '.join(sys.argv[1:])
-            logger.info(f"{script} {arguments}\n"
-                        f"--\n")
+    # Display command (Only if called from CLI: check for .py in first arg)
+    # Use next(iter()) to not fail on empty list (vs. sys.argv[0])
+    if '.py' in next(iter(sys.argv), None):
+        script = os.path.basename(sys.argv[0]).strip(".py")
+        arguments = ' '.join(sys.argv[1:])
+        logger.info(f"{script} {arguments}\n"
+                    f"--\n")
 
 
 def add_elapsed_time_counter():

--- a/testing/test_sct_register_to_template.py
+++ b/testing/test_sct_register_to_template.py
@@ -49,7 +49,7 @@ def test_integrity(param_test):
     index_args = param_test.default_args.index(param_test.args)
 
     # apply transformation to binary mask: template --> anat
-    sct_apply_transfo.main(args=[
+    sct_apply_transfo.main(argv=[
         '-i', param_test.fname_gt[index_args],
         '-d', param_test.file_seg,
         '-w', 'warp_template2anat.nii.gz',
@@ -58,7 +58,7 @@ def test_integrity(param_test):
         '-v', '0'])
 
     # apply transformation to binary mask: anat --> template
-    sct_apply_transfo.main(args=[
+    sct_apply_transfo.main(argv=[
         '-i', param_test.file_seg,
         '-d', param_test.fname_gt[index_args],
         '-w', 'warp_anat2template.nii.gz',

--- a/unit_testing/test_centerline.py
+++ b/unit_testing/test_centerline.py
@@ -13,13 +13,15 @@ from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, f
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.testing.create_test_data import dummy_centerline
 import spinalcordtoolbox.math
-from spinalcordtoolbox.utils import sct_test_path, init_sct
+from spinalcordtoolbox.utils import sct_test_path, init_sct, set_global_loglevel
 
 sys.path.append(os.path.join(__sct_dir__, 'scripts'))
 
-
-init_sct(log_level=2)  # Set logger in debug mode
-VERBOSE = 0  # Set to 2 to save images, 0 otherwise
+# Set logger to "DEBUG"
+init_sct()
+set_global_loglevel(verbose=2)
+# Separate setting for get_centerline. Set to 2 to save images ("DEBUG"), 0 otherwise ("INFO")
+VERBOSE = 0
 
 
 # Generate a list of fake centerlines: (dummy_segmentation(params), dict of expected results)

--- a/unit_testing/test_qmri.py
+++ b/unit_testing/test_qmri.py
@@ -8,10 +8,12 @@ import pytest
 
 from spinalcordtoolbox.qmri import mt
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils import init_sct
+from spinalcordtoolbox.utils import init_sct, set_global_loglevel
 
-init_sct(log_level=2)  # Set logger in debug mode
-VERBOSE = 0  # Set to 2 to save images, 0 otherwise
+
+# Set logger to "DEBUG"
+init_sct()
+set_global_loglevel(verbose=2)
 
 
 def make_sct_image(data):


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Motivation: Currently, we can call some, but not all scripts using `sct_function.main()`. This is because script init steps are inconsistent between scripts.

So, this PR refactors scripts to all have the same consistent structure, as described in the [CLI script conventions](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-CLI-script-conventions-(structure,-argparse)) dev Wiki page. This includes some format tidying. For most of the scripts, the necessary changes were very straightforward:

* Adding arguments to main.
* Renaming variables (`args` -> `argv`, `args` -> `arguments`, `verbosity` -> `verbose`).
* Grouping statements at the top of main.
* Removing some `Param()` objects that were unnecessary.
* Adding missing verbose arguments (`-v`).
* Creating a main function when it didn't exist.

But, for some scripts, a more involved refactor was needed. So, extra care should be given to the following scripts when reviewing:

* `sct_apply_transfo`: Had some unique parsing behavior (flatting lists for `-w` and `-winv` before parsing). But, this was only ever used in one call to `sct_apply_transfo`, so I figured it wasn't worth the extra complexity. I removed the parsing behavior, and left it to be handled at the site of the call. (In this case, a single call within `sct_register_to_template` was modified.)
* `sct_check_dependencies`: Doesn't have `-v` and instead uses `-complete` for verbose. A bit strange, but I cleaned this up a bit.
* `sct_denoising_olm`: Did parsing within `if __name__ == "__main__"`, then main() accepted parsed arguments. I refactored so that main accepted the unparsed argument list, then did parsing inside main.
* `sct_dmri_compute_dti`: `Param().verbose` was used as a sort of global default. I refactored this to use an explicitly passed `verbose` variable.
* `sct_download_data`: The function `get_parser` took a `dict_url` parameter, when usually this function doesn't take parameters. Instead, I made `dict_url` a global variable. 
* `sct_extract_metric`: Like `sct_denoising_olm`, it did parsing within `if __name__ == "__main__"`, then main() accepted parsed arguments. I refactored so that main accepted the unparsed argument list, then did parsing inside main.
* `sct_flatten_sagittal`: Like `sct_denoising_olm`, it did parsing within `if __name__ == "__main__"`, then main() accepted parsed arguments. I refactored so that main accepted the unparsed argument list, then did parsing inside main.
* `sct_get_centerline`: Add verbose typing.
* `sct_register_multimodal`: The function `get_parser` took a `paramregmulti` parameter, when normally this function doesn't take parameters. Instead, I made `paramregmulti` a global variable, which also removed a duplicate definition in the process.
* `sct_warp_template`: `Param()` was used as a sort of global default. I refactored this to use an explicitly passed variables (`verbose`, `folder_template`, `folder_atlas`, `folder_spinal_levels`, `file_info_label`, `list_labels_nn`)
* `unit_testing/test_centerline` and `unit_testing/test_qmri`: I made a quick tweak because they were calling `init_sct` to set logging levels.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3085.