### PR TITLE
Add qc params in sct_fmri_moco and sct_dmri_moco

### DIFF
--- a/spinalcordtoolbox/moco.py
+++ b/spinalcordtoolbox/moco.py
@@ -128,7 +128,7 @@ def moco_wrapper(param):
     Wrapper that performs motion correction.
 
     :param param: ParamMoco class
-    :return: None
+    :return: fname_moco
     """
     file_data = 'data.nii'  # corresponds to the full input data (e.g. dmri or fmri)
     file_data_dirname, file_data_basename, file_data_ext = extract_fname(file_data)
@@ -476,6 +476,7 @@ def moco_wrapper(param):
         [os.path.join(param.path_out, add_suffix(os.path.basename(param.fname_data), param.suffix)),
          param.fname_data], mode='ortho,ortho')
 
+    return fname_moco
 
 def moco(param):
     """

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -187,8 +187,7 @@ def main(argv=None):
         param.update(arguments.param)
 
     # run moco
-    img_moco = moco_wrapper(param)
-    fname_output_data = img_moco.absolutepath
+    fname_output_image = moco_wrapper(param)
 
     # QC report
     path_qc = arguments.qc
@@ -196,7 +195,7 @@ def main(argv=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
     if path_qc is not None:
-        generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
+        generate_qc(fname_in1=fname_output_image, fname_in2=param.fname_data, fname_seg=param.fname_mask,
                     args=arguments, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
                     subject=qc_subject, process='sct_dmri_moco')
 

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -197,8 +197,8 @@ def main(argv=None):
     qc_subject = arguments.qc_subject
     if path_qc is not None:
         generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
-                    path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset, subject=qc_subject,
-                    process='sct_dmri_moco')
+                    args=arguments, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
+                    subject=qc_subject, process='sct_dmri_moco')
 
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -135,7 +135,31 @@ def get_parser():
         choices=[0, 1, 2],
         default=1,
         # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
-        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode")
+        help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
+    )
+    optional.add_argument(
+        '-qc',
+        metavar=Metavar.folder,
+        action=ActionCreateFolder,
+        help="The path where the quality control generated content will be saved."
+    )
+    optional.add_argument(
+        '-qc-fps',
+        metavar=Metavar.float,
+        type=float,
+        default=2,
+        help="This float number is the frame rate of the output gif images. Default value is 2 fps."
+    )
+    optional.add_argument(
+        '-qc-dataset',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the dataset the process was run on."
+    )
+    optional.add_argument(
+        '-qc-subject',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
+    )
     return parser
 
 

--- a/spinalcordtoolbox/scripts/sct_dmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_dmri_moco.py
@@ -31,6 +31,7 @@ import os
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, set_global_loglevel
+from spinalcordtoolbox.reports.qc import generate_qc
 
 
 def get_parser():
@@ -186,7 +187,19 @@ def main(argv=None):
         param.update(arguments.param)
 
     # run moco
-    moco_wrapper(param)
+    img_moco = moco_wrapper(param)
+    fname_output_data = img_moco.absolutepath
+
+    # QC report
+    path_qc = arguments.qc
+    qc_fps = arguments.qc_fps
+    qc_dataset = arguments.qc_dataset
+    qc_subject = arguments.qc_subject
+    if path_qc is not None:
+        generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
+                    path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset, subject=qc_subject,
+                    process='sct_dmri_moco')
+
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -173,7 +173,8 @@ def main(argv=None):
     qc_subject = arguments.qc_subject
     if path_qc is not None:
         generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
-                    path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset, subject=qc_subject, process='sct_fmri_moco')
+                    path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset, subject=qc_subject,
+                    process='sct_fmri_moco')
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -16,7 +16,7 @@ import os
 
 from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, set_global_loglevel
-
+from spinalcordtoolbox.reports.qc import generate_qc
 
 def get_parser():
     # initialize parameters
@@ -162,7 +162,17 @@ def main(argv=None):
         param.update(arguments.param)
 
     # run moco
