### PR TITLE
Fix test download concurrency bug.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,11 +25,13 @@ from spinalcordtoolbox.scripts import sct_download_data as downloader
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def testdata():
-    """ Download sct_testing_data prior to test collection. """
-    logger.info("Downloading sct test data")
-    downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+def pytest_sessionstart():
+    """Download sct_testing_data prior to test collection."""
+    # pytest_sessionstart runs once before any test session starts, then again for each
+    # worker session. We only want it to run once, so check to see if we're in a worker session.
+    if "PYTEST_XDIST_WORKER" not in os.environ.keys():
+        logger.info("Downloading sct test data")
+        downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,6 @@ from hashlib import md5
 
 import pytest
 from pytest import fixture
-#from pytest_cases import fixture
 
 from spinalcordtoolbox.utils.sys import sct_dir_local_path, sct_test_path
 from spinalcordtoolbox.utils.fs import Lockf

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,13 @@ import sys
 import os
 import logging
 from typing import Mapping
+import functools
 from hashlib import md5
+import inspect
+try:
+    import cPickle as pickle # py 3.6 doesn't have cPickle?
+except ImportError:
+    import pickle
 
 import pytest
 from pytest import fixture
@@ -52,49 +58,102 @@ def testrun_tmp_path(tmp_path_factory):
         return tmp_path_factory.getbasetemp()
 
 
+def node_scoped(fixture):
+    """
+    Ensure a fixture only runs once per *node* per test run.
+
+    When using pytest-xdist, there are multiple worker processes potentially spread out over on multiple worker machines ("nodes").
+    It causes `@fixture(scope="session")` to essentially mean `@fixture(scope="worker")` and this has caused lots of confusion:
+      https://github.com/pytest-dev/pytest-xdist/issues/271
+
+    For fixtures that need to generate shared data in-RAM, that is fine. But for fixtures that generate shared data on-disk
+    it causes redundant work and possible corruption.
+    Since this doesn't seem fixable inside of pytest (https://github.com/pytest-dev/pytest-xdist/issues/271#issuecomment-762453836)
+    this provides a workaround that creates fixtures that run once per run per node.
+
+    Usage:
+
+        @fixture(scope="session")
+        @node_scoped
+        def fixture():
+            return make_some_data()
+    """
+    from _pytest.compat import is_generator
+    if is_generator(fixture):
+        raise TypeError("node_scoped doesn't (yet) support generator-fixtures")
+
+
+    @functools.wraps(fixture)
+    def _fixture(testrun_tmp_path, *args, **kwargs):
+        #
+        # xdist means we need to deal with interprocess concurrency, so here we handle it with a lock file:
+        # whichever worker gets the lock first generates the fixture, then marks itself done using a second file.
+        # Every other worker blocks until at least the first one is done, then they will see the '.done' file and skip on.
+        # We don't try to handle cleaning up the lockfile when we're done (which can be very tricky to get right!);
+        # because we're running under pytest we can just lean on the master process to clean it up for us.
+        #
+        # Here we are using [`fcntl.lockf`](https://apenwarr.ca/log/20101213):
+        # > in C, use fcntl(), but avoid lockf(), which is not necessarily the same thing.
+        # > in python, use fcntl.lockf(), which is the same thing as fcntl() in C.
+        #
+        # There are several other options:
+        # - [`portalocker.Lock`](https://pypi.org/project/portalocker/)
+        # - [`posix_ipc.Semaphore`](http://semanchuk.com/philip/posix_ipc/)
+        # - ?
+        #
+        # This is compatible with pytest-xdist's multi-server mode, where it distributes tests out via ssh.
+        # Each node has its own fcntl locks, so workers that end up on the same host will only do the work
+        # once, while those on different hosts will have at least one of them pick it up.
+
+        fixture_path = testrun_tmp_path / "fixtures" / f"{fixture.__name__}"
+        os.makedirs(fixture_path, exist_ok=True)
+        lock = fixture_path / f"lock"
+        done = fixture_path / f"done"
+        # instead of testrun_tmp_path, per the suggestion on https://pypi.org/project/pytest-xdist/,
+        # we could use testrun_uid to make our own distinct tmpdir, or perhaps a POSIX semaphore.
+        # this is working for now.
+
+        if 'testrun_tmp_path' in inspect.signature(fixture).parameters:
+            # just in case the fixture *also* uses testrun_tmp_path
+            kwargs = {**kwargs, 'testrun_tmp_path': testrun_tmp_path}
+
+        with open(lock, "w") as lock_fd:
+            with Lockf(lock_fd):
+                if not os.path.exists(done):
+                    result = fixture(*args, **kwargs)
+                    with open(done, "wb") as result_cache:
+                        pickle.dump(result, result_cache)
+                else:
+                    with open(done, "rb") as result_cache:
+                        result = pickle.load(result_cache)
+                return result
+
+
+    # we have to *append* testrun_tmp_path to the wrapper's signature in order for pytest's fixture system to pick it up and feed it to us
+    # this could be shortened with decorator.decorator() (https://github.com/micheles/decorator/blob/master/docs/documentation.md) at the expense of an extra dependency.
+    if 'testrun_tmp_path' not in inspect.signature(fixture).parameters:
+        sig = inspect.signature(_fixture)
+        _fixture.__signature__ = sig.replace(parameters=
+                                                  {**sig.parameters,
+                                                     'testrun_tmp_path': inspect.Parameter('testrun_tmp_path', inspect.Parameter.POSITIONAL_OR_KEYWORD)}
+                                                  .values())
+
+    return _fixture
+
+
 @fixture(scope="session", autouse=True)
 # TODO: make this *not* autouse; instead, replace all calls to sct_test_path() with this fixture, so that pytest can understand the dependencies.
-def sct_testing_data(testrun_tmp_path):
+@node_scoped
+def sct_testing_data(worker_id):
     """ Download sct_testing_data prior to testing. """
