### PR TITLE
Check that conda actually activated during install.

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -288,6 +288,22 @@ function usage() {
   echo -e "\n\t-v \v Full verbose"
 }
 
+if [ "$(uname)" = "Darwin" ]; then
+  # macOS polyfills
+
+  # Linux has `realpath` and `readlink -f`.
+  # BSD has `readlink -f`.
+  # macOS has neither: https://izziswift.com/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac/
+  # even though it *has* the function in its libc: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/realpath.3.html
+  # Someone even wrote a whole C program just for this: https://github.com/harto/realpath-osx/.
+  # https://stackoverflow.com/a/3572105 suggests some bash trickery but it
+  # seems pretty fragile and that it probably doesn't actually expand symlinks.
+  # So here, solve it with python. It's not a great either, but since much of
+  # this script already is just calling python it's fairly safe.
+  realpath() {
+    python -c 'import sys, path; for f in sys.argv[1:]: print(os.path.realpath(f))' "$@"
+  }
+fi
 
 # ======================================================================================================================
 # SCRIPT STARTS HERE

--- a/install_sct
+++ b/install_sct
@@ -527,7 +527,7 @@ yes | python/bin/conda create -n venv_sct python=3.6
 # activate miniconda
 source python/etc/profile.d/conda.sh
 conda activate venv_sct
-if [ "$(which python)" != "$(which python/envs/venv_sct/bin/python)" ]; then
+if [ "$(command -v python)" != "$(command -v python/envs/venv_sct/bin/python)" ]; then
   echo "error: venv_sct failed to activate." >&2
   exit 1
 fi

--- a/install_sct
+++ b/install_sct
@@ -300,7 +300,7 @@ if [ "$(uname)" = "Darwin" ]; then
   # seems pretty fragile and that it probably doesn't actually expand symlinks.
   # So here, solve it with python. It's not great either, but since much of
   # this script already is just calling python at least it's reliable.
-  realpath() {
+  (command -v realpath >/dev/null) || realpath() {
     python -c 'import sys, path; for f in sys.argv[1:]: print(os.path.realpath(f))' "$@"
   }
 fi

--- a/install_sct
+++ b/install_sct
@@ -527,8 +527,9 @@ yes | python/bin/conda create -n venv_sct python=3.6
 # activate miniconda
 source python/etc/profile.d/conda.sh
 conda activate venv_sct
+# double-check conda activated (it can be glitchy): https://github.com/neuropoly/spinalcordtoolbox/issues/3029
 if [ "$(command -v python)" != "$(command -v python/envs/venv_sct/bin/python)" ]; then
-  echo "error: venv_sct failed to activate." >&2
+  echo "error: venv_sct failed to activate. Do you have a conflicting python installation?" >&2
   exit 1
 fi
 

--- a/install_sct
+++ b/install_sct
@@ -528,7 +528,7 @@ yes | python/bin/conda create -n venv_sct python=3.6
 source python/etc/profile.d/conda.sh
 conda activate venv_sct
 # double-check conda activated (it can be glitchy): https://github.com/neuropoly/spinalcordtoolbox/issues/3029
-if [ "$(command -v python)" != "$(command -v python/envs/venv_sct/bin/python)" ]; then
+if [ "$(realpath "$(command -v python)")" != "$(realpath "$(command -v python/envs/venv_sct/bin/python)")" ]; then
   echo "error: venv_sct failed to activate. Do you have a conflicting python installation?" >&2
   exit 1
 fi

--- a/install_sct
+++ b/install_sct
@@ -298,8 +298,8 @@ if [ "$(uname)" = "Darwin" ]; then
   # Someone even wrote a whole C program just for this: https://github.com/harto/realpath-osx/.
   # https://stackoverflow.com/a/3572105 suggests some bash trickery but it
   # seems pretty fragile and that it probably doesn't actually expand symlinks.
-  # So here, solve it with python. It's not a great either, but since much of
-  # this script already is just calling python it's fairly safe.
+  # So here, solve it with python. It's not great either, but since much of
+  # this script already is just calling python at least it's reliable.
   realpath() {
     python -c 'import sys, path; for f in sys.argv[1:]: print(os.path.realpath(f))' "$@"
   }
@@ -544,8 +544,10 @@ yes | python/bin/conda create -n venv_sct python=3.6
 source python/etc/profile.d/conda.sh
 conda activate venv_sct
 # double-check conda activated (it can be glitchy): https://github.com/neuropoly/spinalcordtoolbox/issues/3029
-if [ "$(realpath "$(command -v python)")" != "$(realpath "$(command -v python/envs/venv_sct/bin/python)")" ]; then
-  echo "error: venv_sct failed to activate. Do you have a conflicting python installation?" >&2
+EXPECTED_PYTHON="$(realpath "$(command -v python/envs/venv_sct/bin/python)")"
+ACTUAL_PYTHON="$(realpath "$(command -v python)")"
+if [ "$ACTUAL_PYTHON" != "$EXPECTED_PYTHON"  ]; then
+  echo "Error: Activating venv_sct failed to switch Python interpreter to Miniconda. (Incorrect interpreter loaded: $ACTUAL_PYTHON)" >&2
   exit 1
 fi
 

--- a/install_sct
+++ b/install_sct
@@ -527,6 +527,11 @@ yes | python/bin/conda create -n venv_sct python=3.6
 # activate miniconda
 source python/etc/profile.d/conda.sh
 conda activate venv_sct
+if [ "$(which python)" != "$(which python/envs/venv_sct/bin/python)" ]; then
+  echo "error: venv_sct failed to activate." >&2
+  exit 1
+fi
+
 
 # Install Python dependencies
 print info "Installing Python dependencies..."


### PR DESCRIPTION
This glues over a rare glitch in conda (#3029, https://github.com/conda/conda/issues/10401).

Reviewers: please run this under the bug we reproduced in #3029 to make sure it handles that well.

We might also check for: `pip`, or `python3`? Open to feedback.