### PR TITLE
Restore previously deprecated sct_concat_transfo.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
                 'sct_analyze_texture',
                 'sct_apply_transfo',
                 'sct_check_dependencies',
+                'sct_concat_transfo',
                 'sct_compute_ernst_angle',
                 'sct_compute_hausdorff_distance',
                 'sct_compute_mscc',

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+#########################################################################################
+#
+# Concatenate transformations. This function is a wrapper for isct_ComposeMultiTransform
+#
+# ---------------------------------------------------------------------------------------
+# Copyright (c) 2014 Polytechnique Montreal <www.neuro.polymtl.ca>
+# Authors: Julien Cohen-Adad
+# Modified: 2014-07-20
+#
+# About the license: see the file LICENSE.TXT
+#########################################################################################
+
+# TODO: also enable to concatenate reversed transfo
+
+from __future__ import absolute_import, division
+
+import sys, os, functools, argparse
+
+import sct_utils as sct
+from spinalcordtoolbox.image import Image
+from spinalcordtoolbox.utils import Metavar, SmartFormatter
+
+class Param:
+    # The constructor
+    def __init__(self):
+        self.fname_warp_final = 'warp_final.nii.gz'
+
+
+def main(args=None):
+    """
+    Main function
+    :param args:
+    :return:
+    """
+    # get parser args
+    if args is None:
+        args = None if sys.argv[1:] else ['--help']
+    else:
+        # flatten the list of input arguments because -w and -winv carry a nested list
+        lst = []
+        for line in args:
+            lst.append(line) if isinstance(line, str) else lst.extend(line)
+        args = lst
+    parser = get_parser()
+    arguments = parser.parse_args(args=args)
+
+    # Initialization
+    fname_warp_final = ''  # concatenated transformations
+    fname_dest = arguments.d
+    fname_warp_list = arguments.w
+    warpinv_filename = arguments.winv
+
+    if arguments.o is not None:
+        fname_warp_final = arguments.o
+    verbose = arguments.v
+    sct.init_sct(log_level=verbose, update=True)  # Update log level
+
+    # Parse list of warping fields
+    sct.printv('\nParse list of warping fields...', verbose)
+    use_inverse = []
+    fname_warp_list_invert = []
+    # list_warp = list_warp.replace(' ', '')  # remove spaces
+    # list_warp = list_warp.split(",")  # parse with comma
+    for idx_warp, path_warp in enumerate(fname_warp_list):
+        # Check if this transformation should be inverted
+        if path_warp in warpinv_filename:
+            use_inverse.append('-i')
+            # list_warp[idx_warp] = path_warp[1:]  # remove '-'
+            fname_warp_list_invert += [[use_inverse[idx_warp], fname_warp_list[idx_warp]]]
+        else:
+            use_inverse.append('')
+            fname_warp_list_invert += [[path_warp]]
+        path_warp = fname_warp_list[idx_warp]
+        if path_warp.endswith((".nii", ".nii.gz")) \
+                and Image(fname_warp_list[idx_warp]).header.get_intent()[0] != 'vector':
+            raise ValueError("Displacement field in {} is invalid: should be encoded" \
+                             " in a 5D file with vector intent code" \
+                             " (see https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h" \
+                             .format(path_warp))
+    # need to check if last warping field is an affine transfo
+    isLastAffine = False
+    path_fname, file_fname, ext_fname = sct.extract_fname(fname_warp_list_invert[-1][-1])
+    if ext_fname in ['.txt', '.mat']:
+        isLastAffine = True
+
+    # check if destination file is 3d
+    if not sct.check_dim(fname_dest, dim_lst=[3]):
+        sct.printv('ERROR: Destination data must be 3d')
+
+    # Here we take the inverse of the warp list, because sct_WarpImageMultiTransform concatenates in the reverse order
+    fname_warp_list_invert.reverse()
+    fname_warp_list_invert = functools.reduce(lambda x, y: x + y, fname_warp_list_invert)
+
+    # Check file existence
+    sct.printv('\nCheck file existence...', verbose)
+    sct.check_file_exist(fname_dest, verbose)
+    for i in range(len(fname_warp_list)):
+        sct.check_file_exist(fname_warp_list[i], verbose)
+
+    # Get output folder and file name
+    if fname_warp_final == '':
+        path_out, file_out, ext_out = sct.extract_fname(param.fname_warp_final)
+    else:
+        path_out, file_out, ext_out = sct.extract_fname(fname_warp_final)
+
+    # Check dimension of destination data (cf. issue #1419, #1429)
+    im_dest = Image(fname_dest)
+    if im_dest.dim[2] == 1:
+        dimensionality = '2'
+    else:
+        dimensionality = '3'
+
+    cmd = ['isct_ComposeMultiTransform', dimensionality, 'warp_final' + ext_out, '-R', fname_dest] + fname_warp_list_invert
+    status, output = sct.run(cmd, verbose=verbose, is_sct_binary=True)
+
+    # check if output was generated
+    if not os.path.isfile('warp_final' + ext_out):
+        sct.printv('ERROR: Warping field was not generated.\n' + output, 1, 'error')
+
+    # Generate output files
+    sct.printv('\nGenerate output files...', verbose)
+    sct.generate_output_file('warp_final' + ext_out, os.path.join(path_out, file_out + ext_out))
+
+
+# ==========================================================================================
+def get_parser():
+    # Initialize the parser
+
+    parser = argparse.ArgumentParser(
+        description='Concatenate transformations. This function is a wrapper for isct_ComposeMultiTransform (ANTs). '
+                    'The order of input warping fields is important. For example, if you want to concatenate: '
+                    'A->B and B->C to yield A->C, then you have to input warping fields in this order: A->B B->C.',
+        formatter_class=SmartFormatter,
+        add_help=None,
+        prog=os.path.basename(__file__).strip(".py"))
+
+    mandatoryArguments = parser.add_argument_group("\nMANDATORY ARGUMENTS")
+    mandatoryArguments.add_argument(
+        "-d",
+        required=True,
+        help='Destination image. (e.g. "mt.nii.gz")',
+        metavar=Metavar.file,
+        )
+    mandatoryArguments.add_argument(
+        "-w",
+        required=True,
+        help='Transformation(s), which can be warping fields (nifti image) or affine transformation matrix (text '
+             'file). Separate with space. Example: warp1.nii.gz warp2.nii.gz',
+        nargs='+',
+        metavar=Metavar.file)
+
+    optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
+    optional.add_argument(
+        "-winv",
+        help='Affine transformation(s) listed in flag -w which should be inverted before being used. Note that this '
+             'only concerns affine transformation (not warping fields). If you would like to use an inverse warping'
+             'field, then directly input the inverse warping field in flag -w.',
+        nargs='*',
+        metavar=Metavar.file,
+        default=[])
+    optional.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        help="show this help message and exit")
+    optional.add_argument(
+        "-o",
+        help='Name of output warping field (e.g. "warp_template2mt.nii.gz")',
+        metavar=Metavar.str,
+        required = False)
+    optional.add_argument(
+        "-v",
+        type=int,
+        help="Verbose: 0 = nothing, 1 = classic, 2 = expended",
+        required=False,
+        choices=(0, 1, 2),
+        default = 1)
+
+    return parser
+
+
+#=======================================================================================================================
+# Start program
+#=======================================================================================================================
+if __name__ == "__main__":
+    sct.init_sct()
+    param = Param()
+    # call main function
+    main()

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -54,13 +54,10 @@ def main(argv=None):
     printv('\nParse list of warping fields...', verbose)
     use_inverse = []
     fname_warp_list_invert = []
