### PR TITLE
Fix line breaks in documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,17 +2,11 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to creating a positive environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -22,55 +16,32 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at jcohen@polymtl.ca. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at jcohen@polymtl.ca. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,4 @@
 Contributing to SCT
 ===================
 
-Please refer to SCT's `Github developer
-wiki <https://github.com/neuropoly/spinalcordtoolbox/wiki/Contributing>`__ for contributing guidelines.
+Please refer to SCT's `Github developer wiki <https://github.com/neuropoly/spinalcordtoolbox/wiki/Contributing>`__ for contributing guidelines.

--- a/documentation/source/dev_section/api.rst
+++ b/documentation/source/dev_section/api.rst
@@ -5,8 +5,7 @@ Python API
 
 .. admonition:: Note
 
-   The Python API is not stable yet, so be prepared to update your
-   code with SCT updates.
+   The Python API is not stable yet, so be prepared to update your code with SCT updates.
 
 
 .. contents::

--- a/documentation/source/overview/concepts/pam50.rst
+++ b/documentation/source/overview/concepts/pam50.rst
@@ -10,15 +10,9 @@ PAM50 Template
 Introduction
 ============
 
-Template-based analysis of multi-parametric MRI data of the spinal cord sets
-the foundation for standardization and reproducibility. Particularly, it
-allows researchers to process their data with minimum bias, perform
-multi-center studies, with the goal of improving patient diagnosis and
-prognosis and helping the discovery of new biomarkers of spinal-related
-diseases.
+Template-based analysis of multi-parametric MRI data of the spinal cord sets the foundation for standardization and reproducibility. Particularly, it allows researchers to process their data with minimum bias, perform multi-center studies, with the goal of improving patient diagnosis and prognosis and helping the discovery of new biomarkers of spinal-related diseases.
 
-PAM50 is one such template for MRI of the full spinal cord and brainstem, and
-is included in your installation of SCT. It has the following features:
+PAM50 is one such template for MRI of the full spinal cord and brainstem, and is included in your installation of SCT. It has the following features:
 
 * It is available for T1-, T2-and T2*-weighted MRI contrast.
 * It is compatible with the ICBM152 brain template (a.k.a. MNI template), allowing to conduct simultaneous brain/spine studies within the same coordinate system.
@@ -43,10 +37,7 @@ White and grey matter atlas (``PAM50/atlas``)
     :figwidth: 40%
     :align: right
 
-The White Matter atlas will be a useful tool for your studies of specific spinal cord tracts. It consists of 36 nifti
-volumes named ``PAM50_atlas_<tract_number>.nii.gz`` where ``<tract_number>`` is the number identifying the tract.
-Fifteen WM tracts and three GM regions are available for each side. The values of each voxel of the files ``PAM50_atlas_<tract_number>.nii.gz``
-are the voxel volume proportions occupied by the corresponding tract.
+The White Matter atlas will be a useful tool for your studies of specific spinal cord tracts. It consists of 36 nifti volumes named ``PAM50_atlas_<tract_number>.nii.gz`` where ``<tract_number>`` is the number identifying the tract. Fifteen WM tracts and three GM regions are available for each side. The values of each voxel of the files ``PAM50_atlas_<tract_number>.nii.gz`` are the voxel volume proportions occupied by the corresponding tract.
 
 The atlas folder also contains an ``info_label.txt`` file to explain what each file represents:
 
@@ -61,8 +52,7 @@ Spinal levels (``PAM50/spinal_levels``)
     :figwidth: 40%
     :align: right
 
-In the folder ``data/PAM50/spinal_levels``, you will find 20 label images corresponding to different spinal cord levels, including both C1:C8 and T1:T12. In each nifti file, the value of each voxel is the probability for this voxel to belong to the
-spinal level.
+In the folder ``data/PAM50/spinal_levels``, you will find 20 label images corresponding to different spinal cord levels, including both C1:C8 and T1:T12. In each nifti file, the value of each voxel is the probability for this voxel to belong to the spinal level.
 
 The spinal_levels folder also contains an ``info_label.txt`` file to explain what each file represents:
 

--- a/documentation/source/overview/concepts/quality-control.rst
+++ b/documentation/source/overview/concepts/quality-control.rst
@@ -3,11 +3,6 @@
 Quality Control
 ***************
 
-Some SCT tools can generate Quality Control (QC) reports.
-These reports consist in "appendable" HTML files, containing a table
-of entries and allowing to show, for each entry, animated images
-(background with overlay on and off).
+Some SCT tools can generate Quality Control (QC) reports. These reports consist in "appendable" HTML files, containing a table of entries and allowing to show, for each entry, animated images (background with overlay on and off).
 
-To generate a QC report, add the `-qc` command-line argument,
-with the location (folder, to be created by the SCT tool),
-where the QC files should be generated.
+To generate a QC report, add the `-qc` command-line argument, with the location (folder, to be created by the SCT tool), where the QC files should be generated.

--- a/documentation/source/overview/concepts/spaces-and-coordinates.rst
+++ b/documentation/source/overview/concepts/spaces-and-coordinates.rst
@@ -4,21 +4,15 @@ Voxels Space Orientation and Coordinate Conventions
 Images
 ======
 
-It is important to note that SCT Images, which are derived from NIFTI
-images, have their contents indexed in "Fortran order", meaning that in
-an image of shape :math:`(N_a, N_b, N_c)`, where we consider the `a`
-axis to be the first, two consecutive (in the sense of storage location)
-elements are in the `a` dimension, the first.
-This is by opposition to the C ordering which is more widely used in
-most software, and where the fastest varying element is indexed last.
+It is important to note that SCT Images, which are derived from NIFTI images, have their contents indexed in "Fortran order", meaning that in an image of shape :math:`(N_a, N_b, N_c)`, where we consider the `a` axis to be the first, two consecutive (in the sense of storage location) elements are in the `a` dimension, the first.
+This is by opposition to the C ordering which is more widely used in most software, and where the fastest varying element is indexed last.
 
 .. _reference_spaces:
 
 Reference Spaces
 ================
 
-As in many other tools, SCT follows a standard nomenclature for reference
-spaces in which the world or local coordinates are expressed.
+As in many other tools, SCT follows a standard nomenclature for reference spaces in which the world or local coordinates are expressed.
 
 The string is formed from character label among (relative to a human subject):
 
@@ -28,16 +22,12 @@ The string is formed from character label among (relative to a human subject):
 
 The character position corresponds to the axis index.
 
-SCT uses the "from" convention, which for clarity we postfix by a
-dash.
+SCT uses the "from" convention, which for clarity we postfix by a dash.
 
-The reference space for physical coordinates is LPI- (which is coming
-from nibabel and NIFTI).
+The reference space for physical coordinates is LPI- (which is coming from nibabel and NIFTI).
 
 
-An "image orientation" corresponds to the orientation of the
-surface/volume with regard to the reference orientation.
-It is encoded in the (NIFTI) file header.
+An "image orientation" corresponds to the orientation of the surface/volume with regard to the reference orientation. It is encoded in the (NIFTI) file header.
 
 
 For example, a `RAS` image orientation corresponds to a 3D image with:
@@ -62,35 +52,24 @@ Coordinate Conventions
 Local/Voxel Coordinates
 +++++++++++++++++++++++
 
-When voxel coordinates are integers, coordinates are indices.
-Indices are expressed starting from 0 and up to N-1 where N is the
-number of voxels in the considered dimension.
+When voxel coordinates are integers, coordinates are indices. Indices are expressed starting from 0 and up to N-1 where N is the number of voxels in the considered dimension.
 
-When voxel coordinates are real numbers, we are using an *integer
-voxel center convention* (consistent with nibabel and NIFTI).
+When voxel coordinates are real numbers, we are using an *integer voxel center convention* (consistent with nibabel and NIFTI).
 
-This means that a coordinate such as :code:`(i,j,k) == np.round((i,j,k))`
-expresses the center of a voxel.
+This means that a coordinate such as :code:`(i,j,k) == np.round((i,j,k))` expresses the center of a voxel.
 
-NB: Voxel coordinates are called :math:`(i,j,k)` in the NIFTI
-documentation.
+NB: Voxel coordinates are called :math:`(i,j,k)` in the NIFTI documentation.
 
 
 
 Global/Physical Coordinates
 +++++++++++++++++++++++++++
 
-Physical coordinates are always expressed as real numbers.
-They are defined from the relation expressed by the transform and unit
-system expressed in a image header.
+Physical coordinates are always expressed as real numbers. They are defined from the relation expressed by the transform and unit system expressed in a image header.
 
-Physical coordinates are expressed relative to the LPI- frame,
-considering the voxel dimensions, affine transform between voxel
-coordinates and world coordinates, and the physical dimension unit,
-all of which is encoded in the NIFTI file header.
+Physical coordinates are expressed relative to the LPI- frame, considering the voxel dimensions, affine transform between voxel coordinates and world coordinates, and the physical dimension unit, all of which is encoded in the NIFTI file header.
 
-NB: Voxel coordinates are called :math:`(x,y,z)` in the NIFTI
-documentation.
+NB: Voxel coordinates are called :math:`(x,y,z)` in the NIFTI documentation.
 
 
 References

--- a/documentation/source/overview/concepts/temp-directories.rst
+++ b/documentation/source/overview/concepts/temp-directories.rst
@@ -3,10 +3,7 @@
 Temporary Directories
 *********************
 
-Many SCT commands will create temporary folders to operate,
-and there is an option to avoid removing temporary directories, to be
-used for troubleshooting purposes.
+Many SCT commands will create temporary folders to operate, and there is an option to avoid removing temporary directories, to be used for troubleshooting purposes.
 