-    # pytest-xdist breaks session-scoped fixtures: it silently makes them [worker-scoped instead](https://github.com/pytest-dev/pytest-xdist/issues/271).
-    #
-    # This is a concurrency issue, and an interprocess one at that, so here we handle it with a lock file:
-    # whichever worker gets the lock first generates the fixture, then marks itself done using a second file.
-    # Every other worker blocks until at least the first one is done, then they will see the '.done' file and skip on.
-    # We don't try to handle cleaning up the lockfile when we're done (which can be very tricky to get right!);
-    # because we're running under pytest we can just lean on the master process to clean it up for us.
-    #
-    # Here we are using [`fcntl.lockf`](https://apenwarr.ca/log/20101213):
-    # > in C, use fcntl(), but avoid lockf(), which is not necessarily the same thing.
-    # > in python, use fcntl.lockf(), which is the same thing as fcntl() in C.
-    #
-    # There are several other options:
-    # - [`portalocker.Lock`](https://pypi.org/project/portalocker/)
-    # - [`posix_ipc.Semaphore`](http://semanchuk.com/philip/posix_ipc/)
-    # - ?
-    #
-    # This is compatible with pytest-xdist's multi-server mode, where it distributes tests out via ssh.
-    # Each node has its own fcntl locks, so workers that end up on the same host will only do the work
-    # once, while those on different hosts will have at least one of them pick it up.
 
-    _fixture_name = "sct_testing_data" # TODO: generalize to fixture.__name__
-    lock = testrun_tmp_path / f"{_fixture_name}.lock"
-    done = testrun_tmp_path / f"{_fixture_name}.done"
-    # instead of testrun_tmp_path, per the suggestion on https://pypi.org/project/pytest-xdist/,
-    # we could use testrun_uid to make our own distinct tmpdir, or perhaps a POSIX semaphore.
-    # this is working for now.
-
-    with open(lock, "w") as lock:
-        with Lockf(lock):
-            if not os.path.exists(done):
-                if not os.path.exists(sct_test_path()):
-                    downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
-                with open(done, "w"): pass  # write the 'done' flag
-
-    # return the test path so clients
     # TODO: merge test_data_integrity() in here
 
-    yield sct_test_path()
+    if not os.path.exists(sct_test_path()):
+        downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+
+    # return the test path so clients know they can use it
+    return sct_test_path()
 
     # TODO: delete the data ?
 

--- a/conftest.py
+++ b/conftest.py
@@ -25,10 +25,12 @@ from spinalcordtoolbox.scripts import sct_download_data as downloader
 logger = logging.getLogger(__name__)
 
 
-def pytest_sessionstart():
+@pytest.fixture(scope="session", autouse=True)
+def testdata():
     """ Download sct_testing_data prior to test collection. """
     logger.info("Downloading sct test data")
-    downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+    if not os.path.isdir(sct_test_path()):
+        downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -29,8 +29,7 @@ logger = logging.getLogger(__name__)
 def testdata():
     """ Download sct_testing_data prior to test collection. """
     logger.info("Downloading sct test data")
-    if not os.path.isdir(sct_test_path()):
-        downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+    downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,8 @@ from typing import Mapping
 from hashlib import md5
 
 import pytest
+from pytest import fixture
+#from pytest_cases import fixture
 
 from spinalcordtoolbox.utils.sys import sct_dir_local_path, sct_test_path
 from spinalcordtoolbox.utils.fs import Lockf

--- a/conftest.py
+++ b/conftest.py
@@ -25,13 +25,11 @@ from spinalcordtoolbox.scripts import sct_download_data as downloader
 logger = logging.getLogger(__name__)
 
 
-def pytest_sessionstart():
-    """Download sct_testing_data prior to test collection."""
-    # pytest_sessionstart runs once before any test session starts, then again for each
-    # worker session. We only want it to run once, so check to see if we're in a worker session.
-    if "PYTEST_XDIST_WORKER" not in os.environ.keys():
-        logger.info("Downloading sct test data")
-        downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
+@pytest.fixture(scope="session", autouse=True)
+def testdata():
+    """ Download sct_testing_data prior to test collection. """
+    logger.info("Downloading sct test data")
+    downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session", autouse=True)
-def testdata():
+def sct_testing_data():
     """ Download sct_testing_data prior to test collection. """
     logger.info("Downloading sct test data")
     downloader.main(['-d', 'sct_testing_data', '-o', sct_test_path()])

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,5 @@ transforms3d
 urllib3[secure]
 pytest_console_scripts
 pytest-xdist
+pytest_cases
 tensorboard==1.14.0

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -6,8 +6,6 @@ import sys
 import os
 
 import pytest
-from pytest import fixture
-#from pytest_cases import fixture
 import numpy as np
 import nibabel
 import nibabel.orientations
@@ -16,7 +14,7 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.utils import tmp_create, __sct_dir__
 from spinalcordtoolbox.scripts import sct_image
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def image_paths():
     ret = []
     sct_dir = os.path.dirname(os.path.dirname(__file__))
@@ -29,7 +27,6 @@ def image_paths():
     return ret
 
 
-#TODO: @fixture
 def fake_3dimage_custom(data):
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -38,7 +35,6 @@ def fake_3dimage_custom(data):
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-#TODO: @fixture
 def fake_3dimage_sct_custom(data):
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -51,7 +47,6 @@ def fake_3dimage_sct_custom(data):
     return img
 
 
-#TODO: @fixture
 def fake_3dimage_vis():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -125,7 +120,7 @@ def fake_3dimage_vis():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def fake_3dimage_sct_vis():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -138,7 +133,6 @@ def fake_3dimage_sct_vis():
     return img
 
 
-#TODO: @fixture
 def fake_3dimage():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -169,12 +163,11 @@ def fake_3dimage():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@fixture(name="fake_3dimage", scope="session")
+@pytest.fixture(name="fake_3dimage", scope="session")
 def fake_3dimage_fixture():
     return fake_3dimage()
 
 
