### PR TITLE
Forces output label image to be UINT8 with -create-viewer

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -345,7 +345,7 @@ def launch_sagittal_viewer(img: Image, labels: Sequence[int], msg: str, previous
     if previous_points is not None:
         params.message_warn = 'Please select the label you want to add \nor correct in the list below before clicking \non the image'
 
-    out = zeros_like(img)
+    out = zeros_like(img, dtype='uint8')
     out.absolutepath = params.output_file_name
     launch_sagittal_dialog(img, out, params, previous_points)
 


### PR DESCRIPTION
When creating manual labels, the created labels do not have the value asked for: they are output in float (it whould be integer) and the value is slightly different (precision issue). This bug was introduced in v5.0.0.

This PR fixes the problem by forcing the output label to be UINT8 type.

Also see user forum discussion: https://forum.spinalcordmri.org/t/sct-register-to-template-source-and-destination-landmarks-are-not-the-same/590/4

Fixes #3101
