### PR TITLE
Print actual numbers of jobs run in parallel.

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -408,7 +408,7 @@ def main(argv):
 
     print("RUNNING")
     print("-------")
-    print("Running {} jobs in parallel.\n".format(jobs))
+    print("Processing {} subjects in parallel. (Worker processes used: {}).".format(len(subject_dirs), jobs))
 
     # Run the jobs, recording start and end times
     start = datetime.datetime.now()


### PR DESCRIPTION
Will print "Processing 7 subjects in parallel. (Worker processes used: 15)", fix #2956