-#TODO: @fixture
 def fake_3dimage2():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -197,7 +190,6 @@ def fake_3dimage2():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-#TODO: @fixture
 def fake_4dimage():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -222,7 +214,7 @@ def fake_4dimage():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def fake_4dimage_sct():
     """
     :return: an Image (4D) in RAS+ (aka SCT LPI) space
@@ -235,7 +227,7 @@ def fake_4dimage_sct():
     return img
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def fake_3dimage_sct():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -248,7 +240,7 @@ def fake_3dimage_sct():
     return img
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def fake_3dimage_sct2():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -6,6 +6,8 @@ import sys
 import os
 
 import pytest
+from pytest import fixture
+#from pytest_cases import fixture
 import numpy as np
 import nibabel
 import nibabel.orientations
@@ -13,8 +15,6 @@ import nibabel.orientations
 import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.utils import tmp_create, __sct_dir__
 from spinalcordtoolbox.scripts import sct_image
-
-from pytest_cases import fixture
 
 @fixture(scope="session")
 def image_paths():
@@ -29,7 +29,7 @@ def image_paths():
     return ret
 
 
-@fixture
+#TODO: @fixture
 def fake_3dimage_custom(data):
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -38,7 +38,7 @@ def fake_3dimage_custom(data):
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@fixture
+#TODO: @fixture
 def fake_3dimage_sct_custom(data):
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -51,7 +51,7 @@ def fake_3dimage_sct_custom(data):
     return img
 
 
-@fixture
+#TODO: @fixture
 def fake_3dimage_vis():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -138,7 +138,7 @@ def fake_3dimage_sct_vis():
     return img
 
 
-@fixture
+#TODO: @fixture
 def fake_3dimage():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -174,7 +174,7 @@ def fake_3dimage_fixture():
     return fake_3dimage()
 
 
-@fixture
+#TODO: @fixture
 def fake_3dimage2():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -197,7 +197,7 @@ def fake_3dimage2():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@fixture
+#TODO: @fixture
 def fake_4dimage():
     """
     :return: a Nifti1Image (3D) in RAS+ space

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -14,8 +14,9 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.utils import tmp_create, __sct_dir__
 from spinalcordtoolbox.scripts import sct_image
 
+from pytest_cases import fixture
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def image_paths():
     ret = []
     sct_dir = os.path.dirname(os.path.dirname(__file__))
@@ -28,6 +29,7 @@ def image_paths():
     return ret
 
 
+@fixture
 def fake_3dimage_custom(data):
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -36,6 +38,7 @@ def fake_3dimage_custom(data):
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
+@fixture
 def fake_3dimage_sct_custom(data):
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -48,6 +51,7 @@ def fake_3dimage_sct_custom(data):
     return img
 
 
+@fixture
 def fake_3dimage_vis():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -121,7 +125,7 @@ def fake_3dimage_vis():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def fake_3dimage_sct_vis():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -134,6 +138,7 @@ def fake_3dimage_sct_vis():
     return img
 
 
+@fixture
 def fake_3dimage():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -164,11 +169,12 @@ def fake_3dimage():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@pytest.fixture(name="fake_3dimage", scope="session")
+@fixture(name="fake_3dimage", scope="session")
 def fake_3dimage_fixture():
     return fake_3dimage()
 
 
+@fixture
 def fake_3dimage2():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -191,6 +197,7 @@ def fake_3dimage2():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
+@fixture
 def fake_4dimage():
     """
     :return: a Nifti1Image (3D) in RAS+ space
@@ -215,7 +222,7 @@ def fake_4dimage():
     return nibabel.nifti1.Nifti1Image(data, affine)
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def fake_4dimage_sct():
     """
     :return: an Image (4D) in RAS+ (aka SCT LPI) space
@@ -228,7 +235,7 @@ def fake_4dimage_sct():
     return img
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def fake_3dimage_sct():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -241,7 +248,7 @@ def fake_3dimage_sct():
     return img
 
 
-@pytest.fixture(scope="session")
+@fixture(scope="session")
 def fake_3dimage_sct2():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space

--- a/unit_testing/test_image.py
+++ b/unit_testing/test_image.py
@@ -14,6 +14,7 @@ import spinalcordtoolbox.image as msct_image
 from spinalcordtoolbox.utils import tmp_create, __sct_dir__
 from spinalcordtoolbox.scripts import sct_image
 
+
 @pytest.fixture(scope="session")
 def image_paths():
     ret = []

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -33,6 +33,8 @@ def labels_img():
     return Image(sct_test_path('t2', 'labels.nii.gz'))
 
 
+# TODO [AJ] investigate how to parametrize fixtures from test_image.py
+# without redefining the function here
 def fake_3dimage_sct2():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -5,18 +5,15 @@
 import logging
 from time import time
 
-import pytest
-from pytest import fixture
-parametrize = pytest.mark.parametrize
-#from pytest_cases import fixture, fixture_ref, parametrize
-fixture_ref = lambda _: _  # quick test patch
 import numpy as np
+import pytest
 
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
 from spinalcordtoolbox.utils import sct_test_path
 from spinalcordtoolbox.types import Coordinate
 from .test_image import fake_3dimage, fake_3dimage2
+from .test_utils import fixture, parametrize
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +23,7 @@ def seg_img():
     return Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
 
 
-#TODO: @fixture
+@fixture
 def t2_img():
     return Image(sct_test_path('t2', 't2.nii.gz'))
 
@@ -36,8 +33,6 @@ def labels_img():
     return Image(sct_test_path('t2', 'labels.nii.gz'))
 
 
-#TODO: @fixture
-# def fake_3dimage_sct2(fake_3dimage2):
 def fake_3dimage_sct2():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -51,8 +46,6 @@ def fake_3dimage_sct2():
     return img
 
 
-#TODO: @fixture
-#def fake_3dimage_sct(fake_3dimage):
 def fake_3dimage_sct():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -65,8 +58,9 @@ def fake_3dimage_sct():
                 )
     return img
 
