### PR TITLE
(WIP) Check for header/data dtype mismatches when loading images

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 test=pytest
 
 [tool:pytest]
-addopts = --verbose --disable-warnings --show-capture=stderr --tb=short
+addopts = --verbose --disable-warnings --show-capture=stderr --tb=native
 python_files = unit_testing/test_*.py unit_testing/cli/test_*.py
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 test=pytest
 
 [tool:pytest]
-addopts = --verbose
+addopts = --verbose --disable-warnings --show-capture=stderr --tb=short
 python_files = unit_testing/test_*.py unit_testing/cli/test_*.py
 
 [coverage:run]

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -250,7 +250,7 @@ class Image(object):
     """
 
     def __init__(self, param=None, hdr=None, orientation=None, absolutepath=None, dim=None, verbose=1,
-                 check_sform=False):
+                 check_sform=False, check_dtype=True):
         """
         :param param: string indicating a path to a image file or an `Image` object.
         :param hdr: a nibabel header object to use as the header for the image (overwritten if `param` is provided)
@@ -309,6 +309,14 @@ class Image(object):
                              "sct_image -i {} -set-sform-to-qform -o {}.".format(
                     self._path, self._path, dummy_reaffined))
             raise ValueError("Image sform does not match qform")
+
+        # Make sure header type matches data type
+        # Context: https://github.com/neuropoly/spinalcordtoolbox/issues/3232
+        data_dtype = self.data.dtype
+        hdr_dtype = self.hdr.get_data_dtype()
+        if check_dtype and data_dtype != hdr_dtype:
+            logger.warning(f"Header of {self._path} specifies datatype '{hdr_dtype}', but data is '{data_dtype}'.")
+            raise ValueError("Datatype mismatch between header and data array.")  # Raise error just to demo in CI tests
 
 
     @property

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -315,8 +315,8 @@ class Image(object):
         data_dtype = self.data.dtype
         hdr_dtype = self.hdr.get_data_dtype()
         if check_dtype and data_dtype != hdr_dtype:
-            logger.warning(f"Header of {self._path} specifies datatype '{hdr_dtype}', but data is '{data_dtype}'.")
-            raise ValueError("Datatype mismatch between header and data array.")  # Raise error just to demo in CI tests
+            raise TypeError(f"Datatype mismatch: '{hdr_dtype}' (header) != '{data_dtype}' (data) for image with "
+                            f"filepath '{self._path}'.")
 
 
     @property


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR introduces a check for datatype mismatches between image headers and image data. (Datatype mismatches can cause precision issues in `nib.save`.)

Right now this is marked as draft, because I'm trying to identify which actions in SCT cause mismatches.

### Future work

This PR does _not_ fix the following issues:
* The cause of the datatype mismatch in `sct_dmri_moco` that affected #3232. (To be investigated further.)
* The bug in `nibabel` that results in precision errors.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Partially addresses #3232.