### PR TITLE
Replace "argv if argv else '--help'" behavior with subclassed ArgumentParser

### DIFF
--- a/spinalcordtoolbox/scripts/sct_analyze_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_lesion.py
@@ -13,7 +13,6 @@ import math
 import sys
 import pickle
 import shutil
-import argparse
 
 import numpy as np
 import pandas as pd
@@ -21,15 +20,13 @@ from skimage.measure import label
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='R|Compute statistics on segmented lesions. The function assigns an ID value to each lesion (1, 2, '
                     '3, etc.) and then outputs morphometric measures for each lesion:\n'
                     '- volume [mm^3]\n'
@@ -38,10 +35,7 @@ def get_parser():
                     '                                the lesion as a circle in the axial plane.\n\n'
                     'If the proportion of lesion in each region (e.g. WM and GM) does not sum up to 100%, it means '
                     'that the registered template does not fully cover the lesion. In that case you might want to '
-                    'check the registration results.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py")
+                    'check the registration results.'
     )
 
     mandatory_arguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -519,7 +513,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_analyze_texture.py
+++ b/spinalcordtoolbox/scripts/sct_analyze_texture.py
@@ -11,30 +11,24 @@
 import os
 import sys
 import itertools
-import argparse
 
 import numpy as np
 from skimage.feature import greycomatrix, greycoprops
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like
-from spinalcordtoolbox.utils.shell import Metavar, ActionCreateFolder, SmartFormatter
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, sct_progress_bar, run_proc, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Extraction of grey level co-occurence matrix (GLCM) texture features from an image within a given '
                     'mask. The textures features are those defined in the sckit-image implementation: '
                     'http://scikit-image.org/docs/dev/api/skimage.feature.html#greycoprops. This function outputs '
                     'one nifti file per texture metric (' + ParamGLCM().feature + ') and per orientation called '
                     'fnameInput_feature_distance_angle.nii.gz. Also, a file averaging each metric across the angles, '
-                    'called fnameInput_feature_distance_mean.nii.gz, is output.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py")
+                    'called fnameInput_feature_distance_mean.nii.gz, is output.'
     )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -317,7 +311,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -17,13 +17,12 @@
 import sys
 import os
 import functools
-import argparse
 
 from spinalcordtoolbox.image import Image, generate_output_file
 from spinalcordtoolbox.cropping import ImageCropper
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import cubic_to_point
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, get_interpolation, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, get_interpolation, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, copy
 
@@ -33,13 +32,8 @@ from spinalcordtoolbox.scripts import sct_image
 # PARSER
 # ==========================================================================================
 def get_parser():
-    # parser initialisation
-
-    parser = argparse.ArgumentParser(
-        description='Apply transformations. This function is a wrapper for antsApplyTransforms (ANTs).',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description='Apply transformations. This function is a wrapper for antsApplyTransforms (ANTs).'
     )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -344,7 +338,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_check_dependencies.py
+++ b/spinalcordtoolbox/scripts/sct_check_dependencies.py
@@ -16,7 +16,6 @@
 # TODO: find another way to create log file. E.g. print(). For color as well.
 # TODO: manage .cshrc files
 
-import argparse
 import sys
 import io
 import os
@@ -27,7 +26,7 @@ import psutil
 
 import requirements
 
-from spinalcordtoolbox.utils.shell import SmartFormatter
+from spinalcordtoolbox.utils.shell import SCTArgumentParser
 from spinalcordtoolbox.utils.sys import sct_dir_local_path, init_sct, run_proc, __version__, __sct_dir__, __data_dir__, set_global_loglevel
 
 
@@ -176,14 +175,10 @@ def get_dependencies(requirements_txt=None):
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
-        description='Check the installation and environment variables of the toolbox and its dependencies.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description='Check the installation and environment variables of the toolbox and its dependencies.'
     )
+
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         "-h",
@@ -204,7 +199,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = complete_test = arguments.complete
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
+++ b/spinalcordtoolbox/scripts/sct_compute_ernst_angle.py
@@ -13,9 +13,8 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 
@@ -71,14 +70,11 @@ class ErnstAngle:
 
 
 def get_parser():
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Function to compute the Ernst Angle. For examples of T1 values in the brain, see Wansapura et al. '
                     'NMR relaxation times in the human brain at 3.0 tesla. Journal of magnetic resonance imaging : '
-                    'JMRI (1999) vol. 9 (4) pp. 531-8. \nT1 in WM: 832ms\nT1 in GM: 1331ms',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'JMRI (1999) vol. 9 (4) pp. 531-8. \nT1 in WM: 832ms\nT1 in GM: 1331ms'
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -137,7 +133,7 @@ def get_parser():
 #=======================================================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
+++ b/spinalcordtoolbox/scripts/sct_compute_hausdorff_distance.py
@@ -12,12 +12,11 @@
 
 import sys
 import os
-import argparse
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like, change_orientation
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname
 
@@ -432,14 +431,9 @@ def non_zero_coord(data):
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Compute the Hausdorff\'s distance between two binary images which can be thinned (ie skeletonized).'
-                    ' If only one image is inputted, it will be only thinned',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py")
+                    ' If only one image is inputted, it will be only thinned'
     )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -497,7 +491,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_compute_mscc.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mscc.py
@@ -12,24 +12,19 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 
 
 # PARSER
 # ==========================================================================================
 def get_parser():
-    # parser initialisation
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Compute Maximum Spinal Cord Compression (MSCC) as in: Miyanji F, Furlan JC, Aarabi B, Arnold PM, '
                     'Fehlings MG. Acute cervical traumatic spinal cord injury: MR imaging findings correlated with '
                     'neurologic outcome--prospective study with 100 consecutive patients. Radiology 2007;243(3):820-'