-test_images = [fake_3dimage_sct(), fake_3dimage_sct2(), t2_img()]
-# TODO:? test_images = [fixture_ref(fake_3dimage_sct), fixture_ref(fake_3dimage_sct2), fixture_ref(t2_img)]
+
+test_images = [fake_3dimage_sct(), fake_3dimage_sct2(), t2_img]
+
 
 @parametrize("test_image", test_images)
 def test_create_labels_empty(test_image):
@@ -137,10 +131,8 @@ def test_labelize_from_discs(seg_img, labels_img):
     # TODO [AJ] implement test
 
 
-#@parametrize("test_image", [fixture_ref(fake_3dimage_sct2)])
-@parametrize("test_image", [fake_3dimage_sct2()])
-def test_label_vertebrae(test_image):
-    a = test_image
+def test_label_vertebrae():
+    a = fake_3dimage_sct2()
     expected = zeros_like(a)
     expected.data[0, 0, 0] = 111
     b = sct_labels.label_vertebrae(a, [111])
@@ -149,10 +141,8 @@ def test_label_vertebrae(test_image):
     assert diff.all()
 
 
-#@parametrize("test_image", [fixture_ref(fake_3dimage_sct)])
-@parametrize("test_image", [fake_3dimage_sct()])
-def test_compute_mean_squared_error(test_image):
-    src = test_image
+def test_compute_mean_squared_error():
+    src = fake_3dimage_sct()
     ref = src.copy()
 
     for x, y, z, _ in src.getNonZeroCoordinates():
@@ -162,10 +152,8 @@ def test_compute_mean_squared_error(test_image):
     assert mse == 1.1547005383792515
 
 
-#@parametrize("test_image", [fixture_ref(fake_3dimage_sct)])
-@parametrize("test_image", [fake_3dimage_sct()])
-def test_compute_mse_label_warning(caplog, test_image):
-    src = test_image
+def test_compute_mse_label_warning(caplog):
+    src = fake_3dimage_sct()
     ref = src.copy()
     # Label 1500 is not in the reference image. The label present at [0,0,0] will be missing from the input image
     # This will triggers the warning that we are looking for
@@ -179,10 +167,8 @@ def test_compute_mse_label_warning(caplog, test_image):
     assert string_form_ref in caplog.text
 
 
-#@parametrize("test_image", [fixture_ref(fake_3dimage_sct)])
-@parametrize("test_image", [fake_3dimage_sct()])
-def test_compute_mse_no_label_warning(caplog, test_image):
-    src = test_image
+def test_compute_mse_no_label_warning(caplog):
+    src = fake_3dimage_sct()
     ref = src.copy()
     sct_labels.compute_mean_squared_error(src, ref)
     assert 'Label mismatch' not in caplog.text

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -7,6 +7,8 @@ from time import time
 
 import numpy as np
 import pytest
+from pytest_cases import parametrize_with_cases
+
 
 import spinalcordtoolbox.labels as sct_labels
 from spinalcordtoolbox.image import Image, zeros_like
@@ -16,22 +18,19 @@ from .test_image import fake_3dimage, fake_3dimage2
 
 logger = logging.getLogger(__name__)
 
-@pytest.fixture(scope="module")
+
 def seg_img():
-    yield Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
+    return Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
 
-@pytest.fixture(scope="module")
+
 def t2_img():
-    yield Image(sct_test_path('t2', 't2.nii.gz'))
+    return Image(sct_test_path('t2', 't2.nii.gz'))
 
-@pytest.fixture(scope="module")
+
 def labels_img():
-    yield Image(sct_test_path('t2', 'labels.nii.gz'))
+    return Image(sct_test_path('t2', 'labels.nii.gz'))
 
 
-# TODO [AJ] investigate how to parametrize fixtures from test_image.py
-# without redefining the function here
-@pytest.fixture
 def fake_3dimage_sct2():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -45,7 +44,6 @@ def fake_3dimage_sct2():
     return img
 
 
-@pytest.fixture
 def fake_3dimage_sct():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -59,18 +57,7 @@ def fake_3dimage_sct():
     return img
 
 
-
-# workaround: be able to pass fixtures to parameterize
-# https://stackoverflow.com/questions/42014484/pytest-using-fixtures-as-arguments-in-parametrize/42599627#42599627
-@pytest.fixture
-def test_image(request):
-    yield request.getfixturevalue(request.param)
-
-# these need to be strings to make the above workaround work
-# https://stackoverflow.com/questions/46909275/parametrizing-tests-depending-of-also-parametrized-values-in-pytest/46919449#46919449
-test_images = ['fake_3dimage_sct', 'fake_3dimage_sct2', 't2_img']
-
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_create_labels_empty(test_image):
     a = test_image.copy()
     expected = zeros_like(a)
@@ -85,7 +72,7 @@ def test_create_labels_empty(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_create_labels(test_image):
     a = test_image.copy()
     labels = [Coordinate(l) for l in [[0, 1, 0, 99], [0, 1, 2, 5]]]
@@ -96,7 +83,7 @@ def test_create_labels(test_image):
     assert b.data[0, 1, 2] == 5
 
 
-@pytest.mark.parametrize("test_image", ['seg_img'], indirect=True)
+@parametrize_with_cases("test_image", cases=[seg_img])
 def test_create_labels_along_segmentation(test_image):
     a = test_image.copy()
     labels = [(5, 1), (14, 2), (23, 3)]
@@ -107,13 +94,14 @@ def test_create_labels_along_segmentation(test_image):
     # TODO [AJ] implement test
 
 
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_cubic_to_point(test_image):
     a = test_image.copy()
     sct_labels.cubic_to_point(a)
     # TODO [AJ] implement test
 
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_increment_z_inverse(test_image):
     a = zeros_like(test_image.copy())
     a.data[0, 1, 0] = 1
@@ -131,6 +119,8 @@ def test_increment_z_inverse(test_image):
     assert diff.all()
 
 
+@parametrize_with_cases("seg_img", cases=[seg_img])
+@parametrize_with_cases("labels_img", cases=[labels_img])
 def test_labelize_from_discs(seg_img, labels_img):
     seg = seg_img.copy()
     ref = labels_img.copy()
@@ -139,8 +129,9 @@ def test_labelize_from_discs(seg_img, labels_img):
     # TODO [AJ] implement test
 
 
-def test_label_vertebrae(fake_3dimage_sct2):
-    a = fake_3dimage_sct2
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct2])
+def test_label_vertebrae(test_image):
+    a = test_image
     expected = zeros_like(a)
     expected.data[0, 0, 0] = 111
     b = sct_labels.label_vertebrae(a, [111])
