### PR TITLE
Add option to have a custom task

### DIFF
--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -59,7 +59,9 @@ def get_parser():
         "-task",
         nargs="+",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
-             " To list available tasks, run: sct_deepseg -list-tasks",
+             " To list available tasks, run: sct_deepseg -list-tasks. To use a custom task, indicate the path to the "
+             " ivadomed packaged model. More than one path can be indicated for cascaded application of the models. "
+             " See tutorials at https://ivadomed.org/ for more details. ",
         metavar=Metavar.str)
     seg.add_argument(
         "-list-tasks",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -60,7 +60,7 @@ def get_parser():
         nargs="+",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: sct_deepseg -list-tasks. To use a custom task, indicate the path to the "
-             " ivadomed packaged model (see https://ivadomed.org/en/latest/pretrained_models.html for more details). "
+             " ivadomed packaged model (see https://ivadomed.org/en/latest/pretrained_models.html#packaged-model-format for more details). "
              " More than one path can be indicated for cascaded application of the models.",
         metavar=Metavar.str)
     seg.add_argument(

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -60,8 +60,8 @@ def get_parser():
         nargs="+",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: sct_deepseg -list-tasks. To use a custom task, indicate the path to the "
-             " ivadomed packaged model. More than one path can be indicated for cascaded application of the models. "
-             " See tutorials at https://ivadomed.org/ for more details. ",
+             " ivadomed packaged model (see https://ivadomed.org/en/latest/pretrained_models.html for more details). "
+             " More than one path can be indicated for cascaded application of the models.",
         metavar=Metavar.str)
     seg.add_argument(
         "-list-tasks",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -61,7 +61,7 @@ def get_parser():
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: sct_deepseg -list-tasks. To use a custom task, indicate the path to the "
              " ivadomed packaged model (see https://ivadomed.org/en/latest/pretrained_models.html#packaged-model-format for more details). "
-             " More than one path can be indicated for cascaded application of the models.",
+             " More than one path can be indicated (separated with space) for cascaded application of the models.",
         metavar=Metavar.str)
     seg.add_argument(
         "-list-tasks",

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -152,7 +152,7 @@ def main(argv=None):
     if arguments.task is None:
         parser.error("You need to specify a task.")
 
-    # Verify if the task is custom
+    # Verify if the task is part of the "official" tasks, or if it is pointing to paths containing custom models
     if len(arguments.task) == 1 and arguments.task[0] in deepseg.models.TASKS:
         # Check if all input images are provided
         required_contrasts = deepseg.models.get_required_contrasts(arguments.task[0])

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -57,6 +57,7 @@ def get_parser():
     seg = parser.add_argument_group('\nTASKS')
     seg.add_argument(
         "-task",
+        nargs="+",
         help="Task to perform. It could either be a pre-installed task, task that could be installed, or a custom task."
              " To list available tasks, run: sct_deepseg -list-tasks",
         metavar=Metavar.str)
@@ -149,9 +150,18 @@ def main(argv=None):
     if arguments.task is None:
         parser.error("You need to specify a task.")
 
-    # Check if all input images are provided
-    required_contrasts = deepseg.models.get_required_contrasts(arguments.task)
-    if len(arguments.i) != len(required_contrasts):
+    # Verify if the task is custom
+    if len(arguments.task) == 1 and arguments.task[0] in deepseg.models.TASKS:
+        # Check if all input images are provided
+        required_contrasts = deepseg.models.get_required_contrasts(arguments.task[0])
+        n_contrasts = len(required_contrasts)
+        # Get pipeline model names
+        name_models = deepseg.models.TASKS[arguments.task[0]]['models']
+    else:
+        n_contrasts = len(arguments.i)
+        name_models = arguments.task
+
+    if len(arguments.i) != n_contrasts:
         parser.error(
             "{} input files found. Please provide all required input files for the task {}, i.e. contrasts: {}."
             .format(len(arguments.i), arguments.task, ', '.join(required_contrasts)))
@@ -161,9 +171,6 @@ def main(argv=None):
         parser.error(
             "Please specify the order in which you put the contrasts in the input images (-i) with flag -c, e.g., "
             "-c t1 t2")
-
-    # Get pipeline model names
-    name_models = deepseg.models.TASKS[arguments.task]['models']
 
     # Run pipeline by iterating through the models
     fname_prior = None


### PR DESCRIPTION
## Description
This PR adds the possibility to use a custom model with sct_deepseg. One or more paths to the folder containing a model can be indicated next to the `-task` flag to use custom model(s). If more than one path is used, the models will be applied one after the other (the output of the previous model will become the input of the next).

`sct_deepseg -i img.nii.gz -task <path(s) to folder containing the packaged model>`

## Linked issue
Fixes #3155 