-                    '827.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    '827.'
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -80,7 +75,7 @@ def mscc(di, da, db):
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtr.py
@@ -13,19 +13,16 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, printv, set_global_loglevel
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.qmri.mt import compute_mtr
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description='Compute magnetization transfer ratio (MTR). Output is given in percentage.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+    parser = SCTArgumentParser(
+        description='Compute magnetization transfer ratio (MTR). Output is given in percentage.'
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -75,7 +72,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_compute_mtsat.py
+++ b/spinalcordtoolbox/scripts/sct_compute_mtsat.py
@@ -18,23 +18,19 @@
 
 import sys
 import os
-import argparse
 import json
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, display_viewer_syntax, set_global_loglevel
 from spinalcordtoolbox.qmri.mt import compute_mtsat
 from spinalcordtoolbox.image import Image, splitext
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Compute MTsat and T1map. '
                     'Reference: Helms G, Dathe H, Kallenberg K, Dechent P. High-resolution maps of magnetization '
                     'transfer with inherent correction for RF inhomogeneity and T1 relaxation obtained from 3D FLASH '
-                    'MRI. Magn Reson Med 2008;60(6):1396-1407.',
-        add_help=False,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py")
+                    'MRI. Magn Reson Med 2008;60(6):1396-1407.'
     )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -166,7 +162,7 @@ def fetch_metadata(fname_json, field):
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_compute_snr.py
+++ b/spinalcordtoolbox/scripts/sct_compute_snr.py
@@ -14,12 +14,12 @@
 
 import sys
 import os
-import argparse
+
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image, empty_like, add_suffix
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, parse_num_list, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, parse_num_list, init_sct, printv, set_global_loglevel
 
 
 # PARAMETERS
@@ -33,15 +33,11 @@ class Param(object):
 
 
 def get_parser():
-
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Compute SNR using methods described in [Dietrich et al., Measurement of'
                     ' signal-to-noise ratios in MR images: Influence of multichannel coils, parallel '
-                    'imaging, and reconstruction filters. J Magn Reson Imaging 2007; 26(2): 375-385].',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'imaging, and reconstruction filters. J Magn Reson Imaging 2007; 26(2): 375-385].'
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -106,7 +102,7 @@ def weighted_avg_and_std(values, weights):
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_convert.py
+++ b/spinalcordtoolbox/scripts/sct_convert.py
@@ -14,21 +14,17 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 import spinalcordtoolbox.image as image
 
 
 # PARSER
 # ==========================================================================================
 def get_parser():
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
-        description='Convert image file to another type.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+    parser = SCTArgumentParser(
+        description='Convert image file to another type.'
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -90,7 +86,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_create_mask.py
+++ b/spinalcordtoolbox/scripts/sct_create_mask.py
@@ -16,7 +16,6 @@
 
 import sys
 import os
-import argparse
 
 import numpy as np
 
@@ -24,7 +23,7 @@ import nibabel
 from scipy import ndimage
 
 from spinalcordtoolbox.image import Image, empty_like
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, check_file_exist, extract_fname, rmtree, copy
 from spinalcordtoolbox.labels import create_labels
@@ -54,13 +53,10 @@ class Param:
 def get_parser():
     # Initialize default parameters
     param_default = Param()
-    # Initialize the parser
 
-    parser = argparse.ArgumentParser(
-        description='Create mask along z direction.',
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"),
-        formatter_class=SmartFormatter)
+    parser = SCTArgumentParser(
+        description='Create mask along z direction.'
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -131,7 +127,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_crop_image.py
+++ b/spinalcordtoolbox/scripts/sct_crop_image.py
@@ -10,17 +10,14 @@
 
 import sys
 import os
-import argparse
 
 from spinalcordtoolbox.cropping import ImageCropper, BoundingBox
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
 
 
 def get_parser():
-
-    # Mandatory arguments
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Tools to crop an image. Either via command line or via a Graphical User Interface (GUI). See "
                     "example usage at the end.",
         epilog="EXAMPLES:\n"
@@ -32,10 +29,8 @@ def get_parser():
                "sct_crop_image -i t2.nii.gz -ref mt1.nii.gz\n\n"
                "- To crop an image by specifying min/max (you don't need to specify all dimensions). In the example "
                "below, cropping will occur between x=5 and x=60, and between z=5 and z=zmax-1\n"
-               "sct_crop_image -i t2.nii.gz -xmin 5 -xmax 60 -zmin 5 -zmax -2\n\n",
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip('.py'))
+               "sct_crop_image -i t2.nii.gz -xmin 5 -xmax 60 -zmin 5 -zmax -2\n\n"
+    )
 
     mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatoryArguments.add_argument(
@@ -145,7 +140,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -11,7 +11,6 @@ ivadomed package.
 # TODO: Fetch default value (and display) depending on the model that is used.
 # TODO: accommodate multiclass segmentation
 
-import argparse
 import os
 import sys
 import logging
@@ -24,18 +23,16 @@ from spinalcordtoolbox import image
 import spinalcordtoolbox.deepseg as deepseg
 import spinalcordtoolbox.deepseg.models
 
-from spinalcordtoolbox.utils.shell import SmartFormatter, Metavar, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 logger = logging.getLogger(__name__)
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description="Segment an anatomical structure or pathologies according to the specified deep learning model.",
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+    parser = SCTArgumentParser(
+        description="Segment an anatomical structure or pathologies according to the specified deep learning model."
+    )
 
     input_output = parser.add_argument_group("\nINPUT/OUTPUT")
     input_output.add_argument(
@@ -130,7 +127,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_deepseg_gm.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_gm.py
@@ -10,22 +10,19 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
 from spinalcordtoolbox.image import add_suffix
 from spinalcordtoolbox.reports.qc import generate_qc
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Spinal Cord Gray Matter (GM) Segmentation using deep dilated convolutions. The contrast of the '
                     'input image must be similar to a T2*-weighted image: WM dark, GM bright and CSF bright. '
                     'Reference: Perone CS, Calabrese E, Cohen-Adad J. Spinal cord gray matter segmentation using deep '
-                    'dilated convolutions. Sci Rep 2018;8(1):5966.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'dilated convolutions. Sci Rep 2018;8(1):5966.'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -95,7 +92,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_lesion.py
@@ -14,23 +14,18 @@
 
 import os
 import sys
-import argparse
 
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
 def get_parser():
-    """Initialize the parser."""
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='MS lesion Segmentation using convolutional networks. Reference: Gros C et al. Automatic'
                     'segmentation of the spinal cord and intramedullary multiple sclerosis lesions with convolutional'
-                    'neural networks. Neuroimage. 2018 Oct 6;184:901-915.',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'neural networks. Neuroimage. 2018 Oct 6;184:901-915.'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -114,7 +109,7 @@ def get_parser():
 def main(argv=None):
     """Main function."""
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_deepseg_sc.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg_sc.py
@@ -13,9 +13,8 @@
 
 import os
 import sys
-import argparse
 
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import Image, check_dim
@@ -23,17 +22,12 @@ from spinalcordtoolbox.deepseg_sc.core import deep_segmentation_spinalcord
 from spinalcordtoolbox.reports.qc import generate_qc
 
 
-
 def get_parser():
-    """Initialize the parser."""
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Spinal Cord Segmentation using convolutional networks. Reference: Gros et al. Automatic "
                     "segmentation of the spinal cord and intramedullary multiple sclerosis lesions with convolutional "
-                    "neural networks. Neuroimage. 2019 Jan 1;184:901-915.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"))
+                    "neural networks. Neuroimage. 2019 Jan 1;184:901-915."
+    )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
@@ -132,7 +126,7 @@ def get_parser():
 def main(argv=None):
     """Main function."""
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_denoising_onlm.py
+++ b/spinalcordtoolbox/scripts/sct_denoising_onlm.py
@@ -2,13 +2,12 @@
 
 import sys
 import os