-If you don't know where your temporary directory is located, you can
-look at:
+If you don't know where your temporary directory is located, you can look at:
 https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir

--- a/documentation/source/overview/introduction.rst
+++ b/documentation/source/overview/introduction.rst
@@ -4,36 +4,15 @@ Introduction
 Context
 -------
 
-For the past 25 years, the field of neuroimaging has witnessed the
-development of several software packages for processing multi-parametric
-magnetic resonance imaging (mpMRI) to study the brain. These software packages
-are now routinely used by researchers and clinicians, and have contributed to
-important breakthroughs for the understanding of brain anatomy and function.
+For the past 25 years, the field of neuroimaging has witnessed the development of several software packages for processing multi-parametric magnetic resonance imaging (mpMRI) to study the brain. These software packages are now routinely used by researchers and clinicians, and have contributed to important breakthroughs for the understanding of brain anatomy and function.
 
-However, for a long time, no software package had existed to process mpMRI data of the spinal cord.
-Despite the numerous clinical needs for such advanced mpMRI protocols (multiple
-sclerosis, spinal cord injury, cervical spondylotic myelopathy, etc.),
-researchers have been developing specific tools that, while necessary, do not
-provide an integrative framework that is compatible with most usages and that is
-capable of reaching the community at large. This has hindered cross-validation and
-the possibility to perform multi-center studies.
+However, for a long time, no software package had existed to process mpMRI data of the spinal cord. Despite the numerous clinical needs for such advanced mpMRI protocols (multiple sclerosis, spinal cord injury, cervical spondylotic myelopathy, etc.), researchers have been developing specific tools that, while necessary, do not provide an integrative framework that is compatible with most usages and that is capable of reaching the community at large. This has hindered cross-validation and the possibility to perform multi-center studies.
 
 Purpose
 -------
 
-**Spinal Cord Toolbox (SCT)** brings together the spinal cord neuroimaging community by establishing standard
-templates and analysis procedures.
+**Spinal Cord Toolbox (SCT)** brings together the spinal cord neuroimaging community by establishing standard templates and analysis procedures.
 
-SCT is a comprehensive, free and open-source software dedicated to the
-processing and analysis of spinal cord MRI data. SCT builds on
-previously-validated methods and includes state-of-the-art MRI templates and
-atlases of the spinal cord, algorithms to segment and register new data to the
-templates, and motion correction methods for diffusion and functional time
-series. SCT is tailored towards standardization and automation of the
-processing pipeline, versatility, modularity, and it follows guidelines of
-software development and distribution.
+SCT is a comprehensive, free and open-source software dedicated to the processing and analysis of spinal cord MRI data. SCT builds on previously-validated methods and includes state-of-the-art MRI templates and atlases of the spinal cord, algorithms to segment and register new data to the templates, and motion correction methods for diffusion and functional time series. SCT is tailored towards standardization and automation of the processing pipeline, versatility, modularity, and it follows guidelines of software development and distribution.
 
-Preliminary applications of SCT cover
-a variety of studies, from cross-sectional area measures in large databases of
-patients, to the precise quantification of mpMRI metrics in specific spinal
-pathways. Also see the reference page [TODO].
+Preliminary applications of SCT cover a variety of studies, from cross-sectional area measures in large databases of patients, to the precise quantification of mpMRI metrics in specific spinal pathways. Also see the reference page [TODO].

--- a/documentation/source/overview/overview.rst
+++ b/documentation/source/overview/overview.rst
@@ -4,8 +4,7 @@ Overview
 .. image:: ../../imgs/overview.png
   :alt: Alternative text
 
-SCT tools process MRI data (`NIfTI <https://nifti.nimh.nih.gov/>`_
-files) and can do fully automatic tasks such as:
+SCT tools process MRI data (`NIfTI <https://nifti.nimh.nih.gov/>`_ files) and can do fully automatic tasks such as:
 
 - Segmentation of the spinal cord and gray matter
 - Segmentation of pathologies (eg. multiple sclerosis lesions)

--- a/documentation/source/overview/references.rst
+++ b/documentation/source/overview/references.rst
@@ -102,283 +102,93 @@ The table below provides references relevant to the :ref:`pam50` used by SCT, in
    * - PAM50 template
      - `De Leener B, Fonov VS, Louis Collins D, Callot V, Stikov N, Cohen-Adad J. PAM50: Unbiased multimodal template of the brainstem and spinal cord aligned with the ICBM152 space. Neuroimage 2017. <http://www.sciencedirect.com/science/article/pii/S1053811917308686>`__
    * - MNI-Poly-AMU template
-     - `Fonov et al. Framework for integrated MRI average of the spinal cord white and gray matter: The MNI-Poly-AMU template. Neuroimage 2014. <https://www.ncbi.nlm.nih.gov/pubmed/25204864>`__
+     - `Fonov et al. Framework for integrated MRI average of the spinal cord white and gray matter: The MNI-Poly-AMU template. Neuroimage 2014. <https://www.ncbi.nlm.nih.gov/pubmed/25204864>`__
    * - White matter atlas
-     - `Lévy et al. White matter atlas of the human spinal cord with estimation of partial volume effect. Neuroimage 2015 <https://www.ncbi.nlm.nih.gov/pubmed/26099457>`__
+     - `Lévy et al. White matter atlas of the human spinal cord with estimation of partial volume effect. Neuroimage 2015 <https://www.ncbi.nlm.nih.gov/pubmed/26099457>`__
    * - Probabilistic atlas (AMU40)
-     - `Taso et al. A reliable spatially normalized template of the human spinal cord–Applications to automated white matter/gray matter segmentation and tensor-based morphometry (TBM) mapping of gray matter alterations occurring with age. Neuroimage 2015 <https://www.ncbi.nlm.nih.gov/pubmed/26003856>`__
+     - `Taso et al. A reliable spatially normalized template of the human spinal cord–Applications to automated white matter/gray matter segmentation and tensor-based morphometry (TBM) mapping of gray matter alterations occurring with age. Neuroimage 2015 <https://www.ncbi.nlm.nih.gov/pubmed/26003856>`__
    * - Spinal levels
      - `Cadotte DW, Cadotte A, Cohen-Adad J, Fleet D, Livne M, Wilson JR, Mikulis D, Nugaeva N, Fehlings MG. Characterizing the location of spinal and vertebral levels in the human cervical spinal cord. AJNR Am J Neuroradiol, 2015, 36(4):803-810. <https://paperpile.com/app/p/5b580317-6921-06c8-a2ee-685d4dbaa44c>`_
 
 Applications
 ------------
 
