### PR TITLE
test_scripts_with_no_args_as_subprocess: actually test all scripts

### DIFF
--- a/unit_testing/cli/test_cli.py
+++ b/unit_testing/cli/test_cli.py
@@ -35,7 +35,7 @@ def test_scripts_with_no_args_as_main_func(capsys, script):
 
 
 @pytest.mark.script_launch_mode('subprocess')
-@pytest.mark.parametrize("script", scripts_without_callable_main)
+@pytest.mark.parametrize("script", scripts_to_test)
 def test_scripts_with_no_args_as_subprocess(script, script_runner):
     """Test that [SCRIPTS_NOT_CALLABLE_WITH_MAIN] all return error code 2 and
     show usage descriptions when called with no arguments."""


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
Closes #3186 

Unit test wasn't actually running against all sct scripts.