### PR TITLE
Use 'extend-ignore' in flake8 config to preserve defaults

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ source = spinalcordtoolbox/
 
 [flake8]
 exclude = build,.git,.tox,
-ignore = E501,E402
+extend-ignore = E501,E402
 max-line-length = 179
 
 [isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ source = spinalcordtoolbox/
 
 [flake8]
 exclude = build,.git,.tox,
+# extend-ignore preserves flake8's default ignore list: W503,W504,E24,E121,E123,E126,E226,E704
 extend-ignore = E501,E402
 max-line-length = 179
 

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -294,7 +294,10 @@ def main(argv=None):
         input_files=[fname_in, fname_seg],
     )
     cachefile = os.path.join(curdir, "straightening.cache")
-    if cache_valid(cachefile, cache_sig) and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz")) and os.path.isfile(os.path.join(curdir, "warp_straight2curve.nii.gz")) and os.path.isfile(os.path.join(curdir, "straight_ref.nii.gz")):
+    if (cache_valid(cachefile, cache_sig)
+            and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz"))
+            and os.path.isfile(os.path.join(curdir, "warp_straight2curve.nii.gz"))
+            and os.path.isfile(os.path.join(curdir, "straight_ref.nii.gz"))):
         # if they exist, copy them into current folder
         printv('Reusing existing warping field which seems to be valid', verbose, 'warning')
         copy(os.path.join(curdir, "warp_curve2straight.nii.gz"), 'warp_curve2straight.nii.gz')

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -294,10 +294,7 @@ def main(argv=None):
         input_files=[fname_in, fname_seg],
     )
     cachefile = os.path.join(curdir, "straightening.cache")
-    if (cache_valid(cachefile, cache_sig)
-            and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz"))
-            and os.path.isfile(os.path.join(curdir, "warp_straight2curve.nii.gz"))
-            and os.path.isfile(os.path.join(curdir, "straight_ref.nii.gz"))):
+    if cache_valid(cachefile, cache_sig) and os.path.isfile(os.path.join(curdir, "warp_curve2straight.nii.gz")) and os.path.isfile(os.path.join(curdir, "warp_straight2curve.nii.gz")) and os.path.isfile(os.path.join(curdir, "straight_ref.nii.gz")):
         # if they exist, copy them into current folder
         printv('Reusing existing warping field which seems to be valid', verbose, 'warning')
         copy(os.path.join(curdir, "warp_curve2straight.nii.gz"), 'warp_curve2straight.nii.gz')


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Using extend-ignore [preserves the default list of ignored warnings/errors](https://gitlab.com/pycqa/flake8/-/issues/466#note_111460896), which is important for fixing the W503/W504 conflict.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3235. 
Related to #2679 because of these linting false positives: https://github.com/neuropoly/spinalcordtoolbox/pull/2679/checks?check_run_id=1979921525