### PR TITLE
Uniquely distinguish filenames for tmp files to prevent overwriting

### DIFF
--- a/spinalcordtoolbox/scripts/sct_dice_coefficient.py
+++ b/spinalcordtoolbox/scripts/sct_dice_coefficient.py
@@ -114,11 +114,12 @@ def main(argv=None):
     tmp_dir = os.path.abspath(tmp_dir)
 
     # copy input files to tmp directory
-    # for fname in [fname_input1, fname_input2]:
-    copy(fname_input1, tmp_dir)
-    copy(fname_input2, tmp_dir)
-    fname_input1 = ''.join(extract_fname(fname_input1)[1:])
-    fname_input2 = ''.join(extract_fname(fname_input2)[1:])
+    fname_input1_tmp = 'tmp1_' + ''.join(extract_fname(fname_input1)[1:])
+    fname_input2_tmp = 'tmp2_' + ''.join(extract_fname(fname_input2)[1:])
+    copy(fname_input1, os.path.join(tmp_dir, fname_input1_tmp))
+    copy(fname_input2, os.path.join(tmp_dir, fname_input2_tmp))
+    fname_input1 = fname_input1_tmp
+    fname_input2 = fname_input2_tmp
 
     curdir = os.getcwd()
     os.chdir(tmp_dir)  # go to tmp directory


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

When copying `-i` and `-d` input files to a tmp directory, if they had the same filenames (but different parent directories), then `-d` would overwrite `-i`. So, the dice calculation would be performed between `-d` and `-d` (instead of between `-i` and `-d`).

This change ensures that each temp filename is unique.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3256.