-    moco_wrapper(param)
+    img_moco = moco_wrapper(param)
+    fname_output_data = img_moco.absolutepath
+
+    # QC report
+    path_qc = arguments.qc
+    qc_fps = arguments.qc_fps
+    qc_dataset = arguments.qc_dataset
+    qc_subject = arguments.qc_subject
+    if path_qc is not None:
+        generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
+                    path_qc=os.path.abspath(path_qc), fps = qc_fps, dataset=qc_dataset, subject=qc_subject, process='sct_fmri_moco')
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -114,7 +114,29 @@ def get_parser():
         # Values [0, 1, 2] map to logging levels [WARNING, INFO, DEBUG], but are also used as "if verbose == #" in API
         help="Verbosity. 0: Display only errors/warnings, 1: Errors/warnings + info messages, 2: Debug mode"
     )
-
+    optional.add_argument(
+        '-qc',
+        metavar=Metavar.folder,
+        action=ActionCreateFolder,
+        help="The path where the quality control generated content will be saved."
+    )
+    optional.add_argument(
+        '-qc-fps',
+        metavar=Metavar.float,
+        type=float,
+        default=2,
+        help="This float number is the frame rate of the output gif images. Default value is 2 fps."
+    )
+    optional.add_argument(
+        '-qc-dataset',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the dataset the process was run on."
+    )
+    optional.add_argument(
+        '-qc-subject',
+        metavar=Metavar.str,
+        help="If provided, this string will be mentioned in the QC report as the subject the process was run on."
+    )
     return parser
 
 

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -18,6 +18,7 @@ from spinalcordtoolbox.moco import ParamMoco, moco_wrapper
 from spinalcordtoolbox.utils import SCTArgumentParser, Metavar, ActionCreateFolder, list_type, init_sct, set_global_loglevel
 from spinalcordtoolbox.reports.qc import generate_qc
 
+
 def get_parser():
     # initialize parameters
     # TODO: create a class ParamFmriMoco which inheritates from ParamMoco
@@ -172,7 +173,7 @@ def main(argv=None):
     qc_subject = arguments.qc_subject
     if path_qc is not None:
         generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
-                    path_qc=os.path.abspath(path_qc), fps = qc_fps, dataset=qc_dataset, subject=qc_subject, process='sct_fmri_moco')
+                    path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset, subject=qc_subject, process='sct_fmri_moco')
 
 
 if __name__ == "__main__":

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -163,8 +163,7 @@ def main(argv=None):
         param.update(arguments.param)
 
     # run moco
-    img_moco = moco_wrapper(param)
-    fname_output_data = img_moco.absolutepath
+    fname_output_image = moco_wrapper(param)
 
     # QC report
     path_qc = arguments.qc
@@ -172,7 +171,7 @@ def main(argv=None):
     qc_dataset = arguments.qc_dataset
     qc_subject = arguments.qc_subject
     if path_qc is not None:
-        generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
+        generate_qc(fname_in1=fname_output_image, fname_in2=param.fname_data, fname_seg=param.fname_mask,
                     args=arguments, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
                     subject=qc_subject, process='sct_fmri_moco')
 

--- a/spinalcordtoolbox/scripts/sct_fmri_moco.py
+++ b/spinalcordtoolbox/scripts/sct_fmri_moco.py
@@ -173,8 +173,8 @@ def main(argv=None):
     qc_subject = arguments.qc_subject
     if path_qc is not None:
         generate_qc(fname_in1=fname_output_data, fname_in2=param.fname_data, fname_seg=param.fname_mask,
-                    path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset, subject=qc_subject,
-                    process='sct_fmri_moco')
+                    args=arguments, path_qc=os.path.abspath(path_qc), fps=qc_fps, dataset=qc_dataset,
+                    subject=qc_subject, process='sct_fmri_moco')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This PR adds the following entry parameters to sct_fmri_moco and sct_dmri_moco:
-qc : path for QC report
-qc-fps : float number, frame rate of the output gif images. Default value is 2 fps.
-qc-dataset : string, dataset the process war run on
-qc-subject : string, subject the process was run on

It also adds the call for the generate_qc in sct_fmri_moco and sct_dmri_moco.

In moco_wrapper, the parameter fname_moco is returned for use in qc_report.

## Linked issues
Fixes #3274
