### PR TITLE
Turn on stricter shell rules + maintainence

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -2,7 +2,7 @@
 # CI testing script
 #  Installs SCT from scratch and runs all the tests we've ever written for it.
 
-set -e # Error build immediately if install script exits with non-zero
+set -ueo pipefail # stricter shell rules
 
 echo Installing SCT
 PIP_PROGRESS_BAR=off ./install_sct -y

--- a/.ci.sh
+++ b/.ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # CI testing script
 #  Installs SCT from scratch and runs all the tests we've ever written for it.
 

--- a/.ci.sh
+++ b/.ci.sh
@@ -5,7 +5,7 @@
 set -e # Error build immediately if install script exits with non-zero
 
 echo Installing SCT
-yes | ASK_REPORT_QUESTION=false PIP_PROGRESS_BAR=off ./install_sct
+PIP_PROGRESS_BAR=off ./install_sct -y
 echo $?
 echo "... STATUS"
 

--- a/.ci.sh
+++ b/.ci.sh
@@ -2,7 +2,11 @@
 # CI testing script
 #  Installs SCT from scratch and runs all the tests we've ever written for it.
 
-set -ueo pipefail # stricter shell rules
+# stricter shell mode
+# https://sipb.mit.edu/doc/safe-shell/
+set -eo pipefail  # exit if non-zero error is encountered (even in a pipeline)
+set -u            # exit if unset variables used
+shopt -s failglob # error if a glob doesn't find any files, instead of remaining unexpanded
 
 echo Installing SCT
 PIP_PROGRESS_BAR=off ./install_sct -y

--- a/.ci.sh
+++ b/.ci.sh
@@ -10,8 +10,6 @@ shopt -s failglob # error if a glob doesn't find any files, instead of remaining
 
 echo Installing SCT
 PIP_PROGRESS_BAR=off ./install_sct -y
-echo $?
-echo "... STATUS"
 
 echo *** CHECK PATH ***
 ls -lA bin  # Make sure all binaries and aliases are there
@@ -34,4 +32,3 @@ bash -c 'PYTHONPATH="$PWD/scripts:$PWD" pylint -j3 --py3k --output-format=parsea
 # python create_package.py -s ${TRAVIS_OS_NAME}  # test package creation
 # cd ../spinalcordtoolbox_v*
 # yes | ./install_sct  # test installation of package
-

--- a/.travis.sh
+++ b/.travis.sh
@@ -6,8 +6,11 @@
 # usage: .travis.sh
 #
 # e.g. DOCKER_IMAGE="centos:8" .travis.sh
-
-set -ueo pipefail # stricter shell rules
+# stricter shell mode
+# https://sipb.mit.edu/doc/safe-shell/
+set -eo pipefail  # exit if non-zero error is encountered (even in a pipeline)
+set -u            # exit if unset variables used
+shopt -s failglob # error if a glob doesn't find any files, instead of remaining unexpanded
 
 # if this is a docker job, run in the container instead; but if not just run it here.
 if [ -n "${DOCKER_IMAGE:-}" ]; then

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # TravisCI testing harness.
 #  Supports running locally (i.e. on whatever platform Travis has loaded us in)
 #  or in a docker container specified by $DOCKER_IMAGE.

--- a/.travis.sh
+++ b/.travis.sh
@@ -7,7 +7,7 @@
 #
 # e.g. DOCKER_IMAGE="centos:8" .travis.sh
 
-set -e # Error build immediately if install script exits with non-zero
+set -ueo pipefail # stricter shell rules
 
 # if this is a docker job, run in the container instead; but if not just run it here.
 if [ -n "$DOCKER_IMAGE" ]; then

--- a/.travis.sh
+++ b/.travis.sh
@@ -10,9 +10,9 @@
 set -ueo pipefail # stricter shell rules
 
 # if this is a docker job, run in the container instead; but if not just run it here.
-if [ -n "$DOCKER_IMAGE" ]; then
+if [ -n "${DOCKER_IMAGE:-}" ]; then
     ./util/dockerize.sh ./.ci.sh
-elif [ "${TRAVIS_OS_NAME}" = "windows" ]; then
+elif [ "${TRAVIS_OS_NAME:-}" = "windows" ]; then
     choco install wsl-ubuntu-1804 -y --ignore-checksums
      # or, instead of choco, use curl + powershell:
      # https://docs.microsoft.com/en-us/windows/wsl/install-manual#downloading-distros-via-the-command-line

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     # identical to freshly installed VMs, and by using docker we're
     # mismatching kernels, but it is a lot better than not testing.
     - name: "ArchLinux"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: linux
       dist: bionic  # Arch needs a recent kernel
       services:
@@ -43,7 +43,7 @@ matrix:
       env:
         - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm gcc git curl"
     - name: "Debian Rolling Release"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: linux
       dist: bionic
       services:
@@ -51,7 +51,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:sid"     DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian Testing"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: linux
       dist: bionic
       services:
@@ -59,7 +59,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:testing" DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 10"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: linux
       dist: bionic # kernel ~= Debian:10
       services:
@@ -67,7 +67,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:10"      DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 9"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Debian:9
       services:
@@ -83,7 +83,7 @@ matrix:
       env:
         - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y gcc git curl"
     - name: "CentOS 7"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Centos7
       services:
@@ -97,18 +97,18 @@ matrix:
       dist: bionic
     - os: linux
       name: "Ubuntu 16.04 (Xenial)"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       dist: xenial
     - name: "OSX 10.15 (Catalina)"
       # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode12.2
     - name: "OSX 10.14 (Mojave)"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: osx
       osx_image: xcode11.3
     - name: "OSX 10.13 (High Sierra)"
-      if: branch = release or type = cron
+      #if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
     - name: "Windows Server, 1809"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     # identical to freshly installed VMs, and by using docker we're
     # mismatching kernels, but it is a lot better than not testing.
     - name: "ArchLinux"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: linux
       dist: bionic  # Arch needs a recent kernel
       services:
@@ -43,7 +43,7 @@ matrix:
       env:
         - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm gcc git curl"
     - name: "Debian Rolling Release"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: linux
       dist: bionic
       services:
@@ -51,7 +51,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:sid"     DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian Testing"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: linux
       dist: bionic
       services:
@@ -59,7 +59,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:testing" DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 10"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: linux
       dist: bionic # kernel ~= Debian:10
       services:
@@ -67,7 +67,7 @@ matrix:
       env:
         - DOCKER_IMAGE="debian:10"      DOCKER_DEPS_CMD="apt update && apt install -y libglib2.0-0 procps gcc git curl"
     - name: "Debian 9"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Debian:9
       services:
@@ -83,7 +83,7 @@ matrix:
       env:
         - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y gcc git curl"
     - name: "CentOS 7"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: linux
       dist: xenial # kernel ~= Centos7
       services:
@@ -97,18 +97,18 @@ matrix:
       dist: bionic
     - os: linux
       name: "Ubuntu 16.04 (Xenial)"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       dist: xenial
     - name: "OSX 10.15 (Catalina)"
       # runs on all branches
       os: osx  # list of OSX env: https://docs.travis-ci.com/user/reference/osx/
       osx_image: xcode12.2
     - name: "OSX 10.14 (Mojave)"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: osx
       osx_image: xcode11.3
     - name: "OSX 10.13 (High Sierra)"
-      #if: branch = release or type = cron
+      if: branch = release or type = cron
       os: osx
       osx_image: xcode9.4
     - name: "Windows Server, 1809"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       services:
         - docker
       env:
-        - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm which gcc git curl"
+        - DOCKER_IMAGE="archlinux" DOCKER_DEPS_CMD="pacman -Sy --noconfirm gcc git curl"
     - name: "Debian Rolling Release"
       if: branch = release or type = cron
       os: linux
@@ -81,7 +81,7 @@ matrix:
       services:
         - docker
       env:
-        - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
+        - DOCKER_IMAGE="centos:8" DOCKER_DEPS_CMD="yum install -y gcc git curl"
     - name: "CentOS 7"
       if: branch = release or type = cron
       os: linux
@@ -89,7 +89,7 @@ matrix:
       services:
         - docker
       env:
-        - DOCKER_IMAGE="centos:7" DOCKER_DEPS_CMD="yum install -y which gcc git curl"
+        - DOCKER_IMAGE="centos:7" DOCKER_DEPS_CMD="yum install -y gcc git curl"
     # The rest of the OSes can use Travis's built-in images:
     - name: "Ubuntu 18.04 (Bionic Beaver)"
       # runs on all branches

--- a/install_sct
+++ b/install_sct
@@ -532,7 +532,7 @@ fi
 # Copy files to destination directory
 if [[ "$SCT_DIR" != "$SCT_SOURCE" ]]; then
   print info "Copying source files from $SCT_SOURCE to $SCT_DIR"
-  cp -vR "$SCT_SOURCE/"* "$SCT_DIR/" | while read line; do echo -n "."; done
+  cp -vR "$SCT_SOURCE/"* "$SCT_DIR/" | while read; do echo -n "."; done
 else
   print info "Skipping copy of source files (source and destination folders are the same)"
 fi

--- a/install_sct
+++ b/install_sct
@@ -421,8 +421,8 @@ else
 The install_sct script must be executed from the source directory"
 fi
 
-# Get installation type (from git or from package)
-if [[ -z "${SCT_INSTALL_TYPE:-}" ]]; then
+# Get installation type (from git or from package) if not already specified
+if [[ -z "$SCT_INSTALL_TYPE" ]]; then
   if [[ -d ".git" ]]; then
     # folder .git exist, therefore it is a git installation
     SCT_INSTALL_TYPE="in-place"
@@ -658,7 +658,7 @@ export PATH="$SCT_DIR/$BIN_DIR:$PATH"
 # ----------------------------------------------------------------------------------------------------------------------
 
 # Install binaries