-import argparse
 from time import time
 
 import numpy as np
 import nibabel as nib
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, extract_fname, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, extract_fname, set_global_loglevel
 
 
 # DEFAULT PARAMETERS
@@ -24,14 +23,10 @@ class Param:
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Utility function to denoise images. (Return the denoised image and also the difference '
-                    'between the input and the output.)',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'between the input and the output.)'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -95,7 +90,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_detect_pmj.py
+++ b/spinalcordtoolbox/scripts/sct_detect_pmj.py
@@ -12,31 +12,26 @@ About the license: see the file LICENSE.TXT
 
 import os
 import sys
-import argparse
 
 from scipy.ndimage.measurements import center_of_mass
 import nibabel as nib
 import numpy as np
 
 from spinalcordtoolbox.image import Image, zeros_like
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, copy, rmtree
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Detection of the Ponto-Medullary Junction (PMJ). '
                     ' This method is machine-learning based and adapted for T1w-like or '
                     ' T2w-like images. '
                     ' If the PMJ is detected from the input image, a nifti mask is output '
                     ' ("*_pmj.nii.gz") with one voxel (value=50) located at the predicted PMJ '
-                    ' position. If the PMJ is not detected, nothing is output.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    ' position. If the PMJ is not detected, nothing is output.'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -260,7 +255,7 @@ class DetectPMJ:
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -12,22 +12,19 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 from spinalcordtoolbox.image import add_suffix
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Compute the Dice Coefficient. '
                     'N.B.: indexing (in both time and space) starts with 0 not 1! Inputting -1 for a '
-                    'size will set it to the full image extent for that dimension.',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'size will set it to the full image extent for that dimension.'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -105,7 +102,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_bvalue.py
@@ -16,14 +16,13 @@
 import sys
 import os
 import math
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 
@@ -51,12 +50,9 @@ def main(argv=None):
 
 
 def get_parser():
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
-        description='Calculate b-value (in mm^2/s).',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+    parser = SCTArgumentParser(
+        description='Calculate b-value (in mm^2/s).'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(

--- a/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_compute_dti.py
@@ -12,18 +12,14 @@
 
 import os
 import sys
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 
 
 def get_parser():
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
-        description='Compute Diffusion Tensor Images (DTI) using dipy.',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"))
+    parser = SCTArgumentParser(
+        description='Compute Diffusion Tensor Images (DTI) using dipy.'
+    )
 
     mandatory = parser.add_argument_group("MANDATORY ARGMENTS")
     mandatory.add_argument(
@@ -90,7 +86,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_b0_and_dwi.py
@@ -10,17 +10,16 @@
 
 import os
 import sys
-import argparse
 
 import numpy as np
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.image import Image, concat_data
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Concatenate b=0 scans with DWI time series and update the bvecs and bvals files.\n\n"
                     "Example 1: Add two b=0 file at the beginning and one at the end of the DWI time series:\n"
                     ">> sct_dmri_concat_b0_and_dwi -i b0-1.nii b0-2.nii dmri.nii b0-65.nii -bvec bvecs.txt -bval "
@@ -29,10 +28,7 @@ def get_parser():
                     "Example 2: Concatenate two DWI series and add one b=0 file at the beginning:\n"
                     ">> sct_dmri_concat_b0_and_dwi -i b0-1.nii dmri1.nii dmri2.nii -bvec bvecs1.txt bvecs2.txt -bval "
                     "bvals1.txt bvals2.txt -order b0 dwi dwi -o dmri_concat.nii -obval bvals_concat.txt -obvec "
-                    "bvecs_concat.txt",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "bvecs_concat.txt"
     )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -108,7 +104,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvals.py
@@ -12,19 +12,15 @@
 
 import os
 import sys
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_global_loglevel
 
 
 def get_parser():
-    # Initialize the parser
+    parser = SCTArgumentParser(
+        description='Concatenate bval files in time.'
+    )
 
-    parser = argparse.ArgumentParser(
-        description='Concatenate bval files in time.',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"))
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
@@ -60,7 +56,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_concat_bvecs.py
@@ -12,21 +12,16 @@
 
 import sys
 import os
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, set_global_loglevel
 
 
 def get_parser():
-    # Initialize the parser
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Concatenate bvec files in time. You can either use bvecs in lines or columns. '
                     'N.B.: Return bvecs in lines. If you need it in columns, please use '
-                    'sct_dmri_transpose_bvecs afterwards.',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'sct_dmri_transpose_bvecs afterwards.'
+    )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -63,7 +58,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_display_bvecs.py
@@ -12,24 +12,18 @@
 
 import os
 import sys
-import argparse
 
 import matplotlib.pyplot as plt
 from dipy.data.fetcher import read_bvals_bvecs
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 
 bzero = 0.0001  # b-zero threshold
 
 
 def get_parser():
-
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
-        description='Display scatter plot of gradient directions from bvecs file.',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description='Display scatter plot of gradient directions from bvecs file.'
     )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -67,7 +61,7 @@ def plot_2dscatter(fig_handle=None, subplot=None, x=None, y=None, xlabel='X', yl
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -28,10 +28,9 @@
 
 import sys
 import os
-import argparse
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, set_global_loglevel
 
 
 def get_parser():
@@ -39,18 +38,14 @@ def get_parser():
     # initialize parameters
     param_default = ParamMoco(is_diffusion=True, group_size=3, metric='MI', smooth='1')
 
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Motion correction of dMRI data. Some of the features to improve robustness were proposed in Xu et "
                     "al. (http://dx.doi.org/10.1016/j.neuroimage.2012.11.014) and include:\n"
                     "  - group-wise (-g)\n"
                     "  - slice-wise regularized along z using polynomial function (-param). For more info about the "
                     "method, type: isct_antsSliceRegularizedRegistration\n"
                     "  - masking (-m)\n"
-                    "  - iterative averaging of target volume\n",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "  - iterative averaging of target volume\n"
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -146,7 +141,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_separate_b0_and_dwi.py
@@ -15,13 +15,12 @@
 import sys
 import math
 import time
-import argparse
 import os
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, copy, extract_fname, rmtree
 
@@ -39,14 +38,10 @@ class Param:
 
 
 def get_parser():
-    # Initialize parser
     param_default = Param()
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Separate b=0 and DW images from diffusion dataset. The output files will have a suffix "
-                    "(_b0 and _dwi) appended to the input file name.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "(_b0 and _dwi) appended to the input file name."
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -117,7 +112,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_transpose_bvecs.py
@@ -24,18 +24,13 @@
 
 import os
 import sys
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, extract_fname, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, extract_fname, printv, set_global_loglevel
 
 
 def get_parser():
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
-        description='Transpose bvecs file (if necessary) to get nx3 structure.',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description='Transpose bvecs file (if necessary) to get nx3 structure.'
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -75,7 +70,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_download_data.py
+++ b/spinalcordtoolbox/scripts/sct_download_data.py
@@ -12,10 +12,9 @@
 
 import os
 import sys
-import argparse
 
 from spinalcordtoolbox.download import install_data
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 
@@ -98,11 +97,8 @@ DICT_URL = {
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description="Download binaries from the web.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description="Download binaries from the web."
     )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -146,7 +142,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_extract_metric.py
+++ b/spinalcordtoolbox/scripts/sct_extract_metric.py
@@ -26,7 +26,7 @@ import numpy as np
 from spinalcordtoolbox.metadata import read_label_file
 from spinalcordtoolbox.aggregate_slicewise import check_labels, extract_metric, save_as_csv, Metric, LabelStruc
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, list_type, parse_num_list, display_open
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, parse_num_list, display_open
 from spinalcordtoolbox.utils.sys import init_sct, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import check_file_exist, extract_fname, get_absolute_path
 
@@ -65,7 +65,7 @@ def get_parser():
 
     param_default = Param()
 
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description=(
             f"This program extracts metrics (e.g., DTI or MTR) within labels. Labels could be a single file or "
             f"a folder generated with 'sct_warp_template' containing multiple label files and a label "
@@ -82,11 +82,7 @@ def get_parser():
             f"To compute average MTR in a region defined by a single label file (could be binary or 0-1 "
             f"weighted mask) between slices 1 and 4:\n"
             f"sct_extract_metric -i mtr.nii.gz -f "
-            f"my_mask.nii.gz -z 1:4 -method wa"
-        ),
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+            f"my_mask.nii.gz -z 1:4 -method wa")
     )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -269,7 +265,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
+++ b/spinalcordtoolbox/scripts/sct_flatten_sagittal.py
@@ -13,11 +13,10 @@
 
 import sys
 import os
-import argparse
 import logging
 
 from spinalcordtoolbox.image import Image, add_suffix
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
 from spinalcordtoolbox.flattening import flatten_sagittal
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 
@@ -63,13 +62,10 @@ def main(argv=None):
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Flatten the spinal cord such within the medial sagittal plane. Useful to make nice pictures. "
                     "Output data has suffix _flatten. Output type is float32 (regardless of input type) to minimize "
-                    "loss of precision during conversion.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "loss of precision during conversion."
     )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(

--- a/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_compute_tsnr.py
@@ -14,12 +14,11 @@
 
 import sys
 import os
-import argparse
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image, add_suffix, empty_like
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, display_viewer_syntax, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, display_viewer_syntax, set_global_loglevel
 
 
 class Param:
@@ -65,11 +64,8 @@ class Tsnr:
 # PARSER
 # ==========================================================================================
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description="Compute temporal SNR (tSNR) in fMRI time series.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description="Compute temporal SNR (tSNR) in fMRI time series."
     )
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -107,7 +103,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -13,10 +13,9 @@
 
 import sys
 import os
