### PR TITLE
Fix size calculation bug for '-method map' and '-method ml'

### DIFF
--- a/spinalcordtoolbox/aggregate_slicewise.py
+++ b/spinalcordtoolbox/aggregate_slicewise.py
@@ -299,8 +299,8 @@ def aggregate_per_slice_or_level(metric, mask=None, slices=[], levels=[], persli
                 if mask is not None:
                     mask_slicegroup = mask.data[..., slicegroup, :]
                     agg_metric[slicegroup]['Label'] = mask.label
-                    # Add volume fraction
-                    agg_metric[slicegroup]['Size [vox]'] = np.sum(mask_slicegroup.flatten())
+                    # For size calculation, only the first index [0] is relevant (See spinalcordtoolbox/issues/3216)
+                    agg_metric[slicegroup]['Size [vox]'] = np.sum(mask_slicegroup[..., 0])
                 else:
                     mask_slicegroup = np.ones(data_slicegroup.shape)
                 # Ignore nonfinite values


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Both `-method map` and `-method ml` include data from extra labels in their masks:

https://github.com/neuropoly/spinalcordtoolbox/blob/74f068df9042e6cce8473e67f1a3fe60ddadac70/spinalcordtoolbox/aggregate_slicewise.py#L416-L421

This causes the `Size [vox]` calculation to be larger than expected. 

To fix this, we limit the calculation to only include the first label. (Also, remove `.flatten()`, as it is no longer necessary once we index the array.)

### A note about coupling

This change is coupled very closely to code inside [a separate `extract_metric()` function](https://github.com/neuropoly/spinalcordtoolbox/blob/74f068df9042e6cce8473e67f1a3fe60ddadac70/spinalcordtoolbox/aggregate_slicewise.py#L389-L434): I make the assumption that `mask` will always have an extra dimension for labels, and that only label `[0]` is relevant for size calculations, just like in `extract_metric()`. 

While this assumption holds for our internal use of `aggregate_per_slice_or_level()`, this might be a shaky assumption when thinking about the function in isolation (as part of a public API) since we don't do any input validation to verify `mask`. (I'm not sure the API is ready enough to be thinking about this, though) 

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3216.