--  `Kong et al. Intrinsically organized resting state networks in the
-   human spinal cord. PNAS
-   2014 <http://www.pnas.org/content/111/50/18067.abstract>`__
--  `Duval et al. In vivo mapping of human spinal cord microstructure at
-   300mT/m. Neuroimage
-   2015 <https://www.ncbi.nlm.nih.gov/pubmed/26095093>`__
--  `Yiannakas et al. Fully automated segmentation of the cervical cord
-   from T1-weighted MRI using PropSeg: Application to multiple
-   sclerosis. NeuroImage: Clinical
-   2015 <https://www.ncbi.nlm.nih.gov/pubmed/26793433>`__
--  `Taso et al. Anteroposterior compression of the spinal cord leading
-   to cervical myelopathy: a finite element analysis. Comput Methods
-   Biomech Biomed Engin
-   2015 <http://www.tandfonline.com/doi/full/10.1080/10255842.2015.1069625>`__
--  `Eippert F. et al. Investigating resting-state functional
-   connectivity in the cervical spinal cord at 3T. Neuroimage
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/28027960>`__
--  `Weber K.A. et al. Functional Magnetic Resonance Imaging of the
-   Cervical Spinal Cord During Thermal Stimulation Across Consecutive
-   Runs. Neuroimage
-   2016 <http://www.ncbi.nlm.nih.gov/pubmed/27616641>`__
--  `Weber et al. Lateralization of cervical spinal cord activity during
-   an isometric upper extremity motor task with functional magnetic
-   resonance imaging. Neuroimage
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/26488256>`__
--  `Eippert et al. Denoising spinal cord fMRI data: Approaches to
-   acquisition and analysis. Neuroimage
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/27693613>`__
--  `Samson et al., ZOOM or non-ZOOM? Assessing Spinal Cord Diffusion
-   Tensor Imaging protocols for multi-centre studies. PLOS One
-   2016 <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0155557>`__
--  `Taso et al. Tract-specific and age-related variations of the spinal
-   cord microstructure: a multi-parametric MRI study using diffusion
-   tensor imaging (DTI) and inhomogeneous magnetization transfer (ihMT).
-   NMR Biomed 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27100385>`__
--  `Massire A. et al. High-resolution multi-parametric quantitative
-   magnetic resonance imaging of the human cervical spinal cord at 7T.
-   Neuroimage 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27574985>`__
--  `Duval et al. g-Ratio weighted imaging of the human spinal cord in
-   vivo. Neuroimage
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/27664830>`__
--  `Ljungberg et al. Rapid Myelin Water Imaging in Human Cervical Spinal
-   Cord. Magn Reson Med
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/28940333>`__
--  `Castellano et al., Quantitative MRI of the spinal cord and brain in
-   adrenomyeloneuropathy: in vivo assessment of structural changes.
-   Brain 2016 <http://brain.oxfordjournals.org/content/139/6/1735>`__
--  `Grabher et al., Voxel-based analysis of grey and white matter
-   degeneration in cervical spondylotic myelopathy. Sci Rep
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/27095134>`__
--  `Talbott JF, Narvid J, Chazen JL, Chin CT, Shah V. An Imaging Based
-   Approach to Spinal Cord Infection. Semin Ultrasound CT MR
-   2016 <http://www.journals.elsevier.com/seminars-in-ultrasound-ct-and-mri/recent-articles>`__
--  `McCoy et al. MRI Atlas-Based Measurement of Spinal Cord Injury
-   Predicts Outcome in Acute Flaccid Myelitis. AJNR
-   2016 <http://www.ajnr.org/content/early/2016/12/15/ajnr.A5044.abstract>`__
--  `De Leener et al. Segmentation of the human spinal cord. MAGMA.
-   2016 <https://www.ncbi.nlm.nih.gov/pubmed/26724926>`__
--  `Cohen-Adad et al. Functional Magnetic Resonance Imaging of the
-   Spinal Cord: Current Status and Future Developments. Semin Ultrasound
-   CT MR
-   2016 <http://www.sciencedirect.com/science/article/pii/S088721711630049X>`__
--  `Ventura et al. Cervical spinal cord atrophy in NMOSD without a
-   history of myelitis or MRI-visible lesions. Neurol Neuroimmunol
-   Neuroinflamm 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27144215>`__
--  `Combes et al. Cervical cord myelin water imaging shows degenerative
-   changes over one year in multiple sclerosis but not neuromyelitis
-   optica spectrum disorder. Neuroimage: Clinical.
-   2016 <http://www.sciencedirect.com/science/article/pii/S221315821730150X>`__
--  `Battiston et al. Fast and reproducible in vivo T1 mapping of the
-   human cervical spinal cord. Magn Reson Med
-   2017 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.26852/full>`__
--  `Panara et al. Spinal cord microstructure integrating phase-sensitive
-   inversion recovery and diffusional kurtosis imaging. Neuroradiology
-   2017 <https://link.springer.com/article/10.1007%2Fs00234-017-1864-5>`__
--  `Martin et al. Clinically Feasible Microstructural MRI to Quantify
-   Cervical Spinal Cord Tissue Injury Using DTI, MT, and T2*-Weighted
-   Imaging: Assessment of Normative Data and Reliability. AJNR
-   2017 <https://www.ncbi.nlm.nih.gov/pubmed/28428213>`__
--  `Martin et al. A Novel MRI Biomarker of Spinal Cord White Matter
-   Injury: T2*-Weighted White Matter to Gray Matter Signal Intensity
-   Ratio. AJNR 2017 <https://www.ncbi.nlm.nih.gov/pubmed/28428212>`__
--  `David et al. The efficiency of retrospective artifact correction
-   methods in improving the statistical power of between-group
-   differences in spinal cord DTI. Neuroimage
-   2017 <http://www.sciencedirect.com/science/article/pii/S1053811917305220>`__
--  `Battiston et al. An optimized framework for quantitative
-   Magnetization Transfer imaging of the cervical spinal cord in vivo.
-   Magnetic Resonance in Medicine
-   2017 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.26909/full>`__
--  `Rasoanandrianina et al. Region-specific impairment of the cervical
-   spinal cord (SC) in amyotrophic lateral sclerosis: A preliminary
-   study using SC templates and quantitative MRI (diffusion tensor
-   imaging/inhomogeneous magnetization transfer). NMR Biomed
-   2017 <http://onlinelibrary.wiley.com/doi/10.1002/nbm.3801/full>`__
--  `Weber et al. Thermal Stimulation Alters Cervical Spinal Cord
-   Functional Connectivity in Humans. Neurocience
-   2017 <http://www.sciencedirect.com/science/article/pii/S0306452217307637>`__
--  `Grabher et al. Neurodegeneration in the Spinal Ventral Horn Prior to
-   Motor Impairment in Cervical Spondylotic Myelopathy. Journal of
-   Neurotrauma
-   2017 <http://online.liebertpub.com/doi/abs/10.1089/neu.2017.4980>`__
--  `Duval et al. Scan–rescan of axcaliber, macromolecular tissue volume,
-   and g-ratio in the spinal cord. Magn Reson Med
-   2017 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.26945/full>`__
--  `Smith et al. Lateral corticospinal tract damage correlates with
-   motor output in incomplete spinal cord injury. Archives of Physical
-   Medicine and Rehabilitation
-   2017 <http://www.sciencedirect.com/science/article/pii/S0003999317312844>`__
--  `Prados et al. Spinal cord grey matter segmentation challenge.
-   Neuroimage
-   2017 <https://www.sciencedirect.com/science/article/pii/S1053811917302185#f0005>`__
--  `Peterson et al. Test-Retest and Interreader Reproducibility of
-   Semiautomated Atlas-Based Analysis of Diffusion Tensor Imaging Data
-   in Acute Cervical Spine Trauma in Adult Patients. AJNR Am J
-   Neuroradiol. 2017
-   Oct;38(10):2015-2020 <https://www.ncbi.nlm.nih.gov/pubmed/28818826>`__
--  `Kafali et al. Phase-correcting non-local means filtering for
-   diffusion-weighted imaging of the spinal cord. Magn Reson Med
-   2018 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.27105/full>`__
--  `Albrecht et al. Neuroinflammation of the spinal cord and nerve roots
-   in chronic radicular pain patients. Pain. 2018 May;159(5):968-977.
-   doi:
-   10.1097/j.pain.0000000000001171 <https://www.ncbi.nlm.nih.gov/pubmed/29419657>`__
--  `Hori et al. Application of Quantitative Microstructural MR Imaging
-   with Atlas-based Analysis for the Spinal Cord in Cervical Spondylotic
-   Myelopathy. Sci Rep
-   2018 <https://www.nature.com/articles/s41598-018-23527-8>`__
--  `Huber et al. Dorsal and ventral horn atrophy is associated with
-   clinical outcome after spinal cord injury. Neurology
-   2018 <https://www.ncbi.nlm.nih.gov/pubmed/29592888>`__
--  `Dostal et al. Analysis of diffusion tensor measurements of the human
-   cervical spinal cord based on semiautomatic segmentation of the white
-   and gray matter. J Magn Reson Imaging
-   2018 <https://www.ncbi.nlm.nih.gov/pubmed/29707834>`__
--  `Calabrese et al. Postmortem diffusion MRI of the entire human spinal
-   cord at microscopic resolution. Neuroimage Clin,
-   2018 <https://www.ncbi.nlm.nih.gov/pubmed/29876281>`__
--  `Paquin et al. Spinal Cord Gray Matter Atrophy in Amyotrophic Lateral
-   Sclerosis. AJNR 2018 <http://www.ajnr.org/content/39/1/184>`__
--  `Combès et al. Focal and diffuse cervical spinal cord damage in
-   patients with early relapsing-remitting MS: A multicentre
-   magnetisation transfer ratio study. Multiple Sclerosis Journal,
-   2018 <https://www.ncbi.nlm.nih.gov/m/pubmed/29909771/>`__
--  `Martin et al. Monitoring for myelopathic progression with
-   multiparametric quantitative MRI. PLoS One. 2018 Apr
-   17;13(4):e0195733 <https://www.ncbi.nlm.nih.gov/pubmed/29664964>`__
--  `Martin et al. Can microstructural MRI detect subclinical tissue
-   injury in subjects with asymptomatic cervical spinal cord
-   compression? A prospective cohort study. BMJ Open,
-   2018 <https://www.ncbi.nlm.nih.gov/pubmed/29654015>`__
--  `Querin et al. The spinal and cerebral profile of adult
-   spinal-muscular atrophy: A multimodal imaging study. NeuroImage Clin,
-   2018 <https://www.sciencedirect.com/science/article/pii/S2213158218303668>`__
--  `Shokur et al. Training with brain-machine interfaces, visuo-tactile
-   feedback and assisted locomotion improves sensorimotor, visceral, and
-   psychological signs in chronic paraplegic patients. Plos One,
-   2018 <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0206464>`__
--  `Panara et al. Correlations between cervical spinal cord magnetic
-   resonance diffusion tensor and diffusion kurtosis imaging metrics and
-   motor performance in patients with chronic ischemic brain lesions of
-   the corticospinal tract. Neuroradiology,
-   2018 <https://link.springer.com/article/10.1007/s00234-018-2139-5>`__
--  `Moccia et al. Advances in spinal cord imaging in multiple sclerosis.
-   Ther Adv Neurol Disord,
-   2019 <https://journals.sagepub.com/doi/pdf/10.1177/1756286419840593>`__
--  `Kitany et al. Functional imaging of rostrocaudal spinal activity
-   during upper limb motor tasks. Neuroimage,
-   2019 <https://www.sciencedirect.com/science/article/pii/S1053811919304288>`__
--  `Lorenzi et al. Unsuspected Involvement of Spinal Cord in Alzheimer
-   Disease. Front Cell Neurosci,
-   2020 <https://www.frontiersin.org/articles/10.3389/fncel.2020.00006/full>`__
--  `Papinutto et al. Evaluation of Intra- and Interscanner Reliability
-   of MRI Protocols for Spinal Cord Gray Matter and Total
-   Cross-Sectional Area Measurements. J Magn Reson Imaging,
-   2019 <https://onlinelibrary.wiley.com/doi/epdf/10.1002/jmri.26269>`__
--  `Weeda et al. Validation of mean upper cervical cord area (MUCCA)
-   measurement techniques in multiple sclerosis (MS): High
-   reproducibility and robustness to lesions, but large software and
-   scanner effects. NeuroImage Clin,
-   2019 <https://www.sciencedirect.com/science/article/pii/S2213158219303122>`__
--  `Moccia et al. Longitudinal spinal cord atrophy in multiple sclerosis
-   using the generalised boundary shift integral. Ann Neurol,
-   2019 <https://onlinelibrary.wiley.com/doi/abs/10.1002/ana.25571>`__
--  `Rasoanandrianina et al. Regional T1 mapping of the whole cervical
-   spinal cord using an optimized MP2RAGE sequence. NMR Biomed,
-   2019 <https://onlinelibrary.wiley.com/doi/full/10.1002/nbm.4142>`__
--  `Hopkins et al. Machine Learning for the Prediction of Cervical
-   Spondylotic Myelopathy: A Post Hoc Pilot Study of 28 Participants.
-   World Neurosurg,
-   2019 <https://www.sciencedirect.com/science/article/pii/S1878875019308459>`__
--  `Karbasforoushan et al. Brainstem and spinal cord MRI identifies
-   altered sensorimotor pathways post-stroke. Nat Commun,
-   2019 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6684621/>`__
--  `Seif et al. Guidelines for the conduct of clinical trials in spinal
-   cord injury: Neuroimaging biomarkers. Spinal Cord,
-   2019 <https://www.ncbi.nlm.nih.gov/pubmed/31267015>`__
--  `Lorenzi et al. Unsuspected Involvement of Spinal Cord in Alzheimer
-   Disease. Front Cell Neurosci,
-   2019 <https://www.frontiersin.org/articles/10.3389/fncel.2020.00006/full>`__
--  `Sabaghian et al. Fully Automatic 3D Segmentation of the
-   Thoracolumbar Spinal Cord and the Vertebral Canal From T2-weighted
-   MRI Using K-means Clustering Algorithm. Spinal Cord,
-   2020 <https://pubmed.ncbi.nlm.nih.gov/32132652/>`__
--  `Bonacci et al. Clinical Relevance of Multiparametric MRI Assessment
-   of Cervical Cord Damage in Multiple Sclerosis. Radiology,
-   2020 <https://pubmed.ncbi.nlm.nih.gov/32573387/>`__
--  `Hori. Sodium in the Relapsing - Remitting Multiple Sclerosis Spinal 
-   Cord: Increased Concentrations and Associations With Microstructural 
-   Tissue Anisotropy. JMRI, 2020 
-   <https://onlinelibrary.wiley.com/doi/abs/10.1002/jmri.27253>`__
--  `Lersy et al. Identification and measurement of cervical spinal cord 
-   atrophy in neuromyelitis optica spectrum disorders (NMOSD) and correlation 
-   with clinical characteristics and cervical spinal cord MRI data. 
-   Revue Neurologique, 2020 
-   <https://www.sciencedirect.com/science/article/pii/S0035378720306159>`__
--  `Dahlberg et al. Heritability of cervical spinal cord structure. 
-   Neurol Genet, 2020 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7061306/>`__
--  `Shinn et al. Magnetization transfer and diffusion tensor imaging in dogs
-   with intervertebral disk herniation. Journal of Veterinary 
-   Internal Medicine, 2020 <https://pubmed.ncbi.nlm.nih.gov/33006411/>`__
--  `Azzarito et al. Simultaneous voxel‐wise analysis of brain and 
-   spinal cord morphometry and microstructure within the SPM framework. 
-   Human Brain Mapping, 2020 <https://pubmed.ncbi.nlm.nih.gov/32991031/>`__
--  `Paliwal et al. Magnetization Transfer Ratio and Morphometrics Of the 
-   Spinal Cord Associates withSurgical Recovery in Patients with 
-   Degenerative Cervical Myelopathy. World Neurosurgery, 2020 
-   <https://pubmed.ncbi.nlm.nih.gov/33010502/>`__
--  `Tinnermann et al. Cortico-spinal imaging to study pain. NeuroImage.2020
-   <https://www.sciencedirect.com/science/article/pii/S1053811920309241?via%3Dihub>`__
--  `Rejc et al. Spinal Cord Imaging Markers and Recovery of Volitional
-   Leg Movement With Spinal Cord Epidural Stimulation in Individuals
-   With Clinically Motor Complete Spinal Cord Injury. Front. Syst. Neurosci.,
-   2020 <https://www.frontiersin.org/articles/10.3389/fnsys.2020.559313/full>`__
--  `Labounek et al. HARDI-ZOOMit protocol improves specificity to
-   microstructural changes in presymptomatic myelopathy. Scientific
-   Reports, 2020  <https://www.nature.com/articles/s41598-020-70297-3>`__
--  `Henmar et al. What are the gray and white matter volumes of the
-   human spinal cord? J Neurophysiol, 2020
-   <https://pubmed.ncbi.nlm.nih.gov/33085549/>`__
--  `Burke et al. Injury Volume Extracted from MRI Predicts Neurologic
-   Outcome in Acute Spinal Cord Injury: A Prospective TRACK-SCI Pilot
-   Study. J Clin Neurosci, 2020
-   <https://www.sciencedirect.com/science/article/abs/pii/S0967586820316192>`__
--  `Mossa-Basha et al. Segmented quantitative diffusion tensor imaging
-   evaluation of acute traumatic cervical spinal cord injury.
-   Br J Radiol, 2020 <https://pubmed.ncbi.nlm.nih.gov/33180553/>`__
--  `Mariano et al. Quantitative spinal cord MRI in MOG-antibody disease,
-   neuromyelitis optica and multiple sclerosis. Brain, 2020
-   <https://pubmed.ncbi.nlm.nih.gov/33206944/>`__
--  `Fratini et al. Multiscale Imaging Approach for Studying the Central
-   Nervous System: Methodology and Perspective. Front Neurosci, 2020
-   <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7019007/>`__
--  `Hoggarth et al. Macromolecular changes in spinal cord white matter characterize 
-   whiplash outcome at 1-year post motor vehicle collision. Scientific Reports, 2020 
-   <https://www.nature.com/articles/s41598-020-79190-5>`__
--  `Stroman et al. A comparison of the effectiveness of functional MRI analysis methods 
-   for pain research: The new normal. PLoS One, 2020 
-   <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0243723>`__
--  `Johnson et al. In vivo detection of microstructural spinal cord lesions in dogs 
-   with degenerative myelopathy using diffusion tensor imaging. J Vet Intern Med. 2020
-   <https://onlinelibrary.wiley.com/doi/10.1111/jvim.16014>`_
--  `Kinawy et al. Dynamic Functional Connectivity of Resting-State Spinal Cord fMRI 
-   Reveals Fine-Grained Intrinsic Architecture. Neuron. 2020
-   <https://pubmed.ncbi.nlm.nih.gov/32910894/>`_
--  `Weber et al. Assessing the spatial distribution of cervical spinal cord activity 
-   during tactile stimulation of the upper extremity in humans with functional 
-   magnetic resonance imaging. Neuroimage 2020
-   <https://www.sciencedirect.com/science/article/pii/S1053811920303918>`_
+-  `Kong et al. Intrinsically organized resting state networks in the human spinal cord. PNAS 2014 <http://www.pnas.org/content/111/50/18067.abstract>`__
+-  `Duval et al. In vivo mapping of human spinal cord microstructure at 300mT/m. Neuroimage 2015 <https://www.ncbi.nlm.nih.gov/pubmed/26095093>`__
+-  `Yiannakas et al. Fully automated segmentation of the cervical cord from T1-weighted MRI using PropSeg: Application to multiple sclerosis. NeuroImage: Clinical 2015 <https://www.ncbi.nlm.nih.gov/pubmed/26793433>`__
+-  `Taso et al. Anteroposterior compression of the spinal cord leading to cervical myelopathy: a finite element analysis. Comput Methods Biomech Biomed Engin 2015 <http://www.tandfonline.com/doi/full/10.1080/10255842.2015.1069625>`__
+-  `Eippert F. et al. Investigating resting-state functional connectivity in the cervical spinal cord at 3T. Neuroimage 2016 <https://www.ncbi.nlm.nih.gov/pubmed/28027960>`__
+-  `Weber K.A. et al. Functional Magnetic Resonance Imaging of the Cervical Spinal Cord During Thermal Stimulation Across Consecutive Runs. Neuroimage 2016 <http://www.ncbi.nlm.nih.gov/pubmed/27616641>`__
+-  `Weber et al. Lateralization of cervical spinal cord activity during an isometric upper extremity motor task with functional magnetic resonance imaging. Neuroimage 2016 <https://www.ncbi.nlm.nih.gov/pubmed/26488256>`__
+-  `Eippert et al. Denoising spinal cord fMRI data: Approaches to acquisition and analysis. Neuroimage 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27693613>`__
+-  `Samson et al. ZOOM or non-ZOOM? Assessing Spinal Cord Diffusion Tensor Imaging protocols for multi-centre studies. PLOS One 2016 <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0155557>`__
+-  `Taso et al. Tract-specific and age-related variations of the spinal cord microstructure: a multi-parametric MRI study using diffusion tensor imaging (DTI) and inhomogeneous magnetization transfer (ihMT). NMR Biomed 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27100385>`__
+-  `Massire A. et al. High-resolution multi-parametric quantitative magnetic resonance imaging of the human cervical spinal cord at 7T. Neuroimage 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27574985>`__
+-  `Duval et al. g-Ratio weighted imaging of the human spinal cord in vivo. Neuroimage 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27664830>`__
+-  `Ljungberg et al. Rapid Myelin Water Imaging in Human Cervical Spinal Cord. Magn Reson Med 2016 <https://www.ncbi.nlm.nih.gov/pubmed/28940333>`__
+-  `Castellano et al. Quantitative MRI of the spinal cord and brain in adrenomyeloneuropathy: in vivo assessment of structural changes. Brain 2016 <http://brain.oxfordjournals.org/content/139/6/1735>`__
+-  `Grabher et al. Voxel-based analysis of grey and white matter degeneration in cervical spondylotic myelopathy. Sci Rep 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27095134>`__
+-  `Talbott JF, Narvid J, Chazen JL, Chin CT, Shah V. An Imaging Based Approach to Spinal Cord Infection. Semin Ultrasound CT MR 2016 <http://www.journals.elsevier.com/seminars-in-ultrasound-ct-and-mri/recent-articles>`__
+-  `McCoy et al. MRI Atlas-Based Measurement of Spinal Cord Injury Predicts Outcome in Acute Flaccid Myelitis. AJNR 2016 <http://www.ajnr.org/content/early/2016/12/15/ajnr.A5044.abstract>`__
+-  `De Leener et al. Segmentation of the human spinal cord. MAGMA. 2016 <https://www.ncbi.nlm.nih.gov/pubmed/26724926>`__
+-  `Cohen-Adad et al. Functional Magnetic Resonance Imaging of the Spinal Cord: Current Status and Future Developments. Semin Ultrasound CT MR 2016 <http://www.sciencedirect.com/science/article/pii/S088721711630049X>`__
+-  `Ventura et al. Cervical spinal cord atrophy in NMOSD without a history of myelitis or MRI-visible lesions. Neurol Neuroimmunol Neuroinflamm 2016 <https://www.ncbi.nlm.nih.gov/pubmed/27144215>`__
+-  `Combes et al. Cervical cord myelin water imaging shows degenerative changes over one year in multiple sclerosis but not neuromyelitis optica spectrum disorder. Neuroimage: Clinical. 2016 <http://www.sciencedirect.com/science/article/pii/S221315821730150X>`__
+-  `Battiston et al. Fast and reproducible in vivo T1 mapping of the human cervical spinal cord. Magn Reson Med 2017 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.26852/full>`__
+-  `Panara et al. Spinal cord microstructure integrating phase-sensitive inversion recovery and diffusional kurtosis imaging. Neuroradiology 2017 <https://link.springer.com/article/10.1007%2Fs00234-017-1864-5>`__
+-  `Martin et al. Clinically Feasible Microstructural MRI to Quantify Cervical Spinal Cord Tissue Injury Using DTI, MT, and T2*-Weighted Imaging: Assessment of Normative Data and Reliability. AJNR 2017 <https://www.ncbi.nlm.nih.gov/pubmed/28428213>`__
+-  `Martin et al. A Novel MRI Biomarker of Spinal Cord White Matter Injury: T2*-Weighted White Matter to Gray Matter Signal Intensity Ratio. AJNR 2017 <https://www.ncbi.nlm.nih.gov/pubmed/28428212>`__
+-  `David et al. The efficiency of retrospective artifact correction methods in improving the statistical power of between-group differences in spinal cord DTI. Neuroimage 2017 <http://www.sciencedirect.com/science/article/pii/S1053811917305220>`__
+-  `Battiston et al. An optimized framework for quantitative Magnetization Transfer imaging of the cervical spinal cord in vivo. Magnetic Resonance in Medicine 2017 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.26909/full>`__
+-  `Rasoanandrianina et al. Region-specific impairment of the cervical spinal cord (SC) in amyotrophic lateral sclerosis: A preliminary study using SC templates and quantitative MRI (diffusion tensor imaging/inhomogeneous magnetization transfer). NMR Biomed 2017 <http://onlinelibrary.wiley.com/doi/10.1002/nbm.3801/full>`__
+-  `Weber et al. Thermal Stimulation Alters Cervical Spinal Cord Functional Connectivity in Humans. Neurocience 2017 <http://www.sciencedirect.com/science/article/pii/S0306452217307637>`__
+-  `Grabher et al. Neurodegeneration in the Spinal Ventral Horn Prior to Motor Impairment in Cervical Spondylotic Myelopathy. Journal of Neurotrauma 2017 <http://online.liebertpub.com/doi/abs/10.1089/neu.2017.4980>`__
+-  `Duval et al. Scan–rescan of axcaliber, macromolecular tissue volume, and g-ratio in the spinal cord. Magn Reson Med 2017 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.26945/full>`__
+-  `Smith et al. Lateral corticospinal tract damage correlates with motor output in incomplete spinal cord injury. Archives of Physical Medicine and Rehabilitation 2017 <http://www.sciencedirect.com/science/article/pii/S0003999317312844>`__
+-  `Prados et al. Spinal cord grey matter segmentation challenge. Neuroimage 2017 <https://www.sciencedirect.com/science/article/pii/S1053811917302185#f0005>`__
+-  `Peterson et al. Test-Retest and Interreader Reproducibility of Semiautomated Atlas-Based Analysis of Diffusion Tensor Imaging Data in Acute Cervical Spine Trauma in Adult Patients. AJNR Am J Neuroradiol. 2017 Oct;38(10):2015-2020 <https://www.ncbi.nlm.nih.gov/pubmed/28818826>`__
+-  `Kafali et al. Phase-correcting non-local means filtering for diffusion-weighted imaging of the spinal cord. Magn Reson Med 2018 <http://onlinelibrary.wiley.com/doi/10.1002/mrm.27105/full>`__
+-  `Albrecht et al. Neuroinflammation of the spinal cord and nerve roots in chronic radicular pain patients. Pain. 2018 May;159(5):968-977. doi: 10.1097/j.pain.0000000000001171 <https://www.ncbi.nlm.nih.gov/pubmed/29419657>`__
+-  `Hori et al. Application of Quantitative Microstructural MR Imaging with Atlas-based Analysis for the Spinal Cord in Cervical Spondylotic Myelopathy. Sci Rep 2018 <https://www.nature.com/articles/s41598-018-23527-8>`__
+-  `Huber et al. Dorsal and ventral horn atrophy is associated with clinical outcome after spinal cord injury. Neurology 2018 <https://www.ncbi.nlm.nih.gov/pubmed/29592888>`__
+-  `Dostal et al. Analysis of diffusion tensor measurements of the human cervical spinal cord based on semiautomatic segmentation of the white and gray matter. J Magn Reson Imaging 2018 <https://www.ncbi.nlm.nih.gov/pubmed/29707834>`__
+-  `Calabrese et al. Postmortem diffusion MRI of the entire human spinal cord at microscopic resolution. Neuroimage Clin, 2018 <https://www.ncbi.nlm.nih.gov/pubmed/29876281>`__
+-  `Paquin et al. Spinal Cord Gray Matter Atrophy in Amyotrophic Lateral Sclerosis. AJNR 2018 <http://www.ajnr.org/content/39/1/184>`__
+-  `Combès et al. Focal and diffuse cervical spinal cord damage in patients with early relapsing-remitting MS: A multicentre magnetisation transfer ratio study. Multiple Sclerosis Journal, 2018 <https://www.ncbi.nlm.nih.gov/m/pubmed/29909771/>`__
+-  `Martin et al. Monitoring for myelopathic progression with multiparametric quantitative MRI. PLoS One. 2018 Apr 17;13(4):e0195733 <https://www.ncbi.nlm.nih.gov/pubmed/29664964>`__
+-  `Martin et al. Can microstructural MRI detect subclinical tissue injury in subjects with asymptomatic cervical spinal cord compression? A prospective cohort study. BMJ Open, 2018 <https://www.ncbi.nlm.nih.gov/pubmed/29654015>`__
+-  `Querin et al. The spinal and cerebral profile of adult spinal-muscular atrophy: A multimodal imaging study. NeuroImage Clin, 2018 <https://www.sciencedirect.com/science/article/pii/S2213158218303668>`__
+-  `Shokur et al. Training with brain-machine interfaces, visuo-tactile feedback and assisted locomotion improves sensorimotor, visceral, and psychological signs in chronic paraplegic patients. Plos One, 2018 <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0206464>`__
+-  `Panara et al. Correlations between cervical spinal cord magnetic resonance diffusion tensor and diffusion kurtosis imaging metrics and motor performance in patients with chronic ischemic brain lesions of the corticospinal tract. Neuroradiology, 2018 <https://link.springer.com/article/10.1007/s00234-018-2139-5>`__
+-  `Moccia et al. Advances in spinal cord imaging in multiple sclerosis. Ther Adv Neurol Disord, 2019 <https://journals.sagepub.com/doi/pdf/10.1177/1756286419840593>`__
+-  `Kitany et al. Functional imaging of rostrocaudal spinal activity during upper limb motor tasks. Neuroimage, 2019 <https://www.sciencedirect.com/science/article/pii/S1053811919304288>`__
+-  `Lorenzi et al. Unsuspected Involvement of Spinal Cord in Alzheimer Disease. Front Cell Neurosci, 2020 <https://www.frontiersin.org/articles/10.3389/fncel.2020.00006/full>`__
+-  `Papinutto et al. Evaluation of Intra- and Interscanner Reliability of MRI Protocols for Spinal Cord Gray Matter and Total Cross-Sectional Area Measurements. J Magn Reson Imaging, 2019 <https://onlinelibrary.wiley.com/doi/epdf/10.1002/jmri.26269>`__
+-  `Weeda et al. Validation of mean upper cervical cord area (MUCCA) measurement techniques in multiple sclerosis (MS): High reproducibility and robustness to lesions, but large software and scanner effects. NeuroImage Clin, 2019 <https://www.sciencedirect.com/science/article/pii/S2213158219303122>`__
+-  `Moccia et al. Longitudinal spinal cord atrophy in multiple sclerosis using the generalised boundary shift integral. Ann Neurol, 2019 <https://onlinelibrary.wiley.com/doi/abs/10.1002/ana.25571>`__
+-  `Rasoanandrianina et al. Regional T1 mapping of the whole cervical spinal cord using an optimized MP2RAGE sequence. NMR Biomed, 2019 <https://onlinelibrary.wiley.com/doi/full/10.1002/nbm.4142>`__
+-  `Hopkins et al. Machine Learning for the Prediction of Cervical Spondylotic Myelopathy: A Post Hoc Pilot Study of 28 Participants. World Neurosurg, 2019 <https://www.sciencedirect.com/science/article/pii/S1878875019308459>`__
+-  `Karbasforoushan et al. Brainstem and spinal cord MRI identifies altered sensorimotor pathways post-stroke. Nat Commun, 2019 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6684621/>`__
+-  `Seif et al. Guidelines for the conduct of clinical trials in spinal cord injury: Neuroimaging biomarkers. Spinal Cord, 2019 <https://www.ncbi.nlm.nih.gov/pubmed/31267015>`__
+-  `Lorenzi et al. Unsuspected Involvement of Spinal Cord in Alzheimer Disease. Front Cell Neurosci, 2019 <https://www.frontiersin.org/articles/10.3389/fncel.2020.00006/full>`__
+-  `Sabaghian et al. Fully Automatic 3D Segmentation of the Thoracolumbar Spinal Cord and the Vertebral Canal From T2-weighted MRI Using K-means Clustering Algorithm. Spinal Cord, 2020 <https://pubmed.ncbi.nlm.nih.gov/32132652/>`__
+-  `Bonacci et al. Clinical Relevance of Multiparametric MRI Assessment of Cervical Cord Damage in Multiple Sclerosis. Radiology, 2020 <https://pubmed.ncbi.nlm.nih.gov/32573387/>`__
+-  `Hori. Sodium in the Relapsing - Remitting Multiple Sclerosis Spinal Cord: Increased Concentrations and Associations With Microstructural Tissue Anisotropy. JMRI, 2020 <https://onlinelibrary.wiley.com/doi/abs/10.1002/jmri.27253>`__
+-  `Lersy et al. Identification and measurement of cervical spinal cord atrophy in neuromyelitis optica spectrum disorders (NMOSD) and correlation with clinical characteristics and cervical spinal cord MRI data. Revue Neurologique, 2020 <https://www.sciencedirect.com/science/article/pii/S0035378720306159>`__
+-  `Dahlberg et al. Heritability of cervical spinal cord structure. Neurol Genet, 2020 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7061306/>`__
+-  `Shinn et al. Magnetization transfer and diffusion tensor imaging in dogs with intervertebral disk herniation. Journal of Veterinary Internal Medicine, 2020 <https://pubmed.ncbi.nlm.nih.gov/33006411/>`__
+-  `Azzarito et al. Simultaneous voxel‐wise analysis of brain and spinal cord morphometry and microstructure within the SPM framework. Human Brain Mapping, 2020 <https://pubmed.ncbi.nlm.nih.gov/32991031/>`__
+-  `Paliwal et al. Magnetization Transfer Ratio and Morphometrics Of the Spinal Cord Associates withSurgical Recovery in Patients with Degenerative Cervical Myelopathy. World Neurosurgery, 2020 <https://pubmed.ncbi.nlm.nih.gov/33010502/>`__
+-  `Tinnermann et al. Cortico-spinal imaging to study pain. NeuroImage.2020 <https://www.sciencedirect.com/science/article/pii/S1053811920309241?via%3Dihub>`__
+-  `Rejc et al. Spinal Cord Imaging Markers and Recovery of Volitional Leg Movement With Spinal Cord Epidural Stimulation in Individuals With Clinically Motor Complete Spinal Cord Injury. Front. Syst. Neurosci., 2020 <https://www.frontiersin.org/articles/10.3389/fnsys.2020.559313/full>`__
+-  `Labounek et al. HARDI-ZOOMit protocol improves specificity to microstructural changes in presymptomatic myelopathy. Scientific Reports, 2020 <https://www.nature.com/articles/s41598-020-70297-3>`__
+-  `Henmar et al. What are the gray and white matter volumes of the human spinal cord? J Neurophysiol, 2020 <https://pubmed.ncbi.nlm.nih.gov/33085549/>`__
+-  `Burke et al. Injury Volume Extracted from MRI Predicts Neurologic Outcome in Acute Spinal Cord Injury: A Prospective TRACK-SCI Pilot Study. J Clin Neurosci, 2020 <https://www.sciencedirect.com/science/article/abs/pii/S0967586820316192>`__
+-  `Mossa-Basha et al. Segmented quantitative diffusion tensor imaging evaluation of acute traumatic cervical spinal cord injury. Br J Radiol, 2020 <https://pubmed.ncbi.nlm.nih.gov/33180553/>`__
+-  `Mariano et al. Quantitative spinal cord MRI in MOG-antibody disease, neuromyelitis optica and multiple sclerosis. Brain, 2020 <https://pubmed.ncbi.nlm.nih.gov/33206944/>`__
+-  `Fratini et al. Multiscale Imaging Approach for Studying the Central Nervous System: Methodology and Perspective. Front Neurosci, 2020 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7019007/>`__
+-  `Hoggarth et al. Macromolecular changes in spinal cord white matter characterize whiplash outcome at 1-year post motor vehicle collision. Scientific Reports, 2020 <https://www.nature.com/articles/s41598-020-79190-5>`__
+-  `Stroman et al. A comparison of the effectiveness of functional MRI analysis methods for pain research: The new normal. PLoS One, 2020 <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0243723>`__
+-  `Johnson et al. In vivo detection of microstructural spinal cord lesions in dogs with degenerative myelopathy using diffusion tensor imaging. J Vet Intern Med. 2020 <https://onlinelibrary.wiley.com/doi/10.1111/jvim.16014>`_
+-  `Kinawy et al. Dynamic Functional Connectivity of Resting-State Spinal Cord fMRI Reveals Fine-Grained Intrinsic Architecture. Neuron. 2020 <https://pubmed.ncbi.nlm.nih.gov/32910894/>`_
+-  `Weber et al. Assessing the spatial distribution of cervical spinal cord activity during tactile stimulation of the upper extremity in humans with functional magnetic resonance imaging. Neuroimage 2020 <https://www.sciencedirect.com/science/article/pii/S1053811920303918>`_