-import argparse
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, set_global_loglevel
 
 
 def get_parser():
@@ -25,7 +24,7 @@ def get_parser():
     param_default = ParamMoco(group_size=1, metric='MeanSquares', smooth='0')
 
     # parser initialisation
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Motion correction of fMRI data. Some robust features include:\n"
                     "  - group-wise (-g)\n"
                     "  - slice-wise regularized along z using polynomial function (-p)\n"
@@ -39,10 +38,7 @@ def get_parser():
                     "  - a time-series with 1 voxel in the XY plane, for the X and Y motion direction (two separate "
                     "files), as required for FSL analysis.\n"
                     "  - a TSV file with the slice-wise average of the motion correction for XY (one file), that "
-                    "can be used for Quality Control.\n",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "can be used for Quality Control.\n"
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -124,7 +120,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_get_centerline.py
+++ b/spinalcordtoolbox/scripts/sct_get_centerline.py
@@ -2,21 +2,19 @@
 
 import os
 import sys
-import argparse
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.centerline.core import ParamCenterline, get_centerline, _call_viewer_centerline
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
 def get_parser():
-    # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description=(
             "This function extracts the spinal cord centerline. Three methods are available: 'optic' (automatic), "
             "'viewer' (manual), and 'fitseg' (applied on segmented image). These functions output (i) a NIFTI file "
