### PR TITLE
Add new '-create-seg-mid' option to replace bugged '-create-seg -1' behavior

### DIFF
--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -232,6 +232,11 @@ def get_parser():
 # MAIN
 # ==========================================================================================
 def main(argv=None):
+    for i, arg in enumerate(argv):
+        if arg == '-create-seg' and len(argv) > i+1 and '-1,' in argv[i+1]:
+            raise DeprecationWarning("The use of '-1' for '-create-seg' has been deprecated. Please use "
+                                     "'-create-seg-mid' instead.")
+
     parser = get_parser()
     arguments = parser.parse_args(argv)
     verbose = arguments.v

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -103,8 +103,8 @@ def get_parser():
         type=int,
         help="R|Similar to '-create-seg'. This option takes a single label value, and will automatically select the "
              "mid-point slice in the inferior-superior direction (so there is no need for a slice index).\n"
-             "This is useful for when you have you have centered the field of view of your data at a specific "
-             "location. For example, if you already know that the C2-C3 disc is centered in the I-S direction, then "
+             "This is useful for when you have centered the field of view of your data at a specific location. "
+             "For example, if you already know that the C2-C3 disc is centered in the I-S direction, then "
              "you can enter '-create-seg-mid 3' for that label. This saves you the trouble of having to manually "
              "specify a slice index using '-create-seg'."
     )

--- a/spinalcordtoolbox/scripts/sct_label_utils.py
+++ b/spinalcordtoolbox/scripts/sct_label_utils.py
@@ -93,11 +93,22 @@ def get_parser():
         help="R|Create labels on a cord segmentation (or centerline) image defined by '-i'. Each label should be "
              "specified using the form 'v1,v2' where 'v1' is value of the slice index along the inferior-superior "
              "axis, and 'v2' is the value of the label. Separate each label with ':'. \n"
-             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at the axial slices 5, 14, and 23 (starting from the most inferior slice).\n"
-             "You can also choose a slice value of '-1' to automatically select the mid-point in the "
-             "inferior-superior direction. For example, if you know that the C2-C3 disc is centered in the I-S "
-             "direction, then you can enter '-1,3' for that label instead."
+             "Example: '-create-seg 5,1:14,2:23,3' adds three labels at the axial slices 5, 14, and 23 (starting from "
+             "the most inferior slice)."
     )
+
+    func_group.add_argument(
+        '-create-seg-mid',
+        metavar=Metavar.int,
+        type=int,
+        help="R|Similar to '-create-seg'. This option takes a single label value, and will automatically select the "
+             "mid-point slice in the inferior-superior direction (so there is no need for a slice index).\n"
+             "This is useful for when you have you have centered the field of view of your data at a specific "
+             "location. For example, if you already know that the C2-C3 disc is centered in the I-S direction, then "
+             "you can enter '-create-seg-mid 3' for that label. This saves you the trouble of having to manually "
+             "specify a slice index using '-create-seg'."
+    )
+
     func_group.add_argument(
         '-create-viewer',
         metavar=Metavar.list,
@@ -243,6 +254,9 @@ def main(argv=None):
         out = sct_labels.create_labels(img, labels)
     elif arguments.create_seg is not None:
         labels = arguments.create_seg
+        out = sct_labels.create_labels_along_segmentation(img, labels)
+    elif arguments.create_seg_mid is not None:
+        labels = [(-1, arguments.create_seg_mid)]
         out = sct_labels.create_labels_along_segmentation(img, labels)
     elif arguments.cubic_to_point:
         out = sct_labels.cubic_to_point(img)

--- a/unit_testing/cli/test_cli_sct_label_utils.py
+++ b/unit_testing/cli/test_cli_sct_label_utils.py
@@ -2,6 +2,11 @@ from pytest_console_scripts import script_runner
 import pytest
 import logging
 
+import numpy as np
+
+from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.scripts import sct_label_utils
+
 logger = logging.getLogger(__name__)
 
 
@@ -12,3 +17,24 @@ def test_sct_label_utils_backwards_compat(script_runner):
     logger.debug(f"{ret.stderr}")
     assert ret.success
     assert ret.stderr == ''
+
+
+def test_create_seg_mid(tmp_path):
+    """Test the '-create-seg-mid' option in sct_label_utils."""
+    input = 'sct_testing_data/t2/t2_seg-manual.nii.gz'
+    output = str(tmp_path/'t2_seg_labeled.nii.gz')
+
+    # Create a single label using the new syntax
+    sct_label_utils.main(['-i', input, '-create-seg-mid', '3', '-o', output])
+    output_img = Image(output)
+    labels = np.argwhere(output_img.data)
+    assert len(labels) == 1
+
+    # Ensure slice coordinate of label is centered at midpoint of I-S axis
+    for coord, axis, shape in zip(labels[0], output_img.orientation, Image(output).data.shape):
+        if axis in ['I', 'S']:
+            assert coord == round(shape/2)
+
+    # Old syntax for this behavior should not be allowed
+    with pytest.raises(DeprecationWarning):
+        sct_label_utils.main(['-i', input, '-create-seg', '-1,3', '-o', output])


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The form "`-create-seg -1,value`" doesn't work with `argparse`, because `argparse` interprets `-1,value` as a separate argument. So, we split this functionality off into a new option, as per https://github.com/neuropoly/spinalcordtoolbox/issues/3119#issuecomment-750388733.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3119.