@@ -149,8 +140,9 @@ def test_label_vertebrae(fake_3dimage_sct2):
     assert diff.all()
 
 
-def test_compute_mean_squared_error(fake_3dimage_sct):
-    src = fake_3dimage_sct
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct])
+def test_compute_mean_squared_error(test_image):
+    src = test_image
     ref = src.copy()
 
     for x, y, z, _ in src.getNonZeroCoordinates():
@@ -160,8 +152,9 @@ def test_compute_mean_squared_error(fake_3dimage_sct):
     assert mse == 1.1547005383792515
 
 
-def test_compute_mse_label_warning(caplog, fake_3dimage_sct):
-    src = fake_3dimage_sct
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct])
+def test_compute_mse_label_warning(caplog, test_image):
+    src = test_image
     ref = src.copy()
     # Label 1500 is not in the reference image. The label present at [0,0,0] will be missing from the input image
     # This will triggers the warning that we are looking for
@@ -175,15 +168,16 @@ def test_compute_mse_label_warning(caplog, fake_3dimage_sct):
     assert string_form_ref in caplog.text
 
 
-def test_compute_mse_no_label_warning(caplog, fake_3dimage_sct):
-    src = fake_3dimage_sct
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct])
+def test_compute_mse_no_label_warning(caplog, test_image):
+    src = test_image
     ref = src.copy()
     sct_labels.compute_mean_squared_error(src, ref)
     assert 'Label mismatch' not in caplog.text
 
 
 @pytest.mark.skip(reason="Too long to run on large image!")
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_remove_missing_labels(test_image):
     src = test_image.copy()
     ref = test_image.copy()
@@ -207,7 +201,7 @@ def test_remove_missing_labels(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_continuous_vertebral_levels(test_image):
     a = test_image.copy()
     b = sct_labels.continuous_vertebral_levels(a)
@@ -217,7 +211,7 @@ def test_continuous_vertebral_levels(test_image):
     # TODO [AJ] implement test
 
 
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_remove_labels_from_image(test_image):
     img = test_image.copy()
     expected = test_image.copy()
@@ -236,7 +230,7 @@ def test_remove_labels_from_image(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_image", test_images, indirect=True)
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct, fake_3dimage_sct2, t2_img])
 def test_remove_other_labels_from_image(test_image):
     img = test_image.copy()
     expected = zeros_like(test_image)
@@ -256,8 +250,9 @@ def test_remove_other_labels_from_image(test_image):
     assert diff.all()
 
 
-def test_check_missing_label(fake_3dimage_sct):
-    img = fake_3dimage_sct
+@parametrize_with_cases("test_image", cases=[fake_3dimage_sct])
+def test_check_missing_label(test_image):
+    img = test_image
     false_positive = img.copy()
 
     # modifying the data to create one false negative and one false positive

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -248,9 +248,8 @@ def test_remove_other_labels_from_image(test_image):
     assert diff.all()
 
 
-@parametrize("test_image", test_images)
-def test_check_missing_label(test_image):
-    img = test_image
+def test_check_missing_label():
+    img = fake_3dimage_sct()
     false_positive = img.copy()
 
     # modifying the data to create one false negative and one false positive

--- a/unit_testing/test_labels.py
+++ b/unit_testing/test_labels.py
@@ -16,13 +16,22 @@ from .test_image import fake_3dimage, fake_3dimage2
 
 logger = logging.getLogger(__name__)
 
-seg_img = Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
-t2_img = Image(sct_test_path('t2', 't2.nii.gz'))
-labels_img = Image(sct_test_path('t2', 'labels.nii.gz'))
+@pytest.fixture(scope="module")
+def seg_img():
+    yield Image(sct_test_path('t2', 't2_seg-manual.nii.gz'))
+
+@pytest.fixture(scope="module")
+def t2_img():
+    yield Image(sct_test_path('t2', 't2.nii.gz'))
+
+@pytest.fixture(scope="module")
+def labels_img():
+    yield Image(sct_test_path('t2', 'labels.nii.gz'))
 
 
 # TODO [AJ] investigate how to parametrize fixtures from test_image.py
 # without redefining the function here
+@pytest.fixture
 def fake_3dimage_sct2():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -36,6 +45,7 @@ def fake_3dimage_sct2():
     return img
 
 