-if [[ -n "${NO_SCT_BIN_INSTALL:-}" ]]; then
+if [[ -n "$NO_SCT_BIN_INSTALL" ]]; then
   print warning "WARNING: SCT binaries will not be (re)-installed"
 else
   print info "Installing binaries..."
@@ -667,7 +667,7 @@ fi
 print info "All requirements installed!"
 
 # Install data
-if [[ -n "${NO_DATA_INSTALL:-}" ]]; then
+if [[ -n "$NO_DATA_INSTALL" ]]; then
   print warning "WARNING: data/ will not be (re)-install"
 else
   # Download data

--- a/install_sct
+++ b/install_sct
@@ -180,7 +180,7 @@ function check_requirements() {
         GCC_INSTALL="no"
         if [ -z "$NONINTERACTIVE" ]; then
           print question "Do you want to install it now? (accepting to install \"gcc\" will also install \"brew\" in case it is not installed already)? [y]es/[n]o: "
-          read GCC_INSTALL
+          read -r GCC_INSTALL
         fi
       done
       if [[ "$GCC_INSTALL" =~ [Yy](es)? ]]; then
@@ -429,7 +429,7 @@ report system to automatically receive crash reports and errors from users.
 These reports are anonymous.
 
 Do you agree to help us improve SCT? [y]es/[n]o: "
-  read REPORT_STATS
+  read -r REPORT_STATS
 fi
 
 if [[ "$REPORT_STATS" =~ [Yy](es)? ]]; then
@@ -455,7 +455,7 @@ while true; do
     if [ -z "$NONINTERACTIVE" ]; then
       print question "
 Do you agree? [y]es/[n]o: "
-      read keep_default_path
+      read -r keep_default_path
     fi
   done
   if [[ "$keep_default_path" =~ ^[Yy] ]]; then
@@ -467,7 +467,7 @@ Do you agree? [y]es/[n]o: "
 
   print question "Choose install directory. Warning! Give full path (e.g. /usr/django/sct_v3.0): \n"
   # user enters new path
-  read new_install
+  read -r new_install
 
   # Expand ~/
   new_install="${new_install/#\~\//$HOME\/}"
@@ -499,7 +499,7 @@ while [[ ! "$add_to_path" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
   add_to_path="yes"
   if [ -z "$NONINTERACTIVE" ]; then
     print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
-    read add_to_path
+    read -r add_to_path
   fi
 done
 
@@ -532,7 +532,7 @@ fi
 # Copy files to destination directory
 if [[ "$SCT_DIR" != "$SCT_SOURCE" ]]; then
   print info "Copying source files from $SCT_SOURCE to $SCT_DIR"
-  cp -vR "$SCT_SOURCE/"* "$SCT_DIR/" | while read; do echo -n "."; done
+  cp -vR "$SCT_SOURCE/"* "$SCT_DIR/" | while read -r; do echo -n "."; done
 else
   print info "Skipping copy of source files (source and destination folders are the same)"
 fi

--- a/install_sct
+++ b/install_sct
@@ -41,7 +41,6 @@ shopt -s failglob # error if a glob doesn't find any files, instead of remaining
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
 # Start Directory So we go back there at the end of the Script
 SCT_SOURCE="$PWD"
-SCRIPT_DIR="scripts"
 DATA_DIR="data"
 PYTHON_DIR="python"
 BIN_DIR="bin"

--- a/install_sct
+++ b/install_sct
@@ -30,14 +30,14 @@ shopt -s failglob # error if a glob doesn't find any files, instead of remaining
 
 
 # Where tmp file are stored
-TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')
+TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')"
 # Start Directory So we go back there at the end of the Script
-SCT_SOURCE=$PWD
+SCT_SOURCE="$PWD"
 SCRIPT_DIR="scripts"
 DATA_DIR="data"
 PYTHON_DIR="python"
 BIN_DIR="bin"
-MACOSSUPPORTED=13  # Minimum version of macOS 10 supported
+MACOSSUPPORTED="13"  # Minimum version of macOS 10 supported
 
 
 # ======================================================================================================================
@@ -50,7 +50,7 @@ MACOSSUPPORTED=13  # Minimum version of macOS 10 supported
 function print() {
   type=$1
   txt=$2
-  case $type in
+  case "$type" in
   # Display useful info (green)
   info)
     echo -e "\n\033[0;32m${txt}\033[0m\n"
@@ -83,7 +83,7 @@ function die() {
 # Run a command and display it in color. Exit if error.
 # @input: string: command to run
 function run() {
-  cmd=$1
+  cmd="$1"
   print code "$cmd"
   $cmd
   if [[ $? != 0 ]]; then
@@ -94,12 +94,12 @@ function run() {
 # Force a clean exit
 function finish() {
   # Catch the last return code
-  value=$?
+  value="$?"
   # Get back to starting point
-  cd $SCT_SOURCE
-  if [[ $value -eq 0 ]]; then
+  cd "$SCT_SOURCE"
+  if [[ "$value" -eq 0 ]]; then
     print info "Installation finished successfully!"
-  elif [[ $value -eq 99 ]]; then
+  elif [[ "$value" -eq 99 ]]; then
     # Showing usage with -h
     echo ""
   else
@@ -108,8 +108,8 @@ Please copy the historic of this Terminal (starting with the command install_sct
 --> http://forum.spinalcordmri.org/c/sct"
   fi
   # clean tmp_dir
-  rm -rf $TMP_DIR
-  exit $value
+  rm -rf "$TMP_DIR"
+  exit "$value"
 }
 
 # reenable tty echo when user presses keyboard interrupt and output non-zero status for finish() function
@@ -125,34 +125,34 @@ detectKeyboardInterrupt() {
 function fetch_os_type() {
   print info "Checking OS type and version..."
   OSver="unknown"  # default value
-  uname_output=`uname -a`
-  echo $uname_output
+  uname_output="$(uname -a)"
+  echo "$uname_output"
   # macOS
-  if echo $uname_output | grep -i darwin >/dev/null 2>&1; then
+  if echo "$uname_output" | grep -i darwin >/dev/null 2>&1; then
     # Fetch macOS version
-    sw_vers_output=`sw_vers | grep -e ProductVersion`
+    sw_vers_output="$(sw_vers | grep -e ProductVersion)"
     echo "$sw_vers_output"
-    OSver=$(echo $sw_vers_output | cut -c 17-)
-    macOSmajor=$(echo $OSver | cut -f 1 -d '.')
-    macOSminor=$(echo $OSver | cut -f 2 -d '.')
+    OSver="$(echo "$sw_vers_output" | cut -c 17-)"
+    macOSmajor="$(echo "$OSver" | cut -f 1 -d '.')"
+    macOSminor="$(echo "$OSver" | cut -f 2 -d '.')"
     # Make sure OSver is supported
     if [[ "${macOSmajor}" = 10 ]] && [[ "${macOSminor}" < "${MACOSSUPPORTED}" ]]; then
       die "Sorry, this version of macOS (10.$macOSminor) is not supported. The minimum version is 10.$MACOSSUPPORTED."
     fi
     # Fix for non-English Unicode systems on MAC
-    if [[ -z $LC_ALL ]]; then
+    if [[ -z "${LC_ALL:-}" ]]; then
       export LC_ALL=en_US.UTF-8
     fi
 
-    if [[ -z $LANG ]]; then
+    if [[ -z "${LANG:-}" ]]; then
       export LANG=en_US.UTF-8
     fi
-    OS=osx
+    OS="osx"
     # make sure bashrc is loaded when starting a new Terminal
     force_bashrc_loading
   # Linux
-  elif echo $uname_output | grep -i linux >/dev/null 2>&1; then
-    OS=linux
+  elif echo "$uname_output" | grep -i linux >/dev/null 2>&1; then
+    OS="linux"
   else
     die "Sorry, the installer only supports Linux and macOS, quitting installer"
   fi
@@ -169,15 +169,15 @@ function check_requirements() {
   gcc --version > /dev/null 2>&1  # run silently, then check output status
   if [[ $? -ne 0 ]]; then
     print warning "WARNING: \"gcc\" is not installed."
-    if [[ $OS == "osx" ]]; then
-      while [[ ! $GCC_INSTALL =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-        GCC_INSTALL=no
+    if [[ "$OS" == "osx" ]]; then
+      while [[ ! "$GCC_INSTALL" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
+        GCC_INSTALL="no"
         if [ -z "$NONINTERACTIVE" ]; then
           print question "Do you want to install it now? (accepting to install \"gcc\" will also install \"brew\" in case it is not installed already)? [y]es/[n]o: "
           read GCC_INSTALL
         fi
       done
-      if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
+      if [[ "$GCC_INSTALL" =~ [Yy](es)? ]]; then
         if [[ ! $(command -v brew) ]]; then
           # NB: this is a different NONINTERACTIVE than ours above; it's for the brew installer
           (NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)")
@@ -201,16 +201,16 @@ function check_requirements() {
 # Gets the shell rc file path based on the default shell.
 # @output: THE_RC and RC_FILE_PATH vars are modified
 function get_shell_rc_path() {
-  if [[ $SHELL == *"bash"* ]]; then
+  if [[ "$SHELL" == *"bash"* ]]; then
     THE_RC="bash"
     RC_FILE_PATH="$HOME/.bashrc"
-  elif [[ $SHELL == *"/sh"* ]]; then
+  elif [[ "$SHELL" == *"/sh"* ]]; then
     THE_RC="bash"
     RC_FILE_PATH="$HOME/.bashrc"
-  elif [[ $SHELL == *"zsh"* ]]; then
+  elif [[ "$SHELL" == *"zsh"* ]]; then
     THE_RC="bash"
     RC_FILE_PATH="$HOME/.zshrc"
-  elif [[ $SHELL == *"csh"* ]]; then
+  elif [[ "$SHELL" == *"csh"* ]]; then
     THE_RC="csh"
     RC_FILE_PATH="$HOME/.cshrc"
   else
@@ -228,17 +228,18 @@ if [[ -n \"\$BASH_VERSION\" ]]; then
     . \"\$HOME/.bashrc\"
     fi
 fi"
-  for profiles in ~/.bash_profile ~/.bash_login ~/.profile; do
-    if [[ -a $profiles ]]; then
-      if ! grep -E "(\.|source) .*bashrc" $profiles >/dev/null 2>&1; then
-        echo "$sourceblock" >>$profiles
+  bidon=""
+  for profile in ~/.bash_profile ~/.bash_login ~/.profile; do
+    if [[ -a "$profile" ]]; then
+      if ! grep -E "(\.|source) .*bashrc" "$profile" >/dev/null 2>&1; then
+        echo "$sourceblock" >>"$profile"
       fi
-      bidon=0
+      bidon="done"
       break
     fi
   done
 
-  if [[ -z $bidon ]]; then
+  if [[ -z "$bidon" ]]; then
     echo "$sourceblock" >>~/.bash_profile
   fi
 }
@@ -246,20 +247,22 @@ fi"
 # Installation text to insert in shell config file
 function edit_shellrc() {
   # Write text common to all shells
-  echo
-  echo "" >>$RC_FILE_PATH
-  echo "# SPINALCORDTOOLBOX (installed on $(date +%Y-%m-%d\ %H:%M:%S))" >>$RC_FILE_PATH
-  echo $DISPLAY_UPDATE_PATH >>$RC_FILE_PATH
-  # Switch between shell
-  if [[ $THE_RC == "bash" ]]; then
-    echo "export SCT_DIR=$SCT_DIR" >>$RC_FILE_PATH
-    echo "export MPLBACKEND=Agg" >>$RC_FILE_PATH
-  elif [[ $THE_RC == "csh" ]]; then
-    echo "setenv SCT_DIR $SCT_DIR" >>$RC_FILE_PATH
-    echo "setenv MPLBACKEND Agg" >>$RC_FILE_PATH
-  fi
-  # add line
-  echo "" >>$RC_FILE_PATH
+  (
+    echo
+    echo ""
+    echo "# SPINALCORDTOOLBOX (installed on $(date +%Y-%m-%d\ %H:%M:%S))"
+    echo "$DISPLAY_UPDATE_PATH"
+    # Switch between shell
+    if [[ "$THE_RC" == "bash" ]]; then
+      echo "export SCT_DIR=$SCT_DIR"
+      echo "export MPLBACKEND=Agg"
+    elif [[ "$THE_RC" == "csh" ]]; then
+      echo "setenv SCT_DIR $SCT_DIR"
+      echo "setenv MPLBACKEND Agg"
+    fi
+    # add line
+    echo ""
+  ) >> "$RC_FILE_PATH"
 }
 
 # Download from URL using curl/wget
@@ -350,15 +353,15 @@ while getopts ":dbyvh" opt; do
   case $opt in
   d)
     echo " data directory will not be (re)-installed"
-    NO_DATA_INSTALL=yes
+    NO_DATA_INSTALL="yes"
     ;;
   b)
     echo " SCT binaries will not be (re)-installed "
-    NO_SCT_BIN_INSTALL=yes
+    NO_SCT_BIN_INSTALL="yes"
     ;;
   y)
     echo " non-interactive mode"
-    NONINTERACTIVE=yes
+    NONINTERACTIVE="yes"
     ;;
   v)
     echo " Full verbose!"
@@ -382,7 +385,7 @@ done
 
 # Catch SCT version
 if [[ -e "spinalcordtoolbox/version.txt" ]]; then
-  SCT_VERSION=$(cat spinalcordtoolbox/version.txt)
+  SCT_VERSION="$(cat spinalcordtoolbox/version.txt)"
 else
   die "ERROR: version.txt not found. \n
 The install_sct script must be executed from the source directory"
@@ -402,12 +405,12 @@ fi
 get_shell_rc_path
 
 # Display install info
-echo -e "\nSCT version ......... "$SCT_VERSION
-echo -e "Installation type ... "$SCT_INSTALL_TYPE
+echo -e "\nSCT version ......... $SCT_VERSION"
+echo -e "Installation type ... $SCT_INSTALL_TYPE"
 echo -e "Operating system .... $OS ($OSver)"
-echo -e "Shell config ........ "$RC_FILE_PATH
+echo -e "Shell config ........ $RC_FILE_PATH"
 
-REPORT_STATS=no
+REPORT_STATS="no"
 if [ -z "$NONINTERACTIVE" ]; then
   # Send crash statistic and error logs to developers, that is the question:
   print question "To improve user experience and fix bugs, the SCT development team is using a
@@ -418,7 +421,7 @@ Do you agree to help us improve SCT? [y]es/[n]o: "
   read REPORT_STATS
 fi
 
-if [[ $REPORT_STATS =~ [Yy](es)? ]]; then
+if [[ "$REPORT_STATS" =~ [Yy](es)? ]]; then
   echo -ne '# Auto-generated by install_sct\nimport os\nSENTRY_DSN=os.environ.get("SCT_SENTRY_DSN", "https://5202d7c96ad84f17a24bd2653f1c4f9e:c1394bb176cc426caf0ff6a9095fb955@sentry.io/415369")\n' >spinalcordtoolbox/sentry_dsn.py
   print info "--> Crash reports will be sent to the SCT development team. Thank you!"
 else
@@ -427,7 +430,7 @@ fi
 
 # if installing from git folder, then becomes default installation folder
 if [[ "$SCT_INSTALL_TYPE" == "in-place" ]]; then
-  SCT_DIR=$SCT_SOURCE
+  SCT_DIR="$SCT_SOURCE"
 else
   SCT_DIR="$HOME/sct_$SCT_VERSION"
 fi
@@ -435,16 +438,16 @@ fi
 # Set install dir
 while true; do
   keep_default_path=""
-  while [[ ! $keep_default_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
+  while [[ ! "$keep_default_path" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
     print info "SCT will be installed here: [$SCT_DIR]"
-    keep_default_path=yes
+    keep_default_path="yes"
     if [ -z "$NONINTERACTIVE" ]; then
       print question "
 Do you agree? [y]es/[n]o: "
       read keep_default_path
     fi
   done
-  if [[ $keep_default_path =~ ^[Yy] ]]; then
+  if [[ "$keep_default_path" =~ ^[Yy] ]]; then
     # user accepts default path --> exit loop
     break
   fi
@@ -456,9 +459,9 @@ Do you agree? [y]es/[n]o: "
   read new_install
 
   # Expand ~/
-  new_install=${new_install/#\~\//$HOME\/}
+  new_install="${new_install/#\~\//$HOME\/}"
   # Remove trailing /
-  new_install=${new_install%/}
+  new_install="${new_install%/}"
 
   # Avoid horrible bug, like removing /bin if SCT_DIR "/" or $HOME/bin
   if [[ "$new_install" == "/" ]] || [[ "$HOME" == "${new_install%/}" ]]; then
@@ -468,19 +471,19 @@ Do you agree? [y]es/[n]o: "
   elif [[ -d "$new_install" ]]; then
     # directory exists --> update SCT_DIR and exit loop
     print warning "WARNING: Directory already exists. Files will be overwritten."
-    SCT_DIR=$new_install
+    SCT_DIR="$new_install"
     break
   elif [[ ! "$new_install" ]]; then
     # If no input, asking again, and again, and again
     continue
   else
-    SCT_DIR=$new_install
+    SCT_DIR="$new_install"
     break
   fi
 done
 
 # Create directory
-mkdir -p $SCT_DIR
+mkdir -p "$SCT_DIR"
 # check if directory was created
 if [[ -d "$SCT_DIR" ]]; then
   # check write permission
@@ -501,7 +504,7 @@ else
 fi
 
 # Update MPLBACKEND on headless system. See: https://github.com/neuropoly/spinalcordtoolbox/issues/2137
-if [[ -z ${MLBACKEND:-} ]]; then
+if [[ -z "${MLBACKEND:-}" ]]; then
   export MPLBACKEND=Agg
 fi
 
@@ -514,18 +517,18 @@ else
 fi
 
 # Clean old install setup in bin/ if existing
-if [[ -x $SCT_DIR/$BIN_DIR ]]; then
+if [[ -x "$SCT_DIR/$BIN_DIR" ]]; then
   print info "Removing sct and isct softlink from $SCT_DIR/$BIN_DIR"
-  find $SCT_DIR/$BIN_DIR -type l -name 'sct_*' -exec rm {} \;
-  find $SCT_DIR/$BIN_DIR -type l -name 'isct_*' -exec rm {} \;
+  find "$SCT_DIR/$BIN_DIR" -type l -name 'sct_*' -exec rm {} \;
+  find "$SCT_DIR/$BIN_DIR" -type l -name 'isct_*' -exec rm {} \;
 fi
 
 # Go to installation folder
-cd $SCT_DIR
+cd "$SCT_DIR"
 
 # Make sure we are in SCT folder (to avoid deleting folder from user)
 if [[ ! -f "spinalcordtoolbox/version.txt" ]]; then
-  die "ERROR: Cannot cd into SCT folder. SCT_DIR="$SCT_DIR
+  die "ERROR: Cannot cd into SCT folder. SCT_DIR=$SCT_DIR"
 fi
 
 
@@ -545,10 +548,10 @@ run "mkdir -p $SCT_DIR/$PYTHON_DIR"
 # Download miniconda
 case $OS in
 linux*)
-  download $TMP_DIR/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
   ;;
 osx)
-  download $TMP_DIR/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+  download "$TMP_DIR/"miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
   ;;
 esac
 
@@ -584,7 +587,7 @@ else
   print info "Using requirements.txt (git installation)"
   export REQUIREMENTS_FILE="requirements.txt"
 fi
-pip install -r $REQUIREMENTS_FILE &&
+pip install -r "$REQUIREMENTS_FILE" &&
   # `tensorflow-tensorboard` is installed by `tensorflow==1.5.0` but is not needed,
   # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
   # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.
@@ -605,8 +608,8 @@ fi
 
 ## Create launchers for Python scripts
 print info "Creating launchers for Python scripts..."
-mkdir -p $SCT_DIR/$BIN_DIR
-for file in $SCT_DIR/python/envs/venv_sct/bin/*sct*; do
+mkdir -p "$SCT_DIR/$BIN_DIR"
+for file in "$SCT_DIR"/python/envs/venv_sct/bin/*sct*; do
   cp "$file" "$SCT_DIR/$BIN_DIR/"
   res=$?
   if [[ $res != 0 ]]; then
@@ -632,7 +635,7 @@ fi
 print info "All requirements installed!"
 
 # Install data
-if [[ -n ${NO_DATA_INSTALL:-} ]]; then
+if [[ -n "${NO_DATA_INSTALL:-}" ]]; then
   print warning "WARNING: data/ will not be (re)-install"
 else
   # Download data
@@ -664,15 +667,15 @@ fi
 
 # update PATH environment
 add_to_path=""
-while [[ ! $add_to_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-  add_to_path=yes
+while [[ ! "$add_to_path" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
+  add_to_path="yes"
   if [ -z "$NONINTERACTIVE" ]; then
     print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
     read add_to_path
   fi
 done
 
-if [[ $add_to_path =~ ^[Yy] ]]; then
+if [[ "$add_to_path" =~ ^[Yy] ]]; then
   edit_shellrc
 else
   print info "Not adding $SCT_DIR to \$PATH.
@@ -684,7 +687,7 @@ print info "Validate installation..."
 # We run the sct_check_dependencies in the TMP_DIR so the tmp.XXX output
 # it creates is cleaned properly
 if sct_check_dependencies; then
-  if [[ $add_to_path =~ ^[Nn] ]]; then
+  if [[ "$add_to_path" =~ ^[Nn] ]]; then
     print info "To use SCT, please update your environment by running:
 $DISPLAY_UPDATE_PATH"
   else

--- a/install_sct
+++ b/install_sct
@@ -82,10 +82,13 @@ function die() {
 # Run a command and display it in color. Exit if error.
 # @input: string: command to run
 function run() {
-  print code "$@"
-  if ! "$@" ; then
-    die "ERROR: Command failed."
-  fi
+  ( # this subshell means the 'die' only kills this function and not the whole script;
+    # the caller can decide what to do instead (but with set -e that usually means terminating the whole script)
+    print code "$@"
+    if ! "$@" ; then
+      die "ERROR: Command failed."
+    fi
+  )
 }
 
 # Force a clean exit

--- a/install_sct
+++ b/install_sct
@@ -433,17 +433,17 @@ fi
 
 # Set install dir
 while true; do
-  change_default_path=""
-  while [[ ! $change_default_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
+  keep_default_path=""
+  while [[ ! $keep_default_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
     print info "SCT will be installed here: [$SCT_DIR]"
-    change_default_path=no
-    if [ -z "$NONINTERACTIVE"]; then
+    keep_default_path=yes
+    if [ -z "$NONINTERACTIVE" ]; then
       print question "
 Do you agree? [y]es/[n]o: "
-      read change_default_path
+      read keep_default_path
     fi
   done
-  if [[ $change_default_path =~ ^[Yy] ]]; then
+  if [[ $keep_default_path =~ ^[Yy] ]]; then
     # user accepts default path --> exit loop
     break
   fi

--- a/install_sct
+++ b/install_sct
@@ -550,7 +550,10 @@ yes | python/bin/conda create -n venv_sct python=3.6
 
 # activate miniconda
 source python/etc/profile.d/conda.sh
+set +u #disable safeties, for conda is not written to their standard.
 conda activate venv_sct
+set -u # reactivate safeties
+
 # double-check conda activated (it can be glitchy): https://github.com/neuropoly/spinalcordtoolbox/issues/3029
 EXPECTED_PYTHON="$(realpath "$(command -v python/envs/venv_sct/bin/python)")"
 ACTUAL_PYTHON="$(realpath "$(command -v python)")"

--- a/install_sct
+++ b/install_sct
@@ -652,8 +652,9 @@ python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.mo
 # Validate installation
 # ----------------------------------------------------------------------------------------------------------------------
 
-# Deactivating conda
-. $SCT_DIR/$PYTHON_DIR/bin/deactivate >/dev/null 2>&1
+# conda is only for a sandbox; users don't use it,
+# so neither should our post-install tests
+conda deactivate >/dev/null 2>&1
 
 # In case of previous SCT installation (4.0.0-beta.1 or before), remove sct_env declaration in bashrc
 print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"

--- a/install_sct
+++ b/install_sct
@@ -477,6 +477,16 @@ Do you agree? [y]es/[n]o: "
   fi
 done
 
+# update PATH environment?
+add_to_path=""
+while [[ ! "$add_to_path" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
+  add_to_path="yes"
+  if [ -z "$NONINTERACTIVE" ]; then
+    print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
+    read add_to_path
+  fi
+done
+
 # Create directory
 mkdir -p "$SCT_DIR"
 # check if directory was created
@@ -651,16 +661,6 @@ if [[ -e "$RC_FILE_PATH" ]]; then
     print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
     sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
 fi
-
-# update PATH environment
-add_to_path=""
-while [[ ! "$add_to_path" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-  add_to_path="yes"
-  if [ -z "$NONINTERACTIVE" ]; then
-    print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
-    read add_to_path
-  fi
-done
 
 if [[ "$add_to_path" =~ ^[Yy] ]]; then
   edit_shellrc

--- a/install_sct
+++ b/install_sct
@@ -656,10 +656,12 @@ python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.mo
 
 # In case of previous SCT installation (4.0.0-beta.1 or before), remove sct_env declaration in bashrc
 print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
-if [[ $OS == "osx" ]]; then
-  sed -ie '/sct_env/ s/^#*/#/' $RC_FILE_PATH
-else
-  sed -e '/sct_env/ s/^#*/#/' -i $RC_FILE_PATH
+if [[ -e "$RC_FILE_PATH" ]]; then
+  if [[ "$OS" == "osx" ]]; then
+    sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
+  else
+    sed -e '/sct_env/ s/^#*/#/' -i "$RC_FILE_PATH"
+  fi
 fi
 
 # update PATH environment

--- a/install_sct
+++ b/install_sct
@@ -176,9 +176,9 @@ function check_requirements() {
       done
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(which brew) ]]; then
-          yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+          NONINTERACTIVE=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         fi
-        yes | brew install gcc
+        brew install -f gcc
         # check if gcc install ran properly
         gcc --version > /dev/null 2>&1  # run silently, then check output status
         if [[ $? -ne 0 ]]; then
@@ -546,7 +546,7 @@ esac
 run "bash $TMP_DIR/miniconda.sh -p $SCT_DIR/$PYTHON_DIR -b -f"
 
 # create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-yes | python/bin/conda create -n venv_sct python=3.6
+python/bin/conda create -y -n venv_sct python=3.6
 
 # activate miniconda
 source python/etc/profile.d/conda.sh
@@ -579,8 +579,8 @@ pip install -r $REQUIREMENTS_FILE &&
   # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
   # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.
   # See https://github.com/neuropoly/spinalcordtoolbox/issues/3035 for more info.
-  yes | pip uninstall tensorflow-tensorboard &&
-  yes | pip uninstall tensorboard &&
+  pip uninstall -y tensorflow-tensorboard &&
+  pip uninstall -y tensorboard &&
   pip install tensorboard
 if [[ $? != 0 ]]; then
   die "Failed running pip install: $?"

--- a/install_sct
+++ b/install_sct
@@ -85,8 +85,7 @@ function die() {
 function run() {
   cmd="$1"
   print code "$cmd"
-  $cmd
-  if [[ $? != 0 ]]; then
+  if ! $cmd ; then
     die "ERROR: Command failed."
   fi
 }
@@ -166,8 +165,7 @@ function check_requirements() {
     die "ERROR: neither \"curl\" nor \"wget\" is installed. Please install either of them and restart SCT installation."
   fi
   # check gcc
-  gcc --version > /dev/null 2>&1  # run silently, then check output status
-  if [[ $? -ne 0 ]]; then
+  if ! gcc --version > /dev/null 2>&1; then
     print warning "WARNING: \"gcc\" is not installed."
     if [[ "$OS" == "osx" ]]; then
       while [[ ! "$GCC_INSTALL" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
@@ -184,8 +182,7 @@ function check_requirements() {
         fi
         brew install -f gcc
         # check if gcc install ran properly
-        gcc --version > /dev/null 2>&1  # run silently, then check output status
-        if [[ $? -ne 0 ]]; then
+        if ! gcc --version > /dev/null 2>&1; then
           die "ERROR: Installation of \"gcc\" failed. Please contact SCT team for assistance."
         fi
       else
@@ -576,7 +573,7 @@ if [ "$ACTUAL_PYTHON" != "$EXPECTED_PYTHON"  ]; then
 fi
 
 
-# Install Python dependencies
+## Install the spinalcordtoolbox into the Conda venv
 print info "Installing Python dependencies..."
 # Check if a frozen version of the requirements exist (for release only)
 if [[ -f "requirements-freeze.txt" ]]; then
@@ -587,34 +584,27 @@ else
   print info "Using requirements.txt (git installation)"
   export REQUIREMENTS_FILE="requirements.txt"
 fi
-pip install -r "$REQUIREMENTS_FILE" &&
+(
+  pip install -r "$REQUIREMENTS_FILE" &&
   # `tensorflow-tensorboard` is installed by `tensorflow==1.5.0` but is not needed,
   # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
   # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.
   # See https://github.com/neuropoly/spinalcordtoolbox/issues/3035 for more info.
   pip uninstall -y tensorflow-tensorboard &&
   pip uninstall -y tensorboard &&
-  pip install tensorboard
-if [[ $? != 0 ]]; then
+  pip install tensorboard &&
+  # install sct itself
+  print info "Installing spinalcordtoolbox..." &&
+  pip install -e .
+) ||
   die "Failed running pip install: $?"
-fi
 
-## Install the spinalcordtoolbox into the Conda venv
-pip install -e $SCT_DIR
-e_status=$?
-if [[ $e_status != 0 ]]; then
-  die "Failed to pip install sct."
-fi
 
 ## Create launchers for Python scripts
 print info "Creating launchers for Python scripts..."
 mkdir -p "$SCT_DIR/$BIN_DIR"
 for file in "$SCT_DIR"/python/envs/venv_sct/bin/*sct*; do
-  cp "$file" "$SCT_DIR/$BIN_DIR/"
-  res=$?
-  if [[ $res != 0 ]]; then
-    die "Problem creating launchers!"
-  fi
+  cp "$file" "$SCT_DIR/$BIN_DIR/" || die "Problem creating launchers!"
 done
 
 # Activate the launchers, particularly sct_download_data and sct_check_requirements

--- a/install_sct
+++ b/install_sct
@@ -274,28 +274,29 @@ function edit_shellrc() {
 # Download from URL using curl/wget
 function download() {
   # Use curl or wget to download goodies
-  e_status=0
-  # Try with wget
-  if [[ $(command -v wget) ]]; then
-    cmd="wget -O $1 $2"
-    print code "$cmd"
-    $cmd
-    e_status=$?
-    echo exit status is $e_status
-  fi
-  # Try with curl
-  if [[ $(command -v curl) && ! -e $1 ]]; then
-    cmd="curl -o $1 -L $2"
-    print code "$cmd"
-    $cmd
-    e_status=$?
-    echo exit status is $e_status
-  fi
-  # check success
-  if [[ $e_status -ne 0 || ! -e $1 ]]; then
-    die "The download of $2 failed\n
+#   e_status=0
+#   # Try with wget
+#   ( (command -v wget) ]]; then
+#     run wget -O "$1" "$2"
+#     e_status="$?"
+#     echo exit status is "$e_status"
+#   fi
+#   # Try with curl
+#   if [[ $(command -v curl) && ! -e "$1" ]]; then
+#
+#     e_status="$?"
+#     echo exit status is "$e_status"
+#   fi
+#   # check success
+#   if [[ "$e_status" -ne 0 || ! -e "$1" ]]; then
+#     die "The download of $2 failed\n
+# Please check your internet connection before relaunching the installer\n"
+#   fi
+# TODO: check all combinations of errors here
+  ((command -v wget >/dev/null) && run wget -O "$1" "$2" ) ||
+  ((command -v curl >/dev/null) && run curl -o "$1" -L "$2" ) ||
+  die "The download of $2 failed\n
 Please check your internet connection before relaunching the installer\n"
-  fi
 }
 
 # Usage of this script

--- a/install_sct
+++ b/install_sct
@@ -59,23 +59,23 @@ function print() {
   case "$type" in
   # Display useful info (green)
   info)
-    echo -e "\n\033[0;32m${@}\033[0m\n"
+    echo -e "\n\033[0;32m${*}\033[0m\n"
     ;;
   # To interact with user (no carriage return) (light green)
   question)
-    echo -e -n "\n\033[0;92m${@}\033[0m"
+    echo -e -n "\n\033[0;92m${*}\033[0m"
     ;;
   # To display code that is being run in the Terminal (blue)
   code)
-    echo -e "\n\033[0;34m${@}\033[0m\n"
+    echo -e "\n\033[0;34m${*}\033[0m\n"
     ;;
   # Warning message (yellow)
   warning)
-    echo -e "\n\033[0;93m${@}\033[0m\n"
+    echo -e "\n\033[0;93m${*}\033[0m\n"
     ;;
   # Error message (red)
   error)
-    echo -e "\n\033[0;31m${@}\033[0m\n"
+    echo -e "\n\033[0;31m${*}\033[0m\n"
     ;;
   esac
 }

--- a/install_sct
+++ b/install_sct
@@ -515,8 +515,8 @@ fi
 # Clean old install setup in bin/ if existing
 if [[ -x $SCT_DIR/$BIN_DIR ]]; then
   print info "Removing sct and isct softlink from $SCT_DIR/$BIN_DIR"
-  find $SCT_DIR/$BIN_DIR -type l -name \"sct_*\" -exec rm {} \;
-  find $SCT_DIR/$BIN_DIR -type l -name \"isct_*\" -exec rm {} \;
+  find $SCT_DIR/$BIN_DIR -type l -name 'sct_*' -exec rm {} \;
+  find $SCT_DIR/$BIN_DIR -type l -name 'isct_*' -exec rm {} \;
 fi
 
 # Go to installation folder

--- a/install_sct
+++ b/install_sct
@@ -20,8 +20,14 @@
 # Authors: PO Quirion, J Cohen-Adad, J Carretero
 # License: see the file LICENSE.TXT
 
-# set -v  # v: verbose, e: exit if non-zero output is encountered. Using set -e will exit even when trying to remove
-# a folder that already exists, therefore, it should only be used for debugging mode.
+# stricter shell mode
+# https://sipb.mit.edu/doc/safe-shell/
+set -eo pipefail  # exit if non-zero error is encountered (even in a pipeline)
+set -u            # exit if unset variables used
+shopt -s failglob # error if a glob fails
+
+# set -v  # v: verbose
+
 
 # Where tmp file are stored
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'TMP_DIR')
@@ -102,7 +108,7 @@ Please copy the historic of this Terminal (starting with the command install_sct
 --> http://forum.spinalcordmri.org/c/sct"
   fi
   # clean tmp_dir
-  rm -r $TMP_DIR
+  rm -rf $TMP_DIR
   exit $value
 }
 

--- a/install_sct
+++ b/install_sct
@@ -346,7 +346,7 @@ for arg in "$@"; do
 done
 
 NONINTERACTIVE=""
-while getopts ":dhbpvy" opt; do
+while getopts ":dhbvy" opt; do
   case $opt in
   d)
     echo " data directory will not be (re)-installed"

--- a/install_sct
+++ b/install_sct
@@ -380,7 +380,7 @@ The install_sct script must be executed from the source directory"
 fi
 
 # Get installation type (from git or from package)
-if [[ "x$SCT_INSTALL_TYPE" == "x" ]]; then
+if [[ -z "${SCT_INSTALL_TYPE:-}" ]]; then
   if [[ -d ".git" ]]; then
     # folder .git exist, therefore it is a git installation
     SCT_INSTALL_TYPE="in-place"
@@ -401,6 +401,7 @@ echo -e "Shell config ........ "$RC_FILE_PATH
 # If you do not want the crash reports question to be ask,
 # set ASK_REPORT_QUESTION at installation time like this:
 # >>> ASK_REPORT_QUESTION=false ./install_sct
+: ${ASK_REPORT_QUESTION:=Yes}
 REPORT_STATS=no
 if [[ ! $ASK_REPORT_QUESTION =~ ^([[Ff]alse?|[Nn]o?)$ ]]; then
 # Send crash statistic and error logs to developers, that is the question:
@@ -429,6 +430,7 @@ fi
 # Set install dir
 while true; do
 #  print info "SCT will be installed here: [$SCT_DIR]"
+  change_default_path=""
   while [[ ! $change_default_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
     print question "SCT will be installed here: [$SCT_DIR]
 
@@ -489,14 +491,14 @@ else
 fi
 
 # Update MPLBACKEND on headless system. See: https://github.com/neuropoly/spinalcordtoolbox/issues/2137
-if [[ -z $MPLBACKEND ]]; then
+if [[ -z ${MLBACKEND:-} ]]; then
   export MPLBACKEND=Agg
 fi
 
 # Copy files to destination directory
 if [[ "$SCT_DIR" != "$SCT_SOURCE" ]]; then
   print info "Copying source files from $SCT_SOURCE to $SCT_DIR"
-  cp -vR $SCT_INSTALL_CP_OPTIONS "$SCT_SOURCE/"* "$SCT_DIR/" | while read line; do echo -n "."; done
+  cp -vR "$SCT_SOURCE/"* "$SCT_DIR/" | while read line; do echo -n "."; done
 else
   print info "Skipping copy of source files (source and destination folders are the same)"
 fi
@@ -607,7 +609,7 @@ export PATH="$SCT_DIR/$BIN_DIR:$PATH"
 # ----------------------------------------------------------------------------------------------------------------------
 
 # Install binaries
-if [[ $NO_SCT_BIN_INSTALL ]]; then
+if [[ -n ${NO_SCT_BIN_INSTALL:-} ]]; then
   print warning "WARNING: SCT binaries will not be (re)-installed"
 else
   print info "Installing binaries..."
@@ -617,7 +619,7 @@ fi
 print info "All requirements installed!"
 
 # Install data
-if [[ $NO_DATA_INSTALL ]]; then
+if [[ -n ${NO_DATA_INSTALL:-} ]]; then
   print warning "WARNING: data/ will not be (re)-install"
 else
   # Download data
@@ -649,6 +651,7 @@ else
 fi
 
 # update PATH environment
+add_to_path=""
 while [[ ! $add_to_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
   print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
   read add_to_path

--- a/install_sct
+++ b/install_sct
@@ -657,11 +657,7 @@ python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.mo
 # In case of previous SCT installation (4.0.0-beta.1 or before), remove sct_env declaration in bashrc
 print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
 if [[ -e "$RC_FILE_PATH" ]]; then
-  if [[ "$OS" == "osx" ]]; then
     sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
-  else
-    sed -e '/sct_env/ s/^#*/#/' -i "$RC_FILE_PATH"
-  fi
 fi
 
 # update PATH environment

--- a/install_sct
+++ b/install_sct
@@ -625,7 +625,7 @@ export PATH="$SCT_DIR/$BIN_DIR:$PATH"
 # ----------------------------------------------------------------------------------------------------------------------
 
 # Install binaries
-if [[ -n ${NO_SCT_BIN_INSTALL:-} ]]; then
+if [[ -n "${NO_SCT_BIN_INSTALL:-}" ]]; then
   print warning "WARNING: SCT binaries will not be (re)-installed"
 else
   print info "Installing binaries..."

--- a/install_sct
+++ b/install_sct
@@ -272,8 +272,8 @@ function edit_shellrc() {
 
 # Download from URL using curl/wget
 function download() {
-  ((command -v wget >/dev/null) && run wget -O "$1" "$2" ) ||
-  ((command -v curl >/dev/null) && run curl -o "$1" -L "$2" ) ||
+  ( (command -v wget >/dev/null) && run wget -O "$1" "$2" ) ||
+  ( (command -v curl >/dev/null) && run curl -o "$1" -L "$2" ) ||
   die "The download of $2 failed
 Please check that you have wget or curl installed, and
 your internet connection before relaunching the installer"

--- a/install_sct
+++ b/install_sct
@@ -292,11 +292,29 @@ Please check your internet connection before relaunching the installer\n"
 
 # Usage of this script
 function usage() {
-  echo -e "\nUsage: $0 [-d] [-b] [-v]" 1>&2
-  echo -e "\nOPTION"
-  echo -e "\t-d \v Prevent the (re)-installation of the \"data/\" directory "
-  echo -e "\n\t-b \v Prevent the (re)-installation of the SCT binaries files "
-  echo -e "\n\t-v \v Full verbose"
+  # extract the usage block from our own header
+  awk '
+    BEGIN {
+      printing=0
+      blanks=0
+    }
+
+    # filter for block-comments
+    $0 !~ /^#/   { next }
+    # strip off the leading "# "
+                 { sub("^#[[:space:]]?","") }
+
+    # count consecutive blank lines
+    # so we can detect the section break
+    /^$/         { blanks++ }
+    $0 !~ /^$/   { blanks=0 }
+
+    # detect usage section
+    /USAGE/      { printing=1 }
+    printing==1  { print }
+    (printing==1 && blanks>=2) \
+                 { exit }
+  ' "$0"
 }
 
 if [ "$(uname)" = "Darwin" ]; then

--- a/install_sct
+++ b/install_sct
@@ -13,8 +13,16 @@
 # installation is successful.
 #
 # USAGE
-#   ./install_sct
-#   ./install_sct -y  # will install without interruption with 'yes' as default answer
+#   ./install_sct [-h] [-i] [-y] [-d] [-b] [-v]
+#
+# OPTIONS
+#  -h   Show this help
+#  -i   Install in-place; this is the default when working from git.
+#  -y   Install without interruption with 'yes' as default answer
+#  -d   Prevent the (re)-installation of the data/ directory
+#  -b   Prevent the (re)-installation of the SCT binaries files
+#  -v   Full verbose
+#
 #
 # Copyright (c) 2019 Polytechnique Montreal <www.neuro.polymtl.ca>
 # Authors: PO Quirion, J Cohen-Adad, J Carretero
@@ -364,9 +372,19 @@ for arg in "$@"; do
   esac
 done
 
+SCT_INSTALL_TYPE=""
 NONINTERACTIVE=""
-while getopts ":dbyvh" opt; do
+NO_DATA_INSTALL=""
+NO_SCT_BIN_INSTALL=""
+while getopts ":iydbvh" opt; do
   case $opt in
+  i)
+    SCT_INSTALL_TYPE="in-place"
+    ;;
+  y)
+    echo " non-interactive mode"
+    NONINTERACTIVE="yes"
+    ;;
   d)
     echo " data directory will not be (re)-installed"
     NO_DATA_INSTALL="yes"
@@ -375,19 +393,15 @@ while getopts ":dbyvh" opt; do
     echo " SCT binaries will not be (re)-installed "
     NO_SCT_BIN_INSTALL="yes"
     ;;
-  y)
-    echo " non-interactive mode"
-    NONINTERACTIVE="yes"
-    ;;
   v)
     echo " Full verbose!"
     set -x
     ;;
   h)
     usage
-    exit 99
+    exit 0
     ;;
-  \?)
+  *)
     usage
     exit 99
     ;;

--- a/install_sct
+++ b/install_sct
@@ -179,8 +179,8 @@ function check_requirements() {
       done
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(command -v brew) ]]; then
-          # NB: this is a different NONINTERACTIVE, for the brew installer
-          (NONINTERACTIVE=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)")
+          # NB: this is a different NONINTERACTIVE than ours above; it's for the brew installer
+          (NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)")
         fi
         brew install -f gcc
         # check if gcc install ran properly

--- a/install_sct
+++ b/install_sct
@@ -162,7 +162,7 @@ function fetch_os_type() {
 function check_requirements() {
   print info "Checking requirements..."
   # check curl
-  if [[ ! $(which curl) && ! $(which wget) ]]; then
+  if [[ ! ( $(command -v curl) || $(command -v wget) ) ]]; then
     die "ERROR: neither \"curl\" nor \"wget\" is installed. Please install either of them and restart SCT installation."
   fi
   # check gcc
@@ -178,7 +178,7 @@ function check_requirements() {
         fi
       done
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
-        if [[ ! $(which brew) ]]; then
+        if [[ ! $(command -v brew) ]]; then
           # NB: this is a different NONINTERACTIVE, for the brew installer
           (NONINTERACTIVE=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)")
         fi
@@ -267,7 +267,7 @@ function download() {
   # Use curl or wget to download goodies
   e_status=0
   # Try with wget
-  if [[ $(which wget) ]]; then
+  if [[ $(command -v wget) ]]; then
     cmd="wget -O $1 $2"
     print code "$cmd"
     $cmd
@@ -275,7 +275,7 @@ function download() {
     echo exit status is $e_status
   fi
   # Try with curl
-  if [[ $(which curl) && ! -e $1 ]]; then
+  if [[ $(command -v curl) && ! -e $1 ]]; then
     cmd="curl -o $1 -L $2"
     print code "$cmd"
     $cmd

--- a/install_sct
+++ b/install_sct
@@ -104,7 +104,7 @@ function finish() {
     echo ""
   else
     print error "Installation failed!\n
-Please copy the historic of this Terminal (starting with the command install_sct) and paste it in a new created topic on SCT's forum:\n
+Please copy the output of this Terminal (starting with the command install_sct) and upload it as a .txt attachment in a new topic on SCT's forum:\n
 --> http://forum.spinalcordmri.org/c/sct"
   fi
   # clean tmp_dir

--- a/install_sct
+++ b/install_sct
@@ -14,7 +14,7 @@
 #
 # USAGE
 #   ./install_sct
-#   yes | ./install_sct   # will install without interruption with 'yes' as default answer
+#   ./install_sct -y  # will install without interruption with 'yes' as default answer
 #
 # Copyright (c) 2019 Polytechnique Montreal <www.neuro.polymtl.ca>
 # Authors: PO Quirion, J Cohen-Adad, J Carretero
@@ -171,12 +171,16 @@ function check_requirements() {
     print warning "WARNING: \"gcc\" is not installed."
     if [[ $OS == "osx" ]]; then
       while [[ ! $GCC_INSTALL =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-        print question "Do you want to install it now? (accepting to install \"gcc\" will also install \"brew\" in case it is not installed already)? [y]es/[n]o: "
-        read GCC_INSTALL
+        GCC_INSTALL=yes # rude?
+        if [ -z "$NONINTERACTIVE" ]; then
+          print question "Do you want to install it now? (accepting to install \"gcc\" will also install \"brew\" in case it is not installed already)? [y]es/[n]o: "
+          read GCC_INSTALL
+        fi
       done
       if [[ $GCC_INSTALL =~ [Yy](es)? ]]; then
         if [[ ! $(which brew) ]]; then
-          NONINTERACTIVE=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+          # NB: this is a different NONINTERACTIVE, for the brew installer
+          (NONINTERACTIVE=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)")
         fi
         brew install -f gcc
         # check if gcc install ran properly
@@ -341,7 +345,8 @@ for arg in "$@"; do
   esac
 done
 
-while getopts ":dhbpv" opt; do
+NONINTERACTIVE=""
+while getopts ":dhbpvy" opt; do
   case $opt in
   d)
     echo " data directory will not be (re)-installed"
@@ -358,6 +363,9 @@ while getopts ":dhbpv" opt; do
   h)
     usage
     exit 99
+    ;;
+  y)
+    NONINTERACTIVE=yes
     ;;
   \?)
     usage
@@ -398,13 +406,9 @@ echo -e "Installation type ... "$SCT_INSTALL_TYPE
 echo -e "Operating system .... $OS ($OSver)"
 echo -e "Shell config ........ "$RC_FILE_PATH
 
-# If you do not want the crash reports question to be ask,
-# set ASK_REPORT_QUESTION at installation time like this:
-# >>> ASK_REPORT_QUESTION=false ./install_sct
-: ${ASK_REPORT_QUESTION:=Yes}
 REPORT_STATS=no
-if [[ ! $ASK_REPORT_QUESTION =~ ^([[Ff]alse?|[Nn]o?)$ ]]; then
-# Send crash statistic and error logs to developers, that is the question:
+if [ -z "$NONINTERACTIVE" ]; then
+  # Send crash statistic and error logs to developers, that is the question:
   print question "To improve user experience and fix bugs, the SCT development team is using a
 report system to automatically receive crash reports and errors from users.
 These reports are anonymous.
@@ -429,18 +433,23 @@ fi
 
 # Set install dir
 while true; do
-#  print info "SCT will be installed here: [$SCT_DIR]"
   change_default_path=""
   while [[ ! $change_default_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-    print question "SCT will be installed here: [$SCT_DIR]
-
+    print info "SCT will be installed here: [$SCT_DIR]"
+    change_default_path=no
+    if [ -z "$NONINTERACTIVE"]; then
+      print question "
 Do you agree? [y]es/[n]o: "
-    read change_default_path
+      read change_default_path
+    fi
   done
   if [[ $change_default_path =~ ^[Yy] ]]; then
     # user accepts default path --> exit loop
     break
   fi
+
+  # ASSUMPTION: the rest of these are not guarded by $NONINTERACTIVE because this loop should have been broken already in that case.
+
   print question "Choose install directory. Warning! Give full path (e.g. /usr/django/sct_v3.0): \n"
   # user enters new path
   read new_install
@@ -656,8 +665,11 @@ fi
 # update PATH environment
 add_to_path=""
 while [[ ! $add_to_path =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-  print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
-  read add_to_path
+  add_to_path=yes
+  if [ -z "$NONINTERACTIVE" ]; then
+    print question "Do you want to add the sct_* scripts to your PATH environment? [y]es/[n]o: "
+    read add_to_path
+  fi
 done
 
 if [[ $add_to_path =~ ^[Yy] ]]; then

--- a/install_sct
+++ b/install_sct
@@ -346,7 +346,7 @@ for arg in "$@"; do
 done
 
 NONINTERACTIVE=""
-while getopts ":dhbvy" opt; do
+while getopts ":dbyvh" opt; do
   case $opt in
   d)
     echo " data directory will not be (re)-installed"
@@ -356,6 +356,10 @@ while getopts ":dhbvy" opt; do
     echo " SCT binaries will not be (re)-installed "
     NO_SCT_BIN_INSTALL=yes
     ;;
+  y)
+    echo " non-interactive mode"
+    NONINTERACTIVE=yes
+    ;;
   v)
     echo " Full verbose!"
     set -x
@@ -363,9 +367,6 @@ while getopts ":dhbvy" opt; do
   h)
     usage
     exit 99
-    ;;
-  y)
-    NONINTERACTIVE=yes
     ;;
   \?)
     usage

--- a/install_sct
+++ b/install_sct
@@ -273,30 +273,11 @@ function edit_shellrc() {
 
 # Download from URL using curl/wget
 function download() {
-  # Use curl or wget to download goodies
-#   e_status=0
-#   # Try with wget
-#   ( (command -v wget) ]]; then
-#     run wget -O "$1" "$2"
-#     e_status="$?"
-#     echo exit status is "$e_status"
-#   fi
-#   # Try with curl
-#   if [[ $(command -v curl) && ! -e "$1" ]]; then
-#
-#     e_status="$?"
-#     echo exit status is "$e_status"
-#   fi
-#   # check success
-#   if [[ "$e_status" -ne 0 || ! -e "$1" ]]; then
-#     die "The download of $2 failed\n
-# Please check your internet connection before relaunching the installer\n"
-#   fi
-# TODO: check all combinations of errors here
   ((command -v wget >/dev/null) && run wget -O "$1" "$2" ) ||
   ((command -v curl >/dev/null) && run curl -o "$1" -L "$2" ) ||
-  die "The download of $2 failed\n
-Please check your internet connection before relaunching the installer\n"
+  die "The download of $2 failed
+Please check that you have wget or curl installed, and
+your internet connection before relaunching the installer"
 }
 
 # Usage of this script
@@ -583,8 +564,8 @@ export PYTHONNOUSERSITE=1
 
 # Remove old python folder
 print info "Installing conda..."
-run "rm -rf $SCT_DIR/$PYTHON_DIR"
-run "mkdir -p $SCT_DIR/$PYTHON_DIR"
+run rm -rf "$SCT_DIR/$PYTHON_DIR"
+run mkdir -p "$SCT_DIR/$PYTHON_DIR"
 
 # Download miniconda
 case $OS in
@@ -597,7 +578,7 @@ osx)
 esac
 
 # Run conda installer
-run "bash $TMP_DIR/miniconda.sh -p $SCT_DIR/$PYTHON_DIR -b -f"
+run bash "$TMP_DIR/miniconda.sh" -p "$SCT_DIR/$PYTHON_DIR" -b -f
 
 # create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
 python/bin/conda create -y -n venv_sct python=3.6

--- a/install_sct
+++ b/install_sct
@@ -171,7 +171,7 @@ function check_requirements() {
     print warning "WARNING: \"gcc\" is not installed."
     if [[ $OS == "osx" ]]; then
       while [[ ! $GCC_INSTALL =~ ^([Yy](es)?|[Nn]o?)$ ]]; do
-        GCC_INSTALL=yes # rude?
+        GCC_INSTALL=no
         if [ -z "$NONINTERACTIVE" ]; then
           print question "Do you want to install it now? (accepting to install \"gcc\" will also install \"brew\" in case it is not installed already)? [y]es/[n]o: "
           read GCC_INSTALL

--- a/install_sct
+++ b/install_sct
@@ -586,11 +586,11 @@ print info "Installing Python dependencies..."
 # Check if a frozen version of the requirements exist (for release only)
 if [[ -f "requirements-freeze.txt" ]]; then
   print info "Using requirements-freeze.txt (release installation)"
-  export REQUIREMENTS_FILE="requirements-freeze.txt"
+  REQUIREMENTS_FILE="requirements-freeze.txt"
 else
   # Not a package
   print info "Using requirements.txt (git installation)"
-  export REQUIREMENTS_FILE="requirements.txt"
+  REQUIREMENTS_FILE="requirements.txt"
 fi
 (
   pip install -r "$REQUIREMENTS_FILE" &&

--- a/install_sct
+++ b/install_sct
@@ -658,8 +658,10 @@ conda deactivate >/dev/null 2>&1
 
 # In case of previous SCT installation (4.0.0-beta.1 or before), remove sct_env declaration in bashrc
 if [[ -e "$RC_FILE_PATH" ]]; then
-    print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
-    sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
+    if grep "sct_env" "$RC_FILE_PATH"; then
+      print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
+      sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
+    fi
 fi
 
 if [[ "$add_to_path" =~ ^[Yy] ]]; then

--- a/install_sct
+++ b/install_sct
@@ -46,30 +46,29 @@ MACOSSUPPORTED="13"  # Minimum version of macOS 10 supported
 
 # Print with color
 # @input1: {info, code, error}: type of text
-# @input2: text to print
+# rest of inputs: text to print
 function print() {
-  type=$1
-  txt=$2
+  type=$1; shift
   case "$type" in
   # Display useful info (green)
   info)
-    echo -e "\n\033[0;32m${txt}\033[0m\n"
+    echo -e "\n\033[0;32m${@}\033[0m\n"
     ;;
   # To interact with user (no carriage return) (light green)
   question)
-    echo -e -n "\n\033[0;92m${txt}\033[0m"
+    echo -e -n "\n\033[0;92m${@}\033[0m"
     ;;
   # To display code that is being run in the Terminal (blue)
   code)
-    echo -e "\n\033[0;34m${txt}\033[0m\n"
+    echo -e "\n\033[0;34m${@}\033[0m\n"
     ;;
   # Warning message (yellow)
   warning)
-    echo -e "\n\033[0;93m${txt}\033[0m\n"
+    echo -e "\n\033[0;93m${@}\033[0m\n"
     ;;
   # Error message (red)
   error)
-    echo -e "\n\033[0;31m${txt}\033[0m\n"
+    echo -e "\n\033[0;31m${@}\033[0m\n"
     ;;
   esac
 }
@@ -83,9 +82,8 @@ function die() {
 # Run a command and display it in color. Exit if error.
 # @input: string: command to run
 function run() {
-  cmd="$1"
-  print code "$cmd"
-  if ! $cmd ; then
+  print code "$@"
+  if ! "$@" ; then
     die "ERROR: Command failed."
   fi
 }
@@ -619,8 +617,7 @@ if [[ -n "${NO_SCT_BIN_INSTALL:-}" ]]; then
   print warning "WARNING: SCT binaries will not be (re)-installed"
 else
   print info "Installing binaries..."
-  run "sct_download_data -d binaries_${OS} -o ${SCT_DIR}/${BIN_DIR} -k" || \
-      die "Unsupported OS $OS: can't install binaries."
+  run sct_download_data -d "binaries_${OS}" -o "${SCT_DIR}/${BIN_DIR}" -k
 fi
 print info "All requirements installed!"
 
@@ -630,10 +627,10 @@ if [[ -n "${NO_DATA_INSTALL:-}" ]]; then
 else
   # Download data
   print info "Installing data..."
-  run "rm -rf $SCT_DIR/$DATA_DIR"
-  run "mkdir -p $SCT_DIR/$DATA_DIR"
+  run rm -rf "$SCT_DIR/$DATA_DIR"
+  run mkdir -p "$SCT_DIR/$DATA_DIR"
   for data in PAM50 gm_model optic_models pmj_models deepseg_sc_models deepseg_gm_models deepseg_lesion_models c2c3_disc_models; do
-    run "sct_download_data -d $data -o $SCT_DIR/$DATA_DIR/$data"
+    run sct_download_data -d "$data" -o "$SCT_DIR/$DATA_DIR/$data"
   done
 fi
 

--- a/install_sct
+++ b/install_sct
@@ -24,7 +24,7 @@
 # https://sipb.mit.edu/doc/safe-shell/
 set -eo pipefail  # exit if non-zero error is encountered (even in a pipeline)
 set -u            # exit if unset variables used
-shopt -s failglob # error if a glob fails
+shopt -s failglob # error if a glob doesn't find any files, instead of remaining unexpanded
 
 # set -v  # v: verbose
 

--- a/install_sct
+++ b/install_sct
@@ -290,7 +290,7 @@ function usage() {
 
     # filter for block-comments
     $0 !~ /^#/   { next }
-    # strip off the leading "# "
+    # but strip any leading "# "
                  { sub("^#[[:space:]]?","") }
 
     # count consecutive blank lines
@@ -301,8 +301,7 @@ function usage() {
     # detect usage section
     /USAGE/      { printing=1 }
     printing==1  { print }
-    (printing==1 && blanks>=2) \
-                 { exit }
+    (printing==1 && blanks>=2) { exit }
   ' "$0"
 }
 

--- a/install_sct
+++ b/install_sct
@@ -582,6 +582,7 @@ run bash "$TMP_DIR/miniconda.sh" -p "$SCT_DIR/$PYTHON_DIR" -b -f
 python/bin/conda create -y -n venv_sct python=3.6
 
 # activate miniconda
+# shellcheck disable=SC1091
 source python/etc/profile.d/conda.sh
 set +u #disable safeties, for conda is not written to their standard.
 conda activate venv_sct

--- a/install_sct
+++ b/install_sct
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is the spinalcord toolbox (SCT) installer
 # It downloads the Conda (http://conda.pydata.org/) version

--- a/install_sct
+++ b/install_sct
@@ -343,9 +343,6 @@ print info "
 # CLI parser
 # ----------------------------------------------------------------------------------------------------------------------
 
-fetch_os_type
-check_requirements
-
 # Transform  long option "--long" into short option  "-l"
 for arg in "$@"; do
   shift
@@ -394,6 +391,9 @@ done
 # ----------------------------------------------------------------------------------------------------------------------
 # Prepare installation
 # ----------------------------------------------------------------------------------------------------------------------
+
+fetch_os_type
+check_requirements
 
 # Catch SCT version
 if [[ -e "spinalcordtoolbox/version.txt" ]]; then

--- a/install_sct
+++ b/install_sct
@@ -650,8 +650,8 @@ python -c 'import spinalcordtoolbox.deepseg.models; spinalcordtoolbox.deepseg.mo
 conda deactivate >/dev/null 2>&1
 
 # In case of previous SCT installation (4.0.0-beta.1 or before), remove sct_env declaration in bashrc
-print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
 if [[ -e "$RC_FILE_PATH" ]]; then
+    print info "In case an old version SCT is already installed (4.0.0-beta.1 or before), remove 'sct_env' declaration in RC file"
     sed -ie '/sct_env/ s/^#*/#/' "$RC_FILE_PATH"
 fi
 

--- a/install_sct
+++ b/install_sct
@@ -326,17 +326,6 @@ fi
 # SCRIPT STARTS HERE
 # ======================================================================================================================
 
-# This trap specifically catches keyboardInterrupt and output a non-zero status before running finish()
-trap detectKeyboardInterrupt INT
-# Set a trap which, on shell error or shell exit, runs finish()
-trap finish EXIT
-
-print info "
-*******************************
-* Welcome to SCT installation *
-*******************************
-"
-
 # ----------------------------------------------------------------------------------------------------------------------
 # CLI parser
 # ----------------------------------------------------------------------------------------------------------------------
@@ -389,6 +378,17 @@ done
 # ----------------------------------------------------------------------------------------------------------------------
 # Prepare installation
 # ----------------------------------------------------------------------------------------------------------------------
+
+# This trap specifically catches keyboardInterrupt and output a non-zero status before running finish()
+trap detectKeyboardInterrupt INT
+# Set a trap which, on shell error or shell exit, runs finish()
+trap finish EXIT
+
+print info "
+*******************************
+* Welcome to SCT installation *
+*******************************
+"
 
 fetch_os_type
 check_requirements

--- a/install_sct
+++ b/install_sct
@@ -46,6 +46,11 @@ PYTHON_DIR="python"
 BIN_DIR="bin"
 MACOSSUPPORTED="13"  # Minimum version of macOS 10 supported
 
+# CLI options
+SCT_INSTALL_TYPE=""
+NONINTERACTIVE=""
+NO_DATA_INSTALL=""
+NO_SCT_BIN_INSTALL=""
 
 # ======================================================================================================================
 # FUNCTIONS
@@ -338,10 +343,6 @@ for arg in "$@"; do
   esac
 done
 
-SCT_INSTALL_TYPE=""
-NONINTERACTIVE=""
-NO_DATA_INSTALL=""
-NO_SCT_BIN_INSTALL=""
 while getopts ":iydbvh" opt; do
   case $opt in
   i)

--- a/util/dockerize.sh
+++ b/util/dockerize.sh
@@ -3,7 +3,7 @@
 #
 # usage: DOCKER_IMAGE="<image>" DOCKER_DEPS_CMD="<command to run before script>" dockerize.sh script.sh
 
-set -e # Error build immediately if install script exits with non-zero
+set -ueo pipefail # stricter shell rules
 
 CONTAINER=$(docker run \
     --init \

--- a/util/dockerize.sh
+++ b/util/dockerize.sh
@@ -3,7 +3,11 @@
 #
 # usage: DOCKER_IMAGE="<image>" DOCKER_DEPS_CMD="<command to run before script>" dockerize.sh script.sh
 
-set -ueo pipefail # stricter shell rules
+# stricter shell mode
+# https://sipb.mit.edu/doc/safe-shell/
+set -eo pipefail  # exit if non-zero error is encountered (even in a pipeline)
+set -u            # exit if unset variables used
+shopt -s failglob # error if a glob doesn't find any files, instead of remaining unexpanded
 
 CONTAINER=$(docker run \
     --init \

--- a/util/dockerize.sh
+++ b/util/dockerize.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # dockerize.sh: run a script inside of another.
 #
 # usage: DOCKER_IMAGE="<image>" DOCKER_DEPS_CMD="<command to run before script>" dockerize.sh script.sh


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Our installer is fragile around this edges and part of that is that shell itself is fragile. This sets the recommended shell strict-mode settings that make it a bit less of a fragile language to work in.

I did these safety improvements:

- setting [recommended shell safeties](https://sipb.mit.edu/doc/safe-shell/): `set -euo pipefail; shopt -s failglob`
- to appease `set -o pipefail`: switch to `#!/usr/bin/env bash`
    - every time we're not polyglottal is unfortunate, but this option is so useful that I think it's worth depending on bash
-  to appease `set -u`: initializing all variables; in the cases of checking external envs, using the cryptic (but standard) `${var:-}` syntax
- to appease `set -o pipefail`: replacing all our uses of `yes |` with the proper non-interactive flag for each script (mostly: `-y`, but for the brew installer: `NONINTERACTIVE=1`, and for using brew: `-f`)
- inspired by that, adding our own `-y` instead of recommending `yes | install_sct`. This is much less fragile. This fixes #3112.
    - merge `ASK_REPORT_QUESTION` into `-y`; **this is an API change**
        - but is anyone really using this flag anyway?
- to appease `shopt -s failglob`: fixing the pre-clean `find` step
    - in that case, we actually do want to pass a literal `sct_*` into `find(1)` for it to parse.
- set appease `set -e`: check for command results as `if ! cmd;` instead of "cmd; if [[ $? -ne 0 ]];` or sometimes `cmd || die ".."` or `cmd && ....`
    - that's nicer to read anyway
- quoting *all* the variables everywhere
- drop unused variables (`$SCRIPT_DIR` and `$line`) (found by [shellcheck](https://github.com/koalaman/shellcheck))
- use `read -r` (found by [shellcheck](https://github.com/koalaman/shellcheck))

These maintenances:

- update deprecated brew installer; fixes #3105 .
- update deprecated "source conda/bin/deactivate" -> "conda deactivate"
    - (this doesn't actually undo everything conda loads :(; it leaves the `conda` function and `CONDA_*` env vars in memory)

I also did some maintainability improvements:
- removing unnecessary `which` dependency
    - found by @joshuacwnewton in #3103 (https://github.com/neuropoly/spinalcordtoolbox/pull/3103#discussion_r545956795)
- making `run()` much safer; `"$@"` is designed for this kind of thing
    - this is some shell wizardry so ask me to explain it if you need to
- merge the macOS and linux calls to `sed`
    - it looks like the linux call was there first, that was discovered to be incompatible, and the macOS call was added; but it turns out the macOS version is the more compatible one (which sort of makes sense: it's old BSD styles)
- simplify `download()` 
- shortened `edit_shellrc` to only use a single `>>` (the power of subshells!)

I also **tweaked `install_sct`'s UI**:

- moving *all* the prompts (in interactive mode) up to the start of the script instead of the user needing to wait around to answer when the script finishes
- simplifying `usage()`
- *change the wording of the install error message* to ask users to upload instead of paste their logs
- moving "Checking requirements!" after `getopts` so that it doesn't run for just `./install_sct -h`
- `./install_sct -h` returns 0, not 99; it's not an error.

I don't know how to test this well. We don't have a good way to do a test matrix of all possible install cases. We test a bunch of platforms, and that's good, but we don't mix and match the installer's options anywhere.

I've run it as both `./install_sct` and `./install_sct -y` and both work (except for #3107, which I ignored by commenting torch out of my local requirements.txt for now), so I think it's good enough.

Aside: It would be good to test what happens if we try installing on a disk that runs out of space. This branch *should* terminate early in that case, whereas `master` should run through to the end giving many many errors.

## Linked issues

Part of #3029. 
Fixes #3105.  
Fixes #3112.
Unblocks #3071 (both https://github.com/actions/runner/issues/884, discovered @Drulex first discovered (and tested at https://github.com/Drulex/conda-test-actions, https://github.com/Drulex/spinalcordtoolbox/tree/aj-basic-github-actions) about a month ago)