@@ -25,10 +23,7 @@ def get_parser():
             "\n"
             "Reference: C Gros, B De Leener, et al. Automatic spinal cord localization, robust to MRI contrast using "
             "global curve optimization (2017). doi.org/10.1016/j.media.2017.12.001"
-        ),
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+        )
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -123,7 +118,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -12,26 +12,23 @@
 
 import os
 import sys
-import argparse
 
 import numpy as np
 from nibabel import Nifti1Image
 from nibabel.processing import resample_from_to
 
 from spinalcordtoolbox.image import Image, concat_data, add_suffix, change_orientation, concat_warp2d, split_img_data, pad_image
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, extract_fname, rmtree
 
 
 def get_parser():
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Perform manipulations on images (e.g., pad, change space, split along dimension). '
-                    'Inputs can be a number, a 4d image, or several 3d images separated with ","',
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip('.py'))
+                    'Inputs can be a number, a 4d image, or several 3d images separated with ","'
+    )
+
     mandatory = parser.add_argument_group('MANDATORY ARGUMENTS')
     mandatory.add_argument(
         '-i',
@@ -167,7 +164,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -18,7 +18,6 @@
 
 import os
 import sys
-import argparse
 from typing import Sequence
 
 import numpy as np
@@ -27,17 +26,14 @@ import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils import (Metavar, SmartFormatter, ActionCreateFolder, list_type, init_sct, printv,
+from spinalcordtoolbox.utils import (SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, printv,
                                      parse_num_list, set_global_loglevel)
 from spinalcordtoolbox.utils.shell import display_viewer_syntax
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description="Utility functions for label images.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description="Utility functions for label images."
     )
 
     req_group = parser.add_argument_group("\nREQUIRED I/O")
@@ -226,7 +222,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -12,7 +12,6 @@
 
 import sys
 import os
-import argparse
 
 import numpy as np
 
@@ -23,7 +22,7 @@ from spinalcordtoolbox.vertebrae.detect_c2c3 import detect_c2c3
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.math import dilate
 from spinalcordtoolbox.labels import create_labels_along_segmentation
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, list_type, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, cache_signature, cache_valid, cache_save, \
     copy, extract_fname, rmtree
@@ -60,8 +59,7 @@ class Param:
 def get_parser():
     # initialize default param
     param_default = Param()
-    # parser initialisation
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description=(
             "This function takes an anatomical image and its cord segmentation (binary file), and outputs the "
             "cord segmentation labeled with vertebral level. The algorithm requires an initialization (first disc) and "
@@ -70,10 +68,7 @@ def get_parser():
             "'spinalcordtoolbox/vertebrae/detect_c2c3.py' to detect the C2-C3 disc.\n"
             "Tips: To run the function with init txt file that includes flags -initz/-initcenter:\n"
             "  sct_label_vertebrae -i t2.nii.gz -s t2_seg-manual.nii.gz  '$(< init_label_vertebrae.txt)'"
-        ),
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+        )
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -231,7 +226,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_maths.py
+++ b/spinalcordtoolbox/scripts/sct_maths.py
@@ -12,7 +12,6 @@
 
 import os
 import sys
-import argparse
 import pickle
 import gzip
 
@@ -22,19 +21,16 @@ import matplotlib.pyplot as plt
 
 import spinalcordtoolbox.math as sct_math
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, list_type, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 
 
 def get_parser():
