### PR TITLE
Fix recently-introduced faulty slice index comparison

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -233,8 +233,10 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], persli
     :return: Aggregated metric
     """
     if vert_level:
-        vert_level_slices = Image(vert_level).change_orientation('RPI').data.shape[-1]
-        metric_slices = metric.data.shape[-1]
+        # Assumption: vert_level image will only ever be 3D or 4D
+        vert_level_slices = Image(vert_level).change_orientation('RPI').data.shape[2]
+        # Get slices ('z') from metrics regardless of whether they're 1D [z], 3D [x, y, z], and 4D [x, y, z, t]
+        metric_slices = metric.data.shape[2] if len(metric.data.shape) >= 3 else metric.data.shape[0]
         if vert_level_slices != metric_slices:
             raise ValueError(f"Shape mismatch between vertfile [{vert_level_slices}] and metric [{metric_slices}]). "
                              f"Please verify that your vertfile has the same number of slices as your input image, "

--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -233,11 +233,12 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], persli
     :return: Aggregated metric
     """
     if vert_level:
-        vert_level_slices = Image(vert_level).change_orientation('RPI').data.shape[2]
-        metric_slices = metric.data.shape[0]
+        vert_level_slices = Image(vert_level).change_orientation('RPI').data.shape[-1]
+        metric_slices = metric.data.shape[-1]
         if vert_level_slices != metric_slices:
             raise ValueError(f"Shape mismatch between vertfile [{vert_level_slices}] and metric [{metric_slices}]). "
-                             f"Please verify that your vertfile has the same number of slices as your input image.")
+                             f"Please verify that your vertfile has the same number of slices as your input image, "
+                             f"and that your metric is RPI/LPI oriented.")
 
     # If user neither specified slices nor levels, set perslice=True, otherwise, the output will likely contain nan
     # because in many cases the segmentation does not span the whole I-S dimension.

--- a/unit_testing/test_aggregate_slicewise.py
+++ b/unit_testing/test_aggregate_slicewise.py
@@ -28,7 +28,8 @@ def dummy_metrics():
                'with int': Metric(data=np.array([99, 100, 101, 102, 103, 104, 105, 106, 107])),
                'with nan': Metric(data=np.array([99, np.nan, 101, 102, 103, 104, 105, 106, 107])),
                'inconsistent length': Metric(data=np.array([99, 100])),
-               'with string': Metric(data=np.array([99, "boo!", 101, 102, 103, 104, 105, 106, 107]))}
+               'with string': Metric(data=np.array([99, "boo!", 101, 102, 103, 104, 105, 106, 107])),
+               '3D': Metric(data=np.resize(np.array([99, 100, 101, 102, 103, 104, 105, 106, 107]), [4, 5, 9]))}
     return metrics
 
 
@@ -303,9 +304,12 @@ def test_save_as_csv_extract_metric(dummy_data_and_labels):
 
 
 def test_dimension_mismatch_between_metric_and_vertfile(dummy_metrics, dummy_vert_level):
-    """Test that an exception is raised for mismatched metric and -vertfile images."""
-    with pytest.raises(ValueError) as err:
-        aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics['inconsistent length'],
-                                                         vert_level=dummy_vert_level)
-
-    assert "mismatch" in str(err.value)
+    """Test that an exception is raised only for mismatched metric and -vertfile images."""
+    for metric in dummy_metrics:
+        if metric == 'inconsistent length':
+            with pytest.raises(ValueError) as err:
+                aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics[metric], vert_level=dummy_vert_level)
+            assert "mismatch" in str(err.value)
+        else:
+            # Verify that no error is thrown for all other metrics
+            aggregate_slicewise.aggregate_per_slice_or_level(dummy_metrics[metric], vert_level=dummy_vert_level)


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #3120, I mistakenly assumed that all metrics would be 1D, so I indexed the metric using `[0]`. This updates the check to index the right dimension depending on the metric shape.

This PR also adds a new dummy metric that is 3D, so that the tests are more representative of real-world data. 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3202.