--- a/documentation/source/user_section/command-line.rst
+++ b/documentation/source/user_section/command-line.rst
@@ -13,17 +13,14 @@ Command-Line Tools
 Summary of Tools
 ****************
 
-The command-line tools are named ``sct_*``; to see all the commands
-available from SCT, start a new Terminal and type ``sct`` then press
-"tab".
+The command-line tools are named ``sct_*``; to see all the commands available from SCT, start a new Terminal and type ``sct`` then press "tab".
 
 
 Segmentation
 ============
 
 - sct_create_mask_ - Create mask along z direction.
-- sct_deepseg_ - Segment an anatomical structure or pathologies according using a deep learning model created with
-  `ivadomed <http://ivadomed.org/>`_.
+- sct_deepseg_ - Segment an anatomical structure or pathologies according using a deep learning model created with `ivadomed <http://ivadomed.org/>`_.
 - sct_deepseg_gm_ - Segment spinal cord gray matter using deep learning.
 - sct_deepseg_lesion_ - Segment multiple sclerosis lesions.
 - sct_deepseg_sc_ - Segment spinal cord using deep learning.
@@ -52,8 +49,7 @@ Registration
 - sct_apply_transfo_ - Apply transformations.
 - sct_get_centerline_ - Reconstruct spinal cord centerline.
 - sct_register_multimodal_ - Register two images together (non-linear, constrained in axial plane)
