### PR TITLE
Don't use xdist by default.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,3 @@ tqdm
 transforms3d
 urllib3[secure]
 pytest_console_scripts
-pytest-xdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 test=pytest
 
 [tool:pytest]
-addopts = --verbose --numprocesses auto --dist=loadscope
+addopts = --verbose
 python_files = unit_testing/test_*.py unit_testing/cli/test_*.py
 
 [coverage:run]


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR removes the default usage of `pytest-xdist` when running the unit tests. See minutes from dev meeting:

- Motivation: we have hit some limitations/issues with regards to concurrency issues (https://github.com/pytest-dev/pytest-xdist/issues/271#issuecomment-763402552, https://github.com/neuropoly/spinalcordtoolbox/pull/3152). This complicates the ongoing effort to port CI to github actions (https://github.com/neuropoly/spinalcordtoolbox/pull/3125, https://github.com/neuropoly/spinalcordtoolbox/pull/3152)

- Other annoyances such as xdist disabling `-s` (`--capture=no`) thus preventing the user from viewing the output of `stdout` which is confusing for users. (Relevant dev Wiki page about this issue.)
   - This issue specifically is causing Julien to disable `xdist` for local testing, for example. 
- Doesn’t add value in CI since almost all VMs are single-core.
- Alternatives:
   - `pytest-parallel` (to be evaluated)
   - Disabled by default config. People who know what they are doing can enable it (or it can be enabled in ci.sh only).
   - Strategies in https://github.com/neuropoly/spinalcordtoolbox/issues/2674, particularly split tests across jobs; but we also need to consider that each job needs to spend installation time (there is a sweet spot in terms of number of tests per job)
- CI time on GH actions: total ~15min; on Travis: ~1hr
   - Largely dominated by waiting for the macOS VM to boot

In a nutshell: there is not a lot of value added (at the moment) in using `xdist` and working around the issues mentioned above. Tests can happily run sequentially and it won't make a difference for 99% of the people. People who do care about parallelization can still use `xdist` locally.