+@pytest.fixture
 def fake_3dimage_sct():
     """
     :return: an Image (3D) in RAS+ (aka SCT LPI) space
@@ -49,10 +59,18 @@ def fake_3dimage_sct():
     return img
 
 
-test_images = [fake_3dimage_sct(), fake_3dimage_sct2(), t2_img]
 
+# workaround: be able to pass fixtures to parameterize
+# https://stackoverflow.com/questions/42014484/pytest-using-fixtures-as-arguments-in-parametrize/42599627#42599627
+@pytest.fixture
+def test_image(request):
+    yield request.getfixturevalue(request.param)
 
-@pytest.mark.parametrize("test_image", test_images)
+# these need to be strings to make the above workaround work
+# https://stackoverflow.com/questions/46909275/parametrizing-tests-depending-of-also-parametrized-values-in-pytest/46919449#46919449
+test_images = ['fake_3dimage_sct', 'fake_3dimage_sct2', 't2_img']
+
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_create_labels_empty(test_image):
     a = test_image.copy()
     expected = zeros_like(a)
@@ -67,7 +85,7 @@ def test_create_labels_empty(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_create_labels(test_image):
     a = test_image.copy()
     labels = [Coordinate(l) for l in [[0, 1, 0, 99], [0, 1, 2, 5]]]
@@ -78,9 +96,9 @@ def test_create_labels(test_image):
     assert b.data[0, 1, 2] == 5
 
 
-@pytest.mark.parametrize("test_seg", [seg_img])
-def test_create_labels_along_segmentation(test_seg):
-    a = test_seg.copy()
+@pytest.mark.parametrize("test_image", ['seg_img'], indirect=True)
+def test_create_labels_along_segmentation(test_image):
+    a = test_image.copy()
     labels = [(5, 1), (14, 2), (23, 3)]
 
     b = sct_labels.create_labels_along_segmentation(a, labels)
@@ -89,13 +107,13 @@ def test_create_labels_along_segmentation(test_seg):
     # TODO [AJ] implement test
 
 
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_cubic_to_point(test_image):
     a = test_image.copy()
     sct_labels.cubic_to_point(a)
     # TODO [AJ] implement test
 
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_increment_z_inverse(test_image):
     a = zeros_like(test_image.copy())
     a.data[0, 1, 0] = 1
@@ -113,17 +131,16 @@ def test_increment_z_inverse(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_seg,test_labels", [(seg_img, labels_img)])
-def test_labelize_from_discs(test_seg, test_labels):
-    seg = test_seg.copy()
-    ref = test_labels.copy()
+def test_labelize_from_discs(seg_img, labels_img):
+    seg = seg_img.copy()
+    ref = labels_img.copy()
 
     sct_labels.labelize_from_discs(seg, ref)
     # TODO [AJ] implement test
 
 
-def test_label_vertebrae():
-    a = fake_3dimage_sct2()
+def test_label_vertebrae(fake_3dimage_sct2):
+    a = fake_3dimage_sct2
     expected = zeros_like(a)
     expected.data[0, 0, 0] = 111
     b = sct_labels.label_vertebrae(a, [111])
@@ -132,8 +149,8 @@ def test_label_vertebrae():
     assert diff.all()
 
 
-def test_compute_mean_squared_error():
-    src = fake_3dimage_sct()
+def test_compute_mean_squared_error(fake_3dimage_sct):
+    src = fake_3dimage_sct
     ref = src.copy()
 
     for x, y, z, _ in src.getNonZeroCoordinates():
@@ -143,8 +160,8 @@ def test_compute_mean_squared_error():
     assert mse == 1.1547005383792515
 
 
-def test_compute_mse_label_warning(caplog):
-    src = fake_3dimage_sct()
+def test_compute_mse_label_warning(caplog, fake_3dimage_sct):
+    src = fake_3dimage_sct
     ref = src.copy()
     # Label 1500 is not in the reference image. The label present at [0,0,0] will be missing from the input image
     # This will triggers the warning that we are looking for
@@ -158,15 +175,15 @@ def test_compute_mse_label_warning(caplog):
     assert string_form_ref in caplog.text
 
 
-def test_compute_mse_no_label_warning(caplog):
-    src = fake_3dimage_sct()
+def test_compute_mse_no_label_warning(caplog, fake_3dimage_sct):
+    src = fake_3dimage_sct
     ref = src.copy()
     sct_labels.compute_mean_squared_error(src, ref)
     assert 'Label mismatch' not in caplog.text
 
 
 @pytest.mark.skip(reason="Too long to run on large image!")
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_remove_missing_labels(test_image):
     src = test_image.copy()
     ref = test_image.copy()
@@ -190,7 +207,7 @@ def test_remove_missing_labels(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_continuous_vertebral_levels(test_image):
     a = test_image.copy()
     b = sct_labels.continuous_vertebral_levels(a)
@@ -200,7 +217,7 @@ def test_continuous_vertebral_levels(test_image):
     # TODO [AJ] implement test
 
 
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_remove_labels_from_image(test_image):
     img = test_image.copy()
     expected = test_image.copy()
@@ -219,7 +236,7 @@ def test_remove_labels_from_image(test_image):
     assert diff.all()
 
 
-@pytest.mark.parametrize("test_image", test_images)
+@pytest.mark.parametrize("test_image", test_images, indirect=True)
 def test_remove_other_labels_from_image(test_image):
     img = test_image.copy()
     expected = zeros_like(test_image)
@@ -239,8 +256,8 @@ def test_remove_other_labels_from_image(test_image):
     assert diff.all()
 
 
-def test_check_missing_label():
-    img = fake_3dimage_sct()
+def test_check_missing_label(fake_3dimage_sct):
+    img = fake_3dimage_sct
     false_positive = img.copy()
 
     # modifying the data to create one false negative and one false positive

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -44,8 +44,8 @@ def im_seg_no_labels(im_seg_labeled):
 
 
 @parametrize("im_seg", [im_seg_labeled, im_seg_one_label, im_seg_no_labels])
-def test_sagittal_slice_get_center_spit(im_in, im_seg):
-    """Test that get_center_spit returns a valid index list."""
+def test_sagittal_slice_get_center_split(im_in, im_seg):
+    """Test that get_center_split returns a valid index list."""
 
     assert im_in.orientation == im_seg.orientation, "im_in and im_seg aren't in the same orientation"
     qcslice = Sagittal([im_in, im_seg], p_resample=None)

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 
 @pytest.fixture(scope="module")

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -3,16 +3,16 @@
 # pytest unit tests for spinalcordtoolbox.reports
 
 import pytest
-from .test_utils import fixture, parametrize
 import numpy as np
 
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
 from spinalcordtoolbox.utils.sys import sct_test_path
+from .test_utils import fixture, parametrize
 
 
 @fixture
-def im_base(path_in=sct_test_path('t2', 't2.nii.gz')):
+def im_in(path_in=sct_test_path('t2', 't2.nii.gz')):
     # Base anatomical image
     return Image(path_in)
 
@@ -44,9 +44,8 @@ def im_seg_no_labels(im_seg_labeled):
 
 
 @parametrize("im_seg", [im_seg_labeled, im_seg_one_label, im_seg_no_labels])
-def test_sagittal_slice_get_center_spit(im_base, im_seg):
+def test_sagittal_slice_get_center_spit(im_in, im_seg):
     """Test that get_center_spit returns a valid index list."""
-    im_in = im_base
 
     assert im_in.orientation == im_seg.orientation, "im_in and im_seg aren't in the same orientation"
     qcslice = Sagittal([im_in, im_seg], p_resample=None)

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -3,10 +3,7 @@
 # pytest unit tests for spinalcordtoolbox.reports
 
 import pytest
-from pytest import fixture
-parametrize = pytest.mark.parametrize
-#from pytest_cases import fixture, fixture_ref, parameterize
-fixture_ref = lambda _: _
+from .test_utils import fixture, parametrize
 import numpy as np
 
 from spinalcordtoolbox.image import Image
@@ -46,7 +43,7 @@ def im_seg_no_labels(im_seg_labeled):
     return im_seg_no_labels
 
 
-@parametrize("im_seg", [fixture_ref(im_seg_labeled), fixture_ref(im_seg_one_label), fixture_ref(im_seg_no_labels)])
+@parametrize("im_seg", [im_seg_labeled, im_seg_one_label, im_seg_no_labels])
 def test_sagittal_slice_get_center_spit(im_base, im_seg):
     """Test that get_center_spit returns a valid index list."""
     im_in = im_base

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -8,10 +8,12 @@ import numpy as np
 from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
 
+
 @pytest.fixture(scope="module")
 def im_base(path_in=sct_test_path('t2', 't2.nii.gz')):
     # Base anatomical image
     yield Image(path_in)
+
 
 @pytest.fixture(scope="module")
 def im_seg_labeled(path_seg=sct_test_path('t2', 'labels.nii.gz')):
@@ -19,6 +21,7 @@ def im_seg_labeled(path_seg=sct_test_path('t2', 'labels.nii.gz')):
     im_seg = Image(path_seg)
     assert np.count_nonzero(im_seg.data) >= 2, "Labeled segmentation image has fewer than 2 labels"
     yield im_seg
+
 
 @pytest.fixture(scope="module")
 def im_seg_one_label(im_seg_labeled):
@@ -28,6 +31,7 @@ def im_seg_one_label(im_seg_labeled):
         im_seg_one_label.data[x, y, z] = 0
     yield im_seg_one_label
 
+
 @pytest.fixture(scope="module")
 def im_seg_no_labels(im_seg_labeled):
     # Create image with no labels
@@ -36,6 +40,7 @@ def im_seg_no_labels(im_seg_labeled):
         im_seg_no_labels.data[x, y, z] = 0
     yield im_seg_no_labels
 
+
 def labeled_data_test_params():
     """Generate image/label pairs for various test cases of
     test_sagittal_slice_get_center_spit."""
@@ -43,13 +48,16 @@ def labeled_data_test_params():
             pytest.param('im_base', 'im_seg_one_label', id='one_label'),
             pytest.param('im_base', 'im_seg_no_labels', id='no_labels')]
 
+
 @pytest.fixture
 def im_in(request):
     return request.getfixturevalue(request.param)
 
+
 @pytest.fixture
 def im_seg(request):
     return request.getfixturevalue(request.param)
+
 
 @pytest.mark.parametrize('im_in,im_seg', labeled_data_test_params(), indirect=True)
 def test_sagittal_slice_get_center_spit(im_in, im_seg):

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -14,7 +14,7 @@ def im_base(path_in=sct_test_path('t2', 't2.nii.gz')):
     yield Image(path_in)
 
 @pytest.fixture(scope="module")
-def im_seg_labeled(path_seg='t2/labels.nii.gz'):
+def im_seg_labeled(path_seg=sct_test_path('t2', 'labels.nii.gz')):
     # Base labeled segmentation
     im_seg = Image(path_seg)
     assert np.count_nonzero(im_seg.data) >= 2, "Labeled segmentation image has fewer than 2 labels"

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -3,6 +3,7 @@
 # pytest unit tests for spinalcordtoolbox.reports
 
 import pytest
+from pytest_cases import parametrize_with_cases
 import numpy as np
 
 from spinalcordtoolbox.image import Image
@@ -10,59 +11,38 @@ from spinalcordtoolbox.reports.slice import Sagittal
 from spinalcordtoolbox.utils.sys import sct_test_path
 
 
-@pytest.fixture(scope="module")
 def im_base(path_in=sct_test_path('t2', 't2.nii.gz')):
     # Base anatomical image
-    yield Image(path_in)
+    return Image(path_in)
 
 
-@pytest.fixture(scope="module")
 def im_seg_labeled(path_seg=sct_test_path('t2', 'labels.nii.gz')):
     # Base labeled segmentation
     im_seg = Image(path_seg)
     assert np.count_nonzero(im_seg.data) >= 2, "Labeled segmentation image has fewer than 2 labels"
-    yield im_seg
+    return im_seg
 
 
-@pytest.fixture(scope="module")
-def im_seg_one_label(im_seg_labeled):
+def im_seg_one_label(im_seg=im_seg_labeled()):
     # Create image with all but one label removed
-    im_seg_one_label = im_seg_labeled.copy()
+    im_seg_one_label = im_seg.copy()
     for x, y, z in np.argwhere(im_seg_one_label.data)[1:]:
         im_seg_one_label.data[x, y, z] = 0
-    yield im_seg_one_label
+    return im_seg_one_label
 
 
-@pytest.fixture(scope="module")
-def im_seg_no_labels(im_seg_labeled):
+def im_seg_no_labels(im_seg=im_seg_labeled()):
     # Create image with no labels
-    im_seg_no_labels = im_seg_labeled.copy()
+    im_seg_no_labels = im_seg.copy()
     for x, y, z in np.argwhere(im_seg_no_labels.data):
         im_seg_no_labels.data[x, y, z] = 0
-    yield im_seg_no_labels
+    return im_seg_no_labels
 
 
-def labeled_data_test_params():
-    """Generate image/label pairs for various test cases of
-    test_sagittal_slice_get_center_spit."""
-    return [pytest.param('im_base', 'im_seg_labeled', id='multiple_labels'),
-            pytest.param('im_base', 'im_seg_one_label', id='one_label'),
-            pytest.param('im_base', 'im_seg_no_labels', id='no_labels')]
-
-
-@pytest.fixture
-def im_in(request):
-    return request.getfixturevalue(request.param)
-
-
-@pytest.fixture
-def im_seg(request):
-    return request.getfixturevalue(request.param)
-
-
-@pytest.mark.parametrize('im_in,im_seg', labeled_data_test_params(), indirect=True)
+@parametrize_with_cases("im_in", cases=[im_base])
+@parametrize_with_cases("im_seg", cases=[im_seg_labeled, im_seg_one_label, im_seg_no_labels])
 def test_sagittal_slice_get_center_spit(im_in, im_seg):
-    """Test that get_center_split returns a valid index list."""
+    """Test that get_center_spit returns a valid index list."""
     assert im_in.orientation == im_seg.orientation, "im_in and im_seg aren't in the same orientation"
     qcslice = Sagittal([im_in, im_seg], p_resample=None)
 

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -9,7 +9,7 @@ from spinalcordtoolbox.image import Image
 from spinalcordtoolbox.reports.slice import Sagittal
 
 @pytest.fixture(scope="module")
-def im_base(path_in='t2/t2.nii.gz'):
+def im_base(path_in=sct_test_path('t2', 't2.nii.gz')):
     # Base anatomical image
     yield Image(path_in)
 

--- a/unit_testing/test_reports.py
+++ b/unit_testing/test_reports.py
@@ -3,7 +3,10 @@
 # pytest unit tests for spinalcordtoolbox.reports
 
 import pytest
-from pytest_cases import fixture, fixture_ref, parametrize
+from pytest import fixture
+parametrize = pytest.mark.parametrize
+#from pytest_cases import fixture, fixture_ref, parameterize
+fixture_ref = lambda _: _
 import numpy as np
 
 from spinalcordtoolbox.image import Image

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -3,8 +3,25 @@
 # pytest unit tests for utils
 
 import pytest
+import pytest_cases
 
 from spinalcordtoolbox import utils
+
+
+def parametrize(argnames: str=None,
+                argvalues: Iterable[Any]=None,
+                *args, **kwargs):
+    """
+    Wrap pytest_cases.parametrize (which wraps pytest.mark.parametrize)
+    to avoid having to repeat fixture_ref() everywhere.
+
+    See https://smarie.github.io/python-pytest-cases/api_reference/#parametrize
+    """
+    return pytest_cases.parametrize(argnames,
+                                    [(pytest_cases.fixture_ref(v) if hasattr(v,'_pytestfixturefunction') else v)
+                                      for v in argvalues],
+                                    *args,
+                                    **kwargs)
 
 
 def test_parse_num_list_inv():

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -7,6 +7,7 @@ import pytest_cases
 
 from spinalcordtoolbox import utils
 
+# This is only needed until pytest_case.fixture is upstreamed: https://github.com/pytest-dev/pytest/issues/3960
 fixture = pytest_cases.fixture
 
 def parametrize(argnames=None,
@@ -18,6 +19,7 @@ def parametrize(argnames=None,
 
     See https://smarie.github.io/python-pytest-cases/api_reference/#parametrize
     """