-- sct_register_to_template_ - Register an image with an anatomical template (eg. the `PAM50 template
-  <https://pubmed.ncbi.nlm.nih.gov/29061527/>`_).
+- sct_register_to_template_ - Register an image with an anatomical template (eg. the `PAM50 template <https://pubmed.ncbi.nlm.nih.gov/29061527/>`_).
 - sct_straighten_spinalcord_ - Straighten spinal cord from centerline
 - sct_warp_template_ - Warps the template and all atlases to a destination image.
 
@@ -73,8 +69,7 @@ Magnetization transfer
 ======================
 
 - sct_compute_mtr_ - Compute magnetization transfer ratio (MTR).
-- sct_compute_mtsat_ - Compute MTsat and T1map `[Helms et al. Magn Reson Med 2008]
-  <https://pubmed.ncbi.nlm.nih.gov/19025906/>`_.
+- sct_compute_mtsat_ - Compute MTsat and T1map `[Helms et al. Magn Reson Med 2008] <https://pubmed.ncbi.nlm.nih.gov/19025906/>`_.
 
 Functional MRI
 ==============
@@ -85,8 +80,7 @@ Functional MRI
 Metric processing
 =================
 
-- sct_analyze_texture_ - Extraction of grey level co-occurence matrix (GLCM) texture features from an image within a
-  given mask.
+- sct_analyze_texture_ - Extraction of grey level co-occurence matrix (GLCM) texture features from an image within a given mask.
 - sct_extract_metric_ - Estimate metric value within tracts, taking into account partial volume effect.
 
 Image manipulation