-    # list_warp = list_warp.replace(' ', '')  # remove spaces
-    # list_warp = list_warp.split(",")  # parse with comma
     for idx_warp, path_warp in enumerate(fname_warp_list):
         # Check if this transformation should be inverted
         if path_warp in warpinv_filename:
             use_inverse.append('-i')
-            # list_warp[idx_warp] = path_warp[1:]  # remove '-'
             fname_warp_list_invert += [[use_inverse[idx_warp], fname_warp_list[idx_warp]]]
         else:
             use_inverse.append('')
@@ -72,11 +69,6 @@ def main(argv=None):
                              " in a 5D file with vector intent code"
                              " (see https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h"
                              .format(path_warp))
-    # need to check if last warping field is an affine transfo
-    isLastAffine = False
-    path_fname, file_fname, ext_fname = extract_fname(fname_warp_list_invert[-1][-1])
-    if ext_fname in ['.txt', '.mat']:
-        isLastAffine = True
 
     # check if destination file is 3d
     check_dim(fname_dest, dim_lst=[3])
@@ -105,11 +97,11 @@ def main(argv=None):
         dimensionality = '3'
 
     cmd = ['isct_ComposeMultiTransform', dimensionality, 'warp_final' + ext_out, '-R', fname_dest] + fname_warp_list_invert
