### PR TITLE
Fixup realpath polyfill

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -301,7 +301,7 @@ if [ "$(uname)" = "Darwin" ]; then
   # So here, solve it with python. It's not great either, but since much of
   # this script already is just calling python at least it's reliable.
   (command -v realpath >/dev/null) || realpath() {
-    python -c 'import sys, path; for f in sys.argv[1:]: print(os.path.realpath(f))' "$@"
+    python3 -c 'import sys, os; [print(os.path.realpath(f)) for f in sys.argv[1:]]' "$@"
   }
 fi
 


### PR DESCRIPTION
Adding in #3103, but https://github.com/neuropoly/spinalcordtoolbox/runs/1601504567?check_suite_focus=true#step:4:1407 shows it failing on Github Actions with

> ```
>   File "<string>", line 1
>    import sys, path; for f in sys.argv[1:]: print(os.path.realpath(f))
>                        ^
> SyntaxError: invalid syntax
> ```

I guess I didn't actually test this.


Strange that it got past CI?? Maybe Travis's macOS images have GNU realpath installed but Actions' don't??

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->