--- a/documentation/source/user_section/getting-started.rst
+++ b/documentation/source/user_section/getting-started.rst
@@ -3,8 +3,7 @@
 Getting Started
 ###############
 
-To get started using SCT, you may take a look at the `Batch Processing
-Example`_, or follow the longer `Courses`_ materials.
+To get started using SCT, you may take a look at the `Batch Processing Example`_, or follow the longer `Courses`_ materials.
 
 .. contents::
    :local:
@@ -14,11 +13,8 @@ Example`_, or follow the longer `Courses`_ materials.
 Batch Processing Example
 ************************
 
-The best way to learn how to use SCT is to look at the example `batch_processing
-<https://github.com/neuropoly/spinalcordtoolbox/blob/master/batch_processing.sh>`_ script. This script performs a
-typical analysis of multi-parametric MRI data, including cross-sectional area measurements, magnetization transfer,
-diffusion tensor imaging metrics computation and extraction within specific tracts, and functional MRI pre-processing.
-This script will download an example dataset containing T1w, T2w, T2\*w, MT, DTI and fMRI data.
+The best way to learn how to use SCT is to look at the example `batch_processing <https://github.com/neuropoly/spinalcordtoolbox/blob/master/batch_processing.sh>`_ script.
+This script performs a typical analysis of multi-parametric MRI data, including cross-sectional area measurements, magnetization transfer, diffusion tensor imaging metrics computation and extraction within specific tracts, and functional MRI pre-processing. This script will download an example dataset containing T1w, T2w, T2\*w, MT, DTI and fMRI data.
 
 To launch the script run:
 
