### PR TITLE
Enforce UINT8 when resampling labels for register to template

### DIFF
--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -842,7 +842,7 @@ def resample_labels(fname_labels, fname_dest, fname_output):
                               int(float(v))])
                   for x, y, z, v in og_labels]
 
-    sct_labels.create_labels_empty(Image(fname_dest), new_labels).save(path=fname_output)
+    sct_labels.create_labels_empty(Image(fname_dest).change_type('uint8'), new_labels).save(path=fname_output)
 
 
 def check_labels(fname_landmarks, label_type='body'):


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
In some datasets, when resampling the label files within the `sct_register_to_template` script, the output label files was encoded in FLOAT64, which in some cases could create label precision error, e.g.: 6.0001 instead of 6.0, leading to label mismatch when registering the input file to the PAM50 labels, then causing issue #3229.

## Linked issues
Fixes #3229.