-    status, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
+    _, output = run_proc(cmd, verbose=verbose, is_sct_binary=True)
 
     # check if output was generated
     if not os.path.isfile('warp_final' + ext_out):
-        printv('ERROR: Warping field was not generated.\n' + output, 1, 'error')
+        raise ValueError(f"Warping field was not generated! {output}")
 
     # Generate output files
     printv('\nGenerate output files...', verbose)

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -44,14 +44,11 @@ def main(argv=None):
 
     # Initialization
     fname_warp_final = ''  # concatenated transformations
+    if arguments.o is not None:
+        fname_warp_final = arguments.o
     fname_dest = arguments.d
     fname_warp_list = arguments.w
     warpinv_filename = arguments.winv
-
-    if arguments.o is not None:
-        fname_warp_final = arguments.o
-    verbose = arguments.v
-    init_sct()
 
     # Parse list of warping fields
     printv('\nParse list of warping fields...', verbose)

--- a/spinalcordtoolbox/scripts/sct_concat_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_concat_transfo.py
@@ -82,8 +82,7 @@ def main(argv=None):
         isLastAffine = True
 
     # check if destination file is 3d
-    if not check_dim(fname_dest, dim_lst=[3]):
-        printv('ERROR: Destination data must be 3d')
+    check_dim(fname_dest, dim_lst=[3])
 
     # Here we take the inverse of the warp list, because sct_WarpImageMultiTransform concatenates in the reverse order
     fname_warp_list_invert.reverse()

--- a/spinalcordtoolbox/scripts/sct_testing.py
+++ b/spinalcordtoolbox/scripts/sct_testing.py
@@ -410,6 +410,7 @@ def get_functions_parallelizable():
         'sct_compute_mtr',
         'sct_compute_mscc',
         'sct_compute_snr',
+        'sct_concat_transfo',
         'sct_create_mask',
         'sct_crop_image',
         'sct_dice_coefficient',

--- a/testing/test_sct_concat_transfo.py
+++ b/testing/test_sct_concat_transfo.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#########################################################################################
+#
+# Test function for sct_concat_transfo
+#
+# ---------------------------------------------------------------------------------------
+# Copyright (c) 2017 Polytechnique Montreal <www.neuro.polymtl.ca>
+# Author: Julien Cohen-Adad
+#
+# About the license: see the file LICENSE.TXT
+#########################################################################################
+
+def init(param_test):
+    """
+    Initialize class: param_test
+    """
+    # initialization
+    default_args = ['-w t2/warp_template2anat.nii.gz mt/warp_t22mt1.nii.gz -d template/template/PAM50_small_t2.nii.gz']
+
+    # assign default params
+    if not param_test.args:
+        param_test.args = default_args
+
+    return param_test
+
+
+def test_integrity(param_test):
+    """
+    Test integrity of function
+    """
+    param_test.output += '\nNot implemented.'
+    return param_test

--- a/unit_testing/cli/test_cli_sct_concat_transfo.py
+++ b/unit_testing/cli/test_cli_sct_concat_transfo.py
@@ -1,0 +1,14 @@
+from pytest_console_scripts import script_runner
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.script_launch_mode('subprocess')
+def test_sct_convert_backwards_compat(script_runner):
+    ret = script_runner.run('sct_testing', '--function', 'sct_concat_transfo')
+    logger.debug(f"{ret.stdout}")
+    logger.debug(f"{ret.stderr}")
+    assert ret.success
+    assert ret.stderr == ''


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [x] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
`sct_concat_transfo.py` was recently obsoleted, but after user feedback it was decided to un-deprecate and restore the script. https://github.com/neuropoly/spinalcordtoolbox/issues/2912#issuecomment-761897967

## Linked issues
#2912 