@@ -26,17 +22,14 @@ To launch the script run:
 
   $SCT_DIR/batch_processing.sh
 
-While the script is running, we encourage you to understand the meaning of each command line that is listed in the
-script. Comments are here to help justify some choices of parameters. If you have any question, please do not
-hesitate to ask for :ref:`support`.
+While the script is running, we encourage you to understand the meaning of each command line that is listed in the script. Comments are here to help justify some choices of parameters. If you have any question, please do not hesitate to ask for :ref:`support`.
 
 The script source is shown below:
 
 .. literalinclude:: ../../../batch_processing.sh
    :language: sh
 
-If you would like to get more examples about what SCT can do, please visit the `sct-pipeline repository
-<https://github.com/sct-pipeline/>`_. Each repository is a pipeline dedicated to a specific research project.
+If you would like to get more examples about what SCT can do, please visit the `sct-pipeline repository <https://github.com/sct-pipeline/>`_. Each repository is a pipeline dedicated to a specific research project.
 
 
 .. _sct_courses:
@@ -44,14 +37,10 @@ If you would like to get more examples about what SCT can do, please visit the `
 Courses
 *******
 
-We organize **free** SCT courses, each year after the ISMRM conference.
-If you’d like to be added to the mailing list, please send an email to
-spinalcordtoolbox@gmail.com. The past courses handouts are listed
-below:
+We organize **free** SCT courses, each year after the ISMRM conference. If you’d like to be added to the mailing list, please send an email to spinalcordtoolbox@gmail.com. The past courses handouts are listed below:
 
 -  `SCT course (v4.2.1), London, 2020-01-21`_ \| `Video recording`_
--  `SCT course (v4.0.0), Beijing, 2019-08-02`_ \| `Slides with Chinese
-   translation`_
+-  `SCT course (v4.0.0), Beijing, 2019-08-02`_ \| `Slides with Chinese translation`_
 -  `SCT course (v4.0.0_beta.4), London, 2019-01-22`_
 -  `SCT course (v3.2.2), Paris, 2018-06-12`_
 -  `SCT course (v3.0.3), Honolulu, 2017-04-28`_
@@ -86,5 +75,4 @@ Please visit our `Youtube channel`_ which contains some tutorials.
 Citing SCT
 **********
 
-If you use SCT in your research or as part of your developments, please always cite SCT as explained in the
-:ref:`references` section.
+If you use SCT in your research or as part of your developments, please always cite SCT as explained in the :ref:`references` section.

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -3,9 +3,7 @@
 Installation
 ############
 
-SCT works in macOS, Linux and Windows (see Requirements below). SCT bundles its own Python distribution (Miniconda),
-installed with all the required packages, and uses specific package versions, in order to ensure reproducibility of
-results. SCT offers various installation methods:
+SCT works in macOS, Linux and Windows (see Requirements below). SCT bundles its own Python distribution (Miniconda), installed with all the required packages, and uses specific package versions, in order to ensure reproducibility of results. SCT offers various installation methods:
 
 .. contents::
    :local:
@@ -24,21 +22,16 @@ Requirements
   * RedHat/CentOS >= 7
   * Windows, see `Install on Windows 10 with WSL`_.
 
-* You need to have ``gcc`` installed. On macOS, we recommend installing `Homebrew <https://brew.sh/>`_ and then run
-  ``brew install gcc``. On Linux, we recommend installing it via your package manager. For example on Debian/Ubuntu:
-  ``apt install gcc``, and on CentOS/RedHat: ``yum -y install gcc``.
+* You need to have ``gcc`` installed. On macOS, we recommend installing `Homebrew <https://brew.sh/>`_ and then run ``brew install gcc``. On Linux, we recommend installing it via your package manager. For example on Debian/Ubuntu: ``apt install gcc``, and on CentOS/RedHat: ``yum -y install gcc``.
 
 
 
 Install from package (recommended)
 ----------------------------------
 
-The simplest way to install SCT is to do it via a stable release. First, download the
-`latest release <https://github.com/neuropoly/spinalcordtoolbox/releases>`_. Major changes to
-each release are listed in the :doc:`/dev_section/CHANGES`.
+The simplest way to install SCT is to do it via a stable release. First, download the `latest release <https://github.com/neuropoly/spinalcordtoolbox/releases>`_. Major changes to each release are listed in the :doc:`/dev_section/CHANGES`.
 
-Once you have downloaded SCT, unpack it (note: Safari will automatically unzip it). Then, open a new Terminal,
-go into the created folder and launch the installer:
+Once you have downloaded SCT, unpack it (note: Safari will automatically unzip it). Then, open a new Terminal, go into the created folder and launch the installer:
 
 .. code:: sh
 
@@ -51,8 +44,7 @@ go into the created folder and launch the installer:
 Install from Github (development)
 ---------------------------------
 
-If you wish to benefit from the cutting-edge version of SCT, or if you wish to contribute to the code, we
-recommend you download the Github version.
+If you wish to benefit from the cutting-edge version of SCT, or if you wish to contribute to the code, we recommend you download the Github version.
 
 #. Retrieve the SCT code
 
@@ -275,8 +267,7 @@ For macOS and Linux users
 Create an X11 server for handling display:
 
 1. Install XQuartz X11 server.
-2. Check ‘Allow connections from network clientsoption inXQuartz\`
-   settings.
+2. Check ‘Allow connections from network clientsoption inXQuartz\` settings.
 3. Quit and restart XQuartz.
 4. In XQuartz window xhost + 127.0.0.1
 5. In your other Terminal window, run:
@@ -344,16 +335,11 @@ Install with pip (experimental)
 
 SCT can be installed using pip, with some caveats:
 
-- The installation is done in-place, so the folder containing SCT must
-  be kept around
+- The installation is done in-place, so the folder containing SCT must be kept around
 
-- In order to ensure coexistence with other packages, the dependency
-  specifications are loosened, and it is possible that your package
-  combination has not been tested with SCT.
+- In order to ensure coexistence with other packages, the dependency specifications are loosened, and it is possible that your package combination has not been tested with SCT.
 
-  So in case of problem, try again with the reference installation,
-  and report a bug indicating the dependency versions retrieved using
-  `sct_check_dependencies`.
+  So in case of problems, try again with the reference installation, and report a bug indicating the dependency versions retrieved using `sct_check_dependencies`.
 
 
 Procedure:
@@ -374,8 +360,7 @@ Procedure:
 
       git checkout ${revision_of_interest}
 
-#. If numpy is not already on the system, install it, either using
-   your distribution package manager or pip.
+#. If numpy is not already on the system, install it, either using your distribution package manager or pip.
 
 #. Install sct using pip
 
@@ -452,15 +437,14 @@ Procedure:
 Matlab Integration on Mac
 -------------------------
 
-Matlab took the liberty of setting ``DYLD_LIBRARY_PATH`` and in order
-for SCT to run, you have to run:
+Matlab took the liberty of setting ``DYLD_LIBRARY_PATH`` and in order for SCT to run, you have to run:
 
 .. code:: matlab
 
    setenv('DYLD_LIBRARY_PATH', '');
 
-Prior to running SCT commands. See
- https://github.com/neuropoly/spinalcordtoolbox/issues/405
+Prior to running SCT commands.
+See https://github.com/neuropoly/spinalcordtoolbox/issues/405
 
 
 

--- a/documentation/source/user_section/support.rst
+++ b/documentation/source/user_section/support.rst
@@ -4,9 +4,6 @@ Support
 #######
 
 
-If you have any SCT-related question, please post it in `the SCT forum <http://forum.spinalcordmri.org/c/sct>`_.
-You may search for previously asked questions there.
+If you have any SCT-related question, please post it in `the SCT forum <http://forum.spinalcordmri.org/c/sct>`_. You may search for previously asked questions there.
 
-If you think you found a previously unknown issue with the software,
-you can report it `on the GitHub's issue page <https://github.com/neuropoly/spinalcordtoolbox/issues/>`_,
-but you may also communicate on the forum.
+If you think you found a previously unknown issue with the software, you can report it `on the GitHub's issue page <https://github.com/neuropoly/spinalcordtoolbox/issues/>`_, but you may also communicate on the forum.