+    # Follow up on this at https://github.com/smarie/python-pytest-cases/issues/177
     return pytest_cases.parametrize(argnames,
                                     [(pytest_cases.fixture_ref(v) if hasattr(v,'_pytestfixturefunction') else v)
                                       for v in argvalues] if argvalues else argvalues,

--- a/unit_testing/test_utils.py
+++ b/unit_testing/test_utils.py
@@ -7,9 +7,10 @@ import pytest_cases
 
 from spinalcordtoolbox import utils
 
+fixture = pytest_cases.fixture
 
-def parametrize(argnames: str=None,
-                argvalues: Iterable[Any]=None,
+def parametrize(argnames=None,
+                argvalues=None,
                 *args, **kwargs):
     """
     Wrap pytest_cases.parametrize (which wraps pytest.mark.parametrize)
@@ -19,7 +20,7 @@ def parametrize(argnames: str=None,
     """
     return pytest_cases.parametrize(argnames,
                                     [(pytest_cases.fixture_ref(v) if hasattr(v,'_pytestfixturefunction') else v)
-                                      for v in argvalues],
+                                      for v in argvalues] if argvalues else argvalues,
                                     *args,
                                     **kwargs)
 


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This replaces using `pytest_sessionstart()` with a [fixture](https://docs.pytest.org/en/stable/fixture.html). This is especially important when using xdist to run tests in parallel, because it [is probably not the right choice](https://stackoverflow.com/questions/12586489/pytest-are-pytest-sessionstart-and-pytest-sessionfinish-valid-hooks/12600154#12600154) while [a fixture is](https://stackoverflow.com/questions/17801300/how-to-run-a-method-before-all-tests-in-all-classes/17844938#17844938).

The order of operations is really complicated here. 

This unfortunately caused a small cascade of changes. At least two files were were generating their own fixtures internally (in a perfectly reasonable way!) that depended on having the test data downloaded, but it wasn't integrated with pytests's fixtures so they would run before the data was downloaded by the main fixture.

There's some ugliness here too: the pseudo-fixtures were being used in `@pytest.mark.parameterize`, but that seems incompatible with fixtures -- pytest doesn't recognize them as fixtures and the test crashes with "function object doesn't have such and such a method". The best workaround I found was https://stackoverflow.com/questions/46368468/run-a-test-with-two-different-pytest-fixtures, so I did that, but it's kind of ugly. I think there's definitely room for improvement here, and I would like some backup on looking into it, please; I just don't understand why I can't write

```
@pytest.fixture
def a():
   return "a"

@pytest.fixture
def b():
   return "b"

@pytest.mark.parameterize("letter", [a,b])
def test_stuff(letter):
    assert letter.upper() == letter.lower().upper()
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2957
