### PR TITLE
Fix incorrect indexing in get_center_spit to prevent QC report cropping

### DIFF
--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -382,7 +382,7 @@ class Sagittal(Slice):
         assert image.orientation == 'SAL'
         # If mask is empty, raise error
         if np.argwhere(image.data).shape[0] == 0:
-            logging.error('Mask is empty')
+            raise ValueError("Label/segmentation image is empty. Can't retrieve RL slice indices.")
         # If mask only has one label (e.g., in sct_detect_pmj), return the R-L index (repeated n_SI times)
         elif np.argwhere(image.data).shape[0] == 1:
             return [np.argwhere(image.data)[0][2]] * image.data.shape[0]  # SAL orientation, so shape[0] -> SI axis

--- a/spinalcordtoolbox/reports/slice.py
+++ b/spinalcordtoolbox/reports/slice.py
@@ -383,9 +383,9 @@ class Sagittal(Slice):
         # If mask is empty, raise error
         if np.argwhere(image.data).shape[0] == 0:
             logging.error('Mask is empty')
-        # If mask only has one label (e.g., in sct_detect_pmj), return the repmat of the R-L index (assuming SAL orient)
+        # If mask only has one label (e.g., in sct_detect_pmj), return the R-L index (repeated n_SI times)
         elif np.argwhere(image.data).shape[0] == 1:
-            return [np.argwhere(image.data)[0][2]] * image.data.shape[2]
+            return [np.argwhere(image.data)[0][2]] * image.data.shape[0]  # SAL orientation, so shape[0] -> SI axis
         # Otherwise, find the center of mass of each label (per axial plane) and extrapolate linearly
         else:
             image.change_orientation('RPI')  # need to do that because get_centerline operates in RPI orientation

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -15,6 +15,7 @@ def labeled_data_test_params(path_in='sct_testing_data/t2/t2.nii.gz',
     test_sagittal_slice_get_center_spit."""
     im_in = Image(path_in)            # Base anatomical image
     im_seg_labeled = Image(path_seg)  # Base labeled segmentation
+    assert np.count_nonzero(im_seg_labeled.data) >= 2, "Labeled segmentation image has fewer than 2 labels"
 
     # Create image with all but one label removed
     im_seg_one_label = im_seg_labeled.copy()
@@ -34,9 +35,9 @@ def labeled_data_test_params(path_in='sct_testing_data/t2/t2.nii.gz',
 @pytest.mark.parametrize('im_in,im_seg', labeled_data_test_params())
 def test_sagittal_slice_get_center_spit(im_in, im_seg):
     """Test that get_center_split returns a valid index list."""
-    assert im_in.orientation == im_seg.orientation
+    assert im_in.orientation == im_seg.orientation, "im_in and im_seg aren't in the same orientation"
     qcslice = Sagittal([im_in, im_seg], p_resample=None)
-    
+
     if np.count_nonzero(im_seg.data) == 0:
         # If im_seg contains no labels, get_center_spit should fail
         with pytest.raises(ValueError):
@@ -46,4 +47,4 @@ def test_sagittal_slice_get_center_spit(im_in, im_seg):
         index = qcslice.get_center_spit()
         for i, axis in enumerate(im_in.orientation):
             if axis in ['S', 'I']:
-                assert len(index) == im_in.data.shape[i]
+                assert len(index) == im_in.data.shape[i], "Index list doesn't have expected length (n_SI)"

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -9,43 +9,41 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
 
 
-def prepare_labeled_data():
+def labeled_data_test_params(path_in='sct_testing_data/t2/t2.nii.gz',
+                             path_seg='sct_testing_data/t2/labels.nii.gz'):
     """Generate image/label pairs for various test cases of
     test_sagittal_slice_get_center_spit."""
-    # Base labeled image
-    im_seg = Image('sct_testing_data/t2/labels.nii.gz')
+    im_in = Image(path_in)            # Base anatomical image
+    im_seg_labeled = Image(path_seg)  # Base labeled segmentation
 
     # Create image with all but one label removed
-    im_seg_one_label = im_seg.copy()
+    im_seg_one_label = im_seg_labeled.copy()
     for x, y, z in np.argwhere(im_seg_one_label.data)[1:]:
         im_seg_one_label.data[x, y, z] = 0
 
     # Create image with no labels
-    im_seg_no_labels = im_seg.copy()
+    im_seg_no_labels = im_seg_labeled.copy()
     for x, y, z in np.argwhere(im_seg_no_labels.data):
         im_seg_no_labels.data[x, y, z] = 0
 
-    return [im_seg, im_seg_one_label, im_seg_no_labels]
+    return [pytest.param(im_in, im_seg_labeled, id='multiple_labels'),
+            pytest.param(im_in, im_seg_one_label, id='one_label'),
+            pytest.param(im_in, im_seg_no_labels, id='no_labels')]
 
 
-def test_sagittal_slice_get_center_spit():
+@pytest.mark.parametrize('im_in,im_seg', labeled_data_test_params())
+def test_sagittal_slice_get_center_spit(im_in, im_seg):
     """Test that get_center_split returns a valid index list."""
-    im_in = Image('sct_testing_data/t2/t2.nii.gz')
-    im_seg_list = prepare_labeled_data()
-
-    for im_seg in im_seg_list:
-        assert im_in.orientation == im_seg.orientation
-        qcslice = Sagittal([im_in, im_seg], p_resample=None)
-
+    assert im_in.orientation == im_seg.orientation
+    qcslice = Sagittal([im_in, im_seg], p_resample=None)
+    
+    if np.count_nonzero(im_seg.data) == 0:
         # If im_seg contains no labels, get_center_spit should fail
-        if np.count_nonzero(im_seg.data) == 0:
-            with pytest.raises(ValueError):
-                index = qcslice.get_center_spit()
-        # Otherwise, if it contains labels, a valid index list should be returned
-        else:
-            index = qcslice.get_center_spit()
-
-        # Index list should be n_SI long. (See issue #3087)
+        with pytest.raises(ValueError):
+            qcslice.get_center_spit()
+    else:
+        # Otherwise, index list should be n_SI long. (See issue #3087)
+        index = qcslice.get_center_spit()
         for i, axis in enumerate(im_in.orientation):
             if axis in ['S', 'I']:
                 assert len(index) == im_in.data.shape[i]

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+# pytest unit tests for spinalcordtoolbox.reports
+
+from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.reports.slice import Sagittal
+
+
+def test_sagittal_slice_get_center_spit():
+    """
+    This test currently only tests get_center_split when the mask only has one
+    label. So, much of the function is untested, therefore:
+        -TODO: Test get_center_split when mask is empty (raise error)
+        -TODO: Test get_center_split when mask has more than one label
+    """
+    # TODO: Figure out how to replace subject data with testing data equivalent
+    fname_in = '../sub-1002358_T1w_RPI_r_gradcorr.nii.gz'
+    fname_seg = '../sub-1002358_T1w_RPI_r_gradcorr_labels-manual.nii.gz'
+    qcslice = Sagittal([Image(fname_in), Image(fname_seg)], p_resample=None)
+    index = qcslice.get_center_spit()
+    # Index list should be n_SI long. RPI image -> SI axis = shape[2] (See issue #3087)
+    assert len(index) == Image(fname_in).data.shape[2]
+    # Index list should only contain one slice value
+    assert len(set(index)) == 1

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -2,23 +2,50 @@
 # -*- coding: utf-8
 # pytest unit tests for spinalcordtoolbox.reports
 
+import pytest
+import numpy as np
+
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
 
 
+def prepare_labeled_data():
+    """Generate image/label pairs for various test cases of
+    test_sagittal_slice_get_center_spit."""
+    # Base labeled image
+    im_seg = Image('sct_testing_data/t2/labels.nii.gz')
+
+    # Create image with all but one label removed
+    im_seg_one_label = im_seg.copy()
+    for x, y, z in np.argwhere(im_seg_one_label.data)[1:]:
+        im_seg_one_label.data[x, y, z] = 0
+
+    # Create image with no labels
+    im_seg_no_labels = im_seg.copy()
+    for x, y, z in np.argwhere(im_seg_no_labels.data):
+        im_seg_no_labels.data[x, y, z] = 0
+
+    return [im_seg, im_seg_one_label, im_seg_no_labels]
+
+
 def test_sagittal_slice_get_center_spit():
-    """
-    This test currently only tests get_center_split when the mask only has one
-    label. So, much of the function is untested, therefore:
-        -TODO: Test get_center_split when mask is empty (raise error)
-        -TODO: Test get_center_split when mask has more than one label
-    """
-    # TODO: Figure out how to replace subject data with testing data equivalent
-    fname_in = '../sub-1002358_T1w_RPI_r_gradcorr.nii.gz'
-    fname_seg = '../sub-1002358_T1w_RPI_r_gradcorr_labels-manual.nii.gz'
-    qcslice = Sagittal([Image(fname_in), Image(fname_seg)], p_resample=None)
-    index = qcslice.get_center_spit()
-    # Index list should be n_SI long. RPI image -> SI axis = shape[2] (See issue #3087)
-    assert len(index) == Image(fname_in).data.shape[2]
-    # Index list should only contain one slice value
-    assert len(set(index)) == 1
+    """Test that get_center_split returns a valid index list."""
+    im_in = Image('sct_testing_data/t2/t2.nii.gz')
+    im_seg_list = prepare_labeled_data()
+
+    for im_seg in im_seg_list:
+        assert im_in.orientation == im_seg.orientation
+        qcslice = Sagittal([im_in, im_seg], p_resample=None)
+
+        # If im_seg contains no labels, get_center_spit should fail
+        if np.count_nonzero(im_seg.data) == 0:
+            with pytest.raises(ValueError):
+                index = qcslice.get_center_spit()
+        # Otherwise, if it contains labels, a valid index list should be returned
+        else:
+            index = qcslice.get_center_spit()
+
+        # Index list should be n_SI long. (See issue #3087)
+        for i, axis in enumerate(im_in.orientation):
+            if axis in ['S', 'I']:
+                assert len(index) == im_in.data.shape[i]


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [X] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The function `get_center_spit` is supposed to return `index: [int] * n_SI` (indices along in the R-L direction for each S-I slice). But, it was incorrectly returning `index: [int] * n_RL` because it was using the wrong axis shape.

This PR fixes the problem so the correct axis shape is used, and also tweaks comments to make this clearer.

It also fixes a bug where `logger.error` was used when an error should have been raised instead.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3087.