--- a/documentation/source/user_section/tutorials.rst
+++ b/documentation/source/user_section/tutorials.rst
@@ -12,5 +12,4 @@ SCT provides a set of step-by-step tutorials demonstrating advanced usage of the
   tutorials/spinalcord_segmentation
   tutorials/correcting_sct_propseg
 
-This section is a work in progress. In the meanwhile, please refer to the :ref:`sct_courses` section for
-tutorials in a presentation format.
+This section is a work in progress. In the meanwhile, please refer to the :ref:`sct_courses` section for tutorials in a presentation format.

--- a/documentation/source/user_section/tutorials/correcting_sct_propseg.rst
+++ b/documentation/source/user_section/tutorials/correcting_sct_propseg.rst
@@ -5,9 +5,7 @@ Correcting sct_propseg
 
 What to do if the propagated segmentation fails or contains local errors?
 
-Due to contrast variations in MR imaging protocols, the contrast between the spinal cord and the cerebro-spinal fluid
-(CSF) can differ between MR volumes. Therefore, the propagated segmentation method may fail sometimes in presence of
-artefact, low contrast, etc. Here above, we propose some protocols to correct some segmentation failures.
+Due to contrast variations in MR imaging protocols, the contrast between the spinal cord and the cerebro-spinal fluid (CSF) can differ between MR volumes. Therefore, the propagated segmentation method may fail sometimes in presence of artefact, low contrast, etc. Here above, we propose some protocols to correct some segmentation failures.
 
 .. contents::
    :local:
@@ -16,17 +14,14 @@ artefact, low contrast, etc. Here above, we propose some protocols to correct so
 Detection problem
 *****************
 
-The computation of the spinal cord orientation, at each iteration of the propagation, can fail in lack of spinal
-cord/CSF contrast. Particularly, this situation can lead to an local over-segmentation or even to a propagation
-which has stopped too soon, resulting in a partial spinal cord segmentation.
+The computation of the spinal cord orientation, at each iteration of the propagation, can fail in lack of spinal cord/CSF contrast. Particularly, this situation can lead to an local over-segmentation or even to a propagation which has stopped too soon, resulting in a partial spinal cord segmentation.
 
 Two correction protocols can be used to improve the segmentation : add centerline information and correct the image
 
 Parameter "-init"
 =================
 
-This enables you to change the starting position of the propagation (and the detection) in the image. You can provide a
-fraction (between 0 and 1) of the image in the inferior-superior director or the number of the desired slice.
+This enables you to change the starting position of the propagation (and the detection) in the image. You can provide a fraction (between 0 and 1) of the image in the inferior-superior director or the number of the desired slice.
 
 .. image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/correcting_sct_propseg/propseg_init.png
   :width: 600
@@ -34,11 +29,7 @@ fraction (between 0 and 1) of the image in the inferior-superior director or the
 Parameter "-init-mask"
 ======================
 
-Unfortunately, PropSeg is not perfect yet and can fails in detecting the spinal cord automatically. To help spinal
-cord detection and propagation, you can provide a binary mask (e.g. created with fslview) containing three non-null
-voxels at the center of the spinal cord, separated by ~1 cm in the superior-inferior direction. The middle point is the
-starting point of the propagation while the two other points represents the direction in which the propagation will be
-going. It is important to provide points that are exactly at the center of the spinal cord. Example below:
+Unfortunately, PropSeg is not perfect yet and can fails in detecting the spinal cord automatically. To help spinal cord detection and propagation, you can provide a binary mask (e.g. created with fslview) containing three non-null voxels at the center of the spinal cord, separated by ~1 cm in the superior-inferior direction. The middle point is the starting point of the propagation while the two other points represents the direction in which the propagation will be going. It is important to provide points that are exactly at the center of the spinal cord. Example below:
 
 .. image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/correcting_sct_propseg/propseg_initmask.png
 
@@ -51,18 +42,9 @@ See figure below:
 Parameter "-init-centerline"
 ============================
 
-The spinal cord orientation is computed at each propagation iteration by minimizing/maximizing (depending on the
-contrast type) the sum of gradient magnitude at vertices positions. Bad contrast or error propagation can make
-orientation computation difficult.
+The spinal cord orientation is computed at each propagation iteration by minimizing/maximizing (depending on the contrast type) the sum of gradient magnitude at vertices positions. Bad contrast or error propagation can make orientation computation difficult.
 
-Centerline information can be provided (using "-init-centerline" parameter) to ensure a correct orientation of the
-propagated deformable model. Spinal cord centerline can be a nifti image, with non-null values on centerline voxels.
-The orientation of the spinal cord will then be computed using a B-spline approximating the set of points extracted
-from this input image. You need to provide only a few points to get a proper representation of the spinal cord
-centerline (at least 5). The more points you provide, the better the segmentation will be. Propagation will start at
-the center of the centerline (this can be change using "-init" parameter) and stop at its edges. Centerline can also be
-provided by a text file, where each row contain x, y and z world coordinates (not pixel coordinates) of a point of the
-spinal cord, from the bottom to the top of the spinal cord.
+Centerline information can be provided (using "-init-centerline" parameter) to ensure a correct orientation of the propagated deformable model. Spinal cord centerline can be a nifti image, with non-null values on centerline voxels. The orientation of the spinal cord will then be computed using a B-spline approximating the set of points extracted from this input image. You need to provide only a few points to get a proper representation of the spinal cord centerline (at least 5). The more points you provide, the better the segmentation will be. Propagation will start at the center of the centerline (this can be change using "-init" parameter) and stop at its edges. Centerline can also be provided by a text file, where each row contain x, y and z world coordinates (not pixel coordinates) of a point of the spinal cord, from the bottom to the top of the spinal cord.
 
 .. image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/correcting_sct_propseg/centerline_creation_3.png
   :width: 600
@@ -73,8 +55,7 @@ Segmentation problem
 Smoothing the image
 ===================
 
-To minimize leaking problems, you could try to smooth the image along the spinal cord, and then re-run the
-segmentation. Here is an example of code used to generate the image below::
+To minimize leaking problems, you could try to smooth the image along the spinal cord, and then re-run the segmentation. Here is an example of code used to generate the image below::
 
     sct_download_data -d sct_example_data
     cd sct_example_data/t1
@@ -82,8 +63,7 @@ segmentation. Here is an example of code used to generate the image below::
     sct_smooth_spinalcord -i t1.nii.gz -s t1_seg.nii.gz -smooth 5
     sct_propseg -i t1_smooth.nii.gz -c t1 -init-centerline t1_seg.nii.gz
 
-WARNING: you should ONLY use the smoothed spinal cord for segmentation. The rest of the processing (vertebral labeling,
-registration to template, etc.) should be done on the un-smoothed image.
+WARNING: you should ONLY use the smoothed spinal cord for segmentation. The rest of the processing (vertebral labeling, registration to template, etc.) should be done on the un-smoothed image.
 
 .. image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/correcting_sct_propseg/smooth_spinalcord.png
   :width: 600
@@ -91,10 +71,7 @@ registration to template, etc.) should be done on the un-smoothed image.
 Manually correcting the image
 =============================
 
-MR images can sometimes present local absence of contrast, making the spinal cord segmentation impossible. This
-situation can only be resolved by manually correcting the initial image. The goal is to enhance the contrast between
-the cord and the CSF by changing the values of some voxels. In most case you only need to modify a couple of voxels
-across 3-4 slices. You can use fslview to do it. More info below:
+MR images can sometimes present local absence of contrast, making the spinal cord segmentation impossible. This situation can only be resolved by manually correcting the initial image. The goal is to enhance the contrast between the cord and the CSF by changing the values of some voxels. In most case you only need to modify a couple of voxels across 3-4 slices. You can use fslview to do it. More info below:
 
 .. image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/correcting_sct_propseg/propseg_enhance_contrast.png
   :width: 600
@@ -102,8 +79,7 @@ across 3-4 slices. You can use fslview to do it. More info below:
 Parameter "-detect-radius"
 ==========================
 
-In case the spinal cord is only partially segmented, you could try to act on this parameter which defines the initial
-diameter of the cord.
+In case the spinal cord is only partially segmented, you could try to act on this parameter which defines the initial diameter of the cord.
 
 .. image:: https://raw.githubusercontent.com/spinalcordtoolbox/doc-figures/master/correcting_sct_propseg/propseg_radius.png
   :width: 600
@@ -111,8 +87,7 @@ diameter of the cord.
 Stretching/Compressing the image
 ================================
 
-In case of a distorted cord, or a small one (e.g., mouse), you can apply an affine transformation to the image, then
-run the segmentation, and then compress back the segmentation.
+In case of a distorted cord, or a small one (e.g., mouse), you can apply an affine transformation to the image, then run the segmentation, and then compress back the segmentation.
 First, create two files for compression and stretching. Example:
 
 affine_stretch.txt::
@@ -122,8 +97,7 @@ affine_stretch.txt::
     Transform: AffineTransform_double_3_3
     Parameters: 0.5 0 0 0 0.5 0 0 0 1 -X -Y -Z
     FixedParameters: 0 0
-    With X, Y and Z being the physical coordinates of the center of your volume. You can get those values by opening the
-    image on fsleyes. The green cross is automatically centered in the middle of the volume, then check the values
+    With X, Y and Z being the physical coordinates of the center of your volume. You can get those values by opening the image on fsleyes. The green cross is automatically centered in the middle of the volume, then check the values
     "Coordinates: Scanner anatomical".
 
 affine_compress.txt::


### PR DESCRIPTION
Just fixing line wrapping everywhere.
If possible I'd like this to be merged fast-forward (no squashing) because I think there's a bit of a difference between general paragraph wrapping across the documentation (no line breaks) vs careful manual semantic line wrapping in the list of references.