### PR TITLE
Handle 'label_discs' case where SC segmentation has holes/discontinuities

### DIFF
--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -251,12 +251,17 @@ def vertebral_detection(fname, fname_seg, contrast, param, init_disc, verbose=1,
     label_discs(fname_seg, list_disc_z, list_disc_value, verbose=verbose)
 
 
+class EmptyArrayError(ValueError):
+    """Custom exception to distinguish between general SciPy ValueErrors."""
+    pass
+
+
 def center_of_mass(x):
     """
     :return: array center of mass
     """
     if (x == 0).all():
-        raise ValueError("Array has no mass")
+        raise EmptyArrayError("Center of mass can't be calculated on empty arrays.")
     return scipy.ndimage.measurements.center_of_mass(x)
 
 

--- a/spinalcordtoolbox/vertebrae/core.py
+++ b/spinalcordtoolbox/vertebrae/core.py
@@ -528,8 +528,9 @@ def label_discs(fname_seg, list_disc_z, list_disc_value, verbose=1):
                 slices = seg.data[:, :, list_disc_z[i]]
                 cx, cy = [int(x) for x in np.round(center_of_mass(slices)).tolist()]
             except EmptyArrayError:
-                logger.warning("Center of mass calculation failed while attempting to label discs. Using interpolated "
-                               "centerline instead. (Consider checking your segmentation file for discontinuities.)")
+                logger.warning("During disc labeling, center of mass calculation failed due to discontinuities in "
+                               "segmented spinal cord; please check the quality of your segmentation. Using "
+                               "interpolated centerline as a fallback.")
                 interpolated_centerline, _, _, _ = get_centerline(seg)
                 slices = interpolated_centerline.data[:, :, list_disc_z[i]]
                 cx, cy = [int(x) for x in np.round(center_of_mass(slices)).tolist()]

--- a/unit_testing/cli/test_cli_sct_label_vertebrae.py
+++ b/unit_testing/cli/test_cli_sct_label_vertebrae.py
@@ -64,3 +64,16 @@ def test_sct_label_vertebrae_consistent_disc(tmp_path):
 
     # Files created in root directory by sct_label_vertebrae
     os.unlink('straightening.cache')
+
+
+def test_sct_label_vertebrae_disc_discontinuity_center_of_mass_error(tmp_path, caplog):
+    # Generate a discontinuity next to an intervertebral disc
+    t2_seg = Image('sct_testing_data/t2/t2_seg-manual.nii.gz')
+    t2_seg.data[:, 16, :] = 0
+    path_out = str(tmp_path / 't2_seg-large-discontinuity.nii.gz')
+    t2_seg.save(path=path_out)
+
+    # Ensure the discontinuity is detected and an interpolated centerline is used instead
+    sct_label_vertebrae.main(['-i', 'sct_testing_data/t2/t2.nii.gz', '-s', path_out, '-c', 't2',
+                              '-initfile', 'sct_testing_data/t2/init_label_vertebrae.txt'])
+    assert "Using interpolated centerline" in caplog.text


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [X] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I first wrote a failing test to reproduce the problem, then applied a fix which causes the test to pass. 

The fix falls back on an interpolated centerline if the segmentation is missing in places where the disc label should go.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3252.