-
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Perform mathematical operations on images. Some inputs can be either a number or a 4d image or '
-                    'several 3d images separated with ","',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    'several 3d images separated with ","'
+    )
 
     mandatory = parser.add_argument_group("MANDATORY ARGUMENTS")
     mandatory.add_argument(
@@ -254,7 +250,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_merge_images.py
+++ b/spinalcordtoolbox/scripts/sct_merge_images.py
@@ -15,12 +15,11 @@
 
 import sys
 import os
-import argparse
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree
 
@@ -42,11 +41,9 @@ class Param:
 def get_parser():
     # Initialize the parser
 
-    parser = argparse.ArgumentParser(
-        description='Merge images to the same space',
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+    parser = SCTArgumentParser(
+        description='Merge images to the same space'
+    )
     mandatory = parser.add_argument_group("MANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
@@ -185,7 +182,7 @@ def merge_images(list_fname_src, fname_dest, list_fname_warp, param):
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_process_segmentation.py
+++ b/spinalcordtoolbox/scripts/sct_process_segmentation.py
@@ -18,7 +18,6 @@
 
 import sys
 import os
-import argparse
 
 import numpy as np
 from matplotlib.ticker import MaxNLocator
@@ -28,7 +27,7 @@ from spinalcordtoolbox.aggregate_slicewise import aggregate_per_slice_or_level, 
 from spinalcordtoolbox.process_seg import compute_shape
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, parse_num_list, display_open
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, parse_num_list, display_open
 from spinalcordtoolbox.utils.sys import init_sct, set_global_loglevel
 from spinalcordtoolbox.utils.fs import get_absolute_path
 
@@ -38,7 +37,7 @@ def get_parser():
     :return: Returns the parser with the command line documentation contained in it.
     """
     # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description=(
             "Compute the following morphometric measures based on the spinal cord segmentation:\n"
             "  - area [mm^2]: Cross-sectional area, measured by counting pixels in each slice. Partial volume can be "
@@ -55,10 +54,7 @@ def get_parser():
             "metric is interesting for detecting non-convex shape (e.g., in case of strong compression)\n"
             "  - length: Length of the segmentation, computed by summing the slice thickness (corrected for the "
             "centerline angle at each slice) across the specified superior-inferior region.\n"
-        ),
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+        )
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -269,7 +265,7 @@ def _make_figure(metric, fit_results):
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_propseg.py
+++ b/spinalcordtoolbox/scripts/sct_propseg.py
@@ -15,14 +15,13 @@
 
 import os
 import sys
-import argparse
 import logging
 
 import numpy as np
 from scipy import ndimage as ndi
 
 from spinalcordtoolbox.image import Image, add_suffix, zeros_like
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, rmtree, extract_fname, mv, copy
 from spinalcordtoolbox.centerline import optic
@@ -149,7 +148,7 @@ def check_and_correct_segmentation(fname_segmentation, fname_centerline, folder_
 
 def get_parser():
     # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description=(
             "This program segments automatically the spinal cord on T1- and T2-weighted images, for any field of view. "
             "You must provide the type of contrast, the image as well as the output folder path. The segmentation "
@@ -176,10 +175,7 @@ def get_parser():
             "cord. Neuroimage 98, 2014. pp 528-536. DOI: 10.1016/j.neuroimage.2014.04.051](https://pubmed.ncbi.nlm.nih.gov/24780696/)\n"
             "  - [De Leener B, Cohen-Adad J, Kadoury S. Automatic segmentation of the spinal cord and spinal canal "
             "coupled with vertebral labeling. IEEE Trans Med Imaging. 2015 Aug;34(8):1705-18.](https://pubmed.ncbi.nlm.nih.gov/26011879/)"
-        ),
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+        )
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -658,7 +654,7 @@ def propseg(img_input, options_dict):
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -9,15 +9,13 @@
 # About the license: see the file LICENSE.TXT
 
 import sys
-import argparse
 
-from spinalcordtoolbox.utils import init_sct, set_global_loglevel
+from spinalcordtoolbox.utils import init_sct, set_global_loglevel, SCTArgumentParser
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Generate Quality Control (QC) report following SCT processing.',
-        formatter_class=argparse.RawTextHelpFormatter,
         epilog='Examples:\n'
                'sct_qc -i t2.nii.gz -s t2_seg.nii.gz -p sct_deepseg_sc\n'
                'sct_qc -i t2.nii.gz -s t2_seg_labeled.nii.gz -p sct_label_vertebrae\n'
@@ -60,12 +58,17 @@ def get_parser():
     parser.add_argument('-v',
                         action='store_true',
                         help="Verbose")
+    parser.add_argument('-h',
+                        '--help',
+                        action="help",
+                        help="show this message and exit")
+
     return parser
 
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_register_multimodal.py
+++ b/spinalcordtoolbox/scripts/sct_register_multimodal.py
@@ -34,13 +34,12 @@
 import sys
 import os
 import time
-import argparse
 
 import numpy as np
 
 from spinalcordtoolbox.reports.qc import generate_qc
 from spinalcordtoolbox.registration.register import Paramreg, ParamregMultiStep
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, list_type, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import extract_fname
 from spinalcordtoolbox.image import check_dim
@@ -56,7 +55,7 @@ paramregmulti = ParamregMultiStep([step0, step1])
 
 def get_parser():
     # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="This program co-registers two 3D volumes. The deformation is non-rigid and is constrained along "
                     "Z direction (i.e., axial plane). Hence, this function assumes that orientation of the destination "
                     "image is axial (RPI). If you need to register two volumes with large deformations and/or "
@@ -78,10 +77,7 @@ def get_parser():
                     "segmentation, i.e. using type=seg\n"
                     " - Columnwise algorithm needs to be applied after a translation and rotation such as centermassrot "
                     "algorithm. For example: -param step=1,type=seg,algo=centermassrot,metric=MeanSquares:"
-                    "step=2,type=seg,algo=columnwise,metric=MeanSquares",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "step=2,type=seg,algo=columnwise,metric=MeanSquares"
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -302,7 +298,7 @@ class Param:
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -17,7 +17,6 @@
 import sys
 import os
 import time
-import argparse
 
 import numpy as np
 
@@ -67,7 +66,7 @@ paramregmulti = ParamregMultiStep([step0, step1, step2])
 # ==========================================================================================
 def get_parser():
     param = Param()
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description=(
             "Register an anatomical image to the spinal cord MRI template (default: PAM50).\n"
             "\n"
@@ -114,10 +113,7 @@ def get_parser():
             "\n"
             "More information about label creation can be found at "
             "https://www.icloud.com/keynote/0th8lcatyVPkM_W14zpjynr5g#SCT%%5FCourse%%5F20200121 (p47)"
-        ),
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+        )
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -284,7 +280,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_resample.py
+++ b/spinalcordtoolbox/scripts/sct_resample.py
@@ -14,9 +14,8 @@
 
 import os
 import sys
-import argparse
 
-from spinalcordtoolbox.utils import Metavar, SmartFormatter, init_sct, printv, set_global_loglevel
+from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, init_sct, printv, set_global_loglevel
 import spinalcordtoolbox.resampling
 
 
@@ -41,11 +40,8 @@ param = Param()
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description="Anisotropic resampling of 3D or 4D data.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description="Anisotropic resampling of 3D or 4D data."
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -115,7 +111,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -15,7 +15,6 @@
 
 import os
 import sys
-import argparse
 from getpass import getpass
 import multiprocessing
 import subprocess
@@ -34,7 +33,7 @@ from textwrap import dedent
 import yaml
 import psutil
 
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar
 from spinalcordtoolbox.utils.sys import send_email, init_sct, __get_commit, __get_git_origin, __version__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import Tee
 
@@ -42,7 +41,7 @@ from stat import S_IEXEC
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description='Wrapper to processing scripts, which loops across subjects. Subjects should be organized as '
                     'folders within a single directory. We recommend following the BIDS convention '
                     '(https://bids.neuroimaging.io/). The processing script should accept a subject directory '
@@ -50,9 +49,8 @@ def get_parser():
                     'arguments passed via `-script-args`. If the script or the input data are located within a '
                     'git repository, the git commit is displayed. If the script or data have changed since the latest '
                     'commit, the symbol "*" is added after the git commit number. If no git repository is found, the '
-                    'git commit version displays "?!?". The script is copied on the output folder (-path-out).',
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip('.py'))
+                    'git commit version displays "?!?". The script is copied on the output folder (-path-out).'
+    )
 
     parser.add_argument('-config', '-c',
                         help='R|'
@@ -151,6 +149,7 @@ def get_parser():
     parser.add_argument('-v', metavar=Metavar.int, type=int, choices=[0, 1, 2], default=1,
                         # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
                         help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
+    parser.add_argument('-h', "--help", action="help", help="show this help message and exit")
 
     return parser
 
@@ -226,7 +225,7 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_smooth_spinalcord.py
@@ -15,12 +15,11 @@
 import sys
 import os
 import time
-import argparse
 
 import numpy as np
 
 from spinalcordtoolbox.image import Image, generate_output_file
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, list_type, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, list_type, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, set_global_loglevel
 from spinalcordtoolbox.utils.fs import tmp_create, cache_save, cache_signature, cache_valid, copy, \
     extract_fname, rmtree
@@ -51,14 +50,11 @@ def get_parser():
     param_default = Param()
 
     # Initialize the parser
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Smooth the spinal cord along its centerline. Steps are:\n"
                     "  1) Spinal cord is straightened (using centerline),\n"
                     "  2) a Gaussian kernel is applied in the superior-inferior direction,\n"
-                    "  3) then cord is de-straightened as originally.\n",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+                    "  3) then cord is de-straightened as originally.\n"
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -122,7 +118,7 @@ def get_parser():
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
+++ b/spinalcordtoolbox/scripts/sct_straighten_spinalcord.py
@@ -14,27 +14,22 @@
 
 import sys
 import os
-import argparse
 
 from spinalcordtoolbox.straightening import SpinalCordStraightener
 from spinalcordtoolbox.centerline.core import ParamCenterline
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, printv, set_global_loglevel
 
 
 def get_parser():
-
-    # Mandatory arguments
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="This program takes as input an anatomic image and the spinal cord centerline (or "
                     "segmentation), and returns the an image of a straightened spinal cord. Reference: "
                     "De Leener B, Mangeat G, Dupont S, Martin AR, Callot V, Stikov N, Fehlings MG, "
                     "Cohen-Adad J. Topologically-preserving straightening of spinal cord MRI. J Magn "
-                    "Reson Imaging. 2017 Oct;46(4):1209-1219",
-        add_help=None,
-        formatter_class=SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"))
+                    "Reson Imaging. 2017 Oct;46(4):1209-1219"
+    )
     mandatory = parser.add_argument_group("MANDATORY ARGUMENTS")
     mandatory.add_argument(
         "-i",
@@ -200,7 +195,7 @@ def main(argv=None):
     :return:
     """
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -23,7 +23,7 @@ import signal
 import numpy as np
 from pandas import DataFrame
 
-from spinalcordtoolbox.utils import init_sct, run_proc, tmp_create, printv, rmtree, __sct_dir__, set_global_loglevel
+from spinalcordtoolbox.utils import init_sct, run_proc, tmp_create, printv, rmtree, __sct_dir__, set_global_loglevel, SCTArgumentParser
 from spinalcordtoolbox.scripts import sct_download_data
 
 # FIXME
@@ -99,11 +99,9 @@ class bcolors:
 # PARSER
 # ==========================================================================================
 def get_parser():
-    import argparse
-
     param_default = Param()
 
-    parser = argparse.ArgumentParser(
+    parser = SCTArgumentParser(
         description="Crash and integrity testing for functions of the Spinal Cord Toolbox. Internet connection is required for downloading testing data.",
     )
 
@@ -158,6 +156,9 @@ def get_parser():
     parser.add_argument("--execution-folder",
                         help="Folder where to run tests from (default. temporary)",
                         )
+    parser.add_argument('-h', "--help",
+                        help="show this message and exit",
+                        action="help")
 
     return parser
 
@@ -210,7 +211,7 @@ def process_function_multiproc(fname, param):
 # ==========================================================================================
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.verbose
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -13,11 +13,10 @@
 
 import sys
 import os
-import argparse
 
 import spinalcordtoolbox.metadata
 from spinalcordtoolbox.reports.qc import generate_qc
-from spinalcordtoolbox.utils.shell import Metavar, SmartFormatter, ActionCreateFolder, display_viewer_syntax
+from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, ActionCreateFolder, display_viewer_syntax
 from spinalcordtoolbox.utils.sys import init_sct, run_proc, printv, __data_dir__, set_global_loglevel
 from spinalcordtoolbox.utils.fs import copy
 
@@ -147,12 +146,8 @@ def get_interp(file_label, list_labels_nn):
 def get_parser():
     # Initialize default parameters
     param_default = Param()
-    # Initialize parser
-    parser = argparse.ArgumentParser(
-        description="This function warps the template and all atlases to a destination image.",
-        formatter_class=SmartFormatter,
-        add_help=None,
-        prog=os.path.basename(__file__).strip(".py")
+    parser = SCTArgumentParser(
+        description="This function warps the template and all atlases to a destination image."
     )
 
     mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
@@ -237,7 +232,7 @@ def get_parser():
 
 def main(argv=None):
     parser = get_parser()
-    arguments = parser.parse_args(argv if argv else ['--help'])
+    arguments = parser.parse_args(argv)
     verbose = arguments.v
     set_global_loglevel(verbose=verbose)
 

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -100,7 +100,12 @@ def display_viewer_syntax(files, colormaps=[], minmax=[], opacities=[], mode='',
 
 
 class SCTArgumentParser(argparse.ArgumentParser):
-    """Parser that centralizes initialization steps common across all SCT scripts."""
+    """
+        Parser that centralizes initialization steps common across all SCT scripts.
+
+        TODO: Centralize `-v`, `-r`, and `-h` arguments here too, as they're copied
+              and pasted across all SCT scripts.
+    """
     def __init__(self, *args, **kwargs):
         def update_parent_default(key, value):
             """A polite way of letting a child class have different default values than the parent class."""

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -124,7 +124,11 @@ class SCTArgumentParser(argparse.ArgumentParser):
         super(SCTArgumentParser, self).__init__(*args, **kwargs)
 
     def error(self, message):
-        """Overridden parent method. Ensures that calling script with no args prints the help. See issue #3137."""
+        """
+            Overridden parent method. Ensures that calling script with no args prints the help.
+
+            See https://github.com/neuropoly/spinalcordtoolbox/issues/3137.
+        """
         # Source: https://stackoverflow.com/a/4042861
         sys.stderr.write(f'{self.prog}: error: {message}\n\n')
         self.print_help(sys.stderr)

--- a/spinalcordtoolbox/utils/shell.py
+++ b/spinalcordtoolbox/utils/shell.py
@@ -130,7 +130,7 @@ class SCTArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
         """
-            Overridden parent method. Ensures that calling script with no args prints the help.
+            Overridden parent method. Ensures that help is printed when called with invalid args.
 
             See https://github.com/neuropoly/spinalcordtoolbox/issues/3137.
         """

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -2,10 +2,43 @@
 # -*- coding: utf-8
 # pytest unit tests for utils
 
+import pytest
+
 from spinalcordtoolbox import utils
+
 
 def test_parse_num_list_inv():
     assert utils.parse_num_list_inv([1, 2, 3, 5, 6, 9]) == '1:3;5:6;9'
     assert utils.parse_num_list_inv([3, 2, 1, 5]) == '1:3;5'
     assert utils.parse_num_list_inv([]) == ''
 
+
+def test_sct_argument_parser(capsys):
+    """Test extra argparse functionality added by SCTArgumentParser subclass."""
+    # Check that new defaults can still be overridden (setting add_help via args AND kwargs)
+    parser1 = utils.SCTArgumentParser(None, None, None, None, [], utils.SmartFormatter, '-', None, None, 'error', True)
+    assert parser1.add_help is True
+    parser2 = utils.SCTArgumentParser(add_help=True)
+    assert parser2.add_help is True
+
+    # Check that new defaults are set properly
+    parser3 = utils.SCTArgumentParser()
+    assert parser3.prog == "test_utils"
+    assert parser3.formatter_class == utils.SmartFormatter
+    assert parser3.add_help is False
+
+    # Check that error is thrown when required argument isn't passed
+    parser3.add_argument('-r', '--required', required=True)
+    parser3.add_argument('-h', "--help", help="show this message and exit", action="help")
+    with pytest.raises(SystemExit) as e:
+        parser3.parse_args()
+    assert e.value.code == 2
+
+    # Check help message is still output when above error is thrown
+    captured = capsys.readouterr()
+    assert "usage: test_utils" in captured.err
+
+    # Ensure no error is thrown when help is explicitly called
+    with pytest.raises(SystemExit) as e:
+        parser3.parse_args(['-h'])
+    assert e.value.code == 0


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

#### Issue

#3091 included the line `arguments = parser.parse_args(argv if argv else ['--help'])`, which shows the help message if no arguments are passed. The problem is, passing `--help` is valid usage, and the error code returned is 0. This is a bug, because passing no arguments should be invalid usage for many scripts!

#### Work done

This PR introduces a subclassed ArgumentParser that overrides the `error` method to print the help instead. This way, a non-zero error code is returned AND the help is shown.

The same changes are made to every script (switching from `ArgumentParser` to `SCTArgumentParser`, removing `argv if argv else --help`) except these two:

* `sct_testing`
* `sct_qc`

These scripts also got an extra `--help` argument, because they never had one in the first place.

#### Aside about centralization

An added benefit of having a subclassed parser is that we get to centralize the default ArgumentParser values for all scripts, which limits duplicated code. 

In theory, we could also centralize the `-h`, `-v`, and `-r` arguments, too. But, that's a more involved effort, and can be done later as part of #2676.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3137.