### PR TITLE
Unpin ivadomed to get latest version and fix wrong q/sform_code output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
 Keras==2.1.5
-ivadomed==2.7.2
+ivadomed==2.7.4
 matplotlib
 nibabel
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 # https://github.com/tensorflow/tensorflow/issues/44467
 h5py~=2.10.0
 Keras==2.1.5
-ivadomed==2.7.4
+ivadomed
 matplotlib
 nibabel
 numpy


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

When running `sct_deepseg` on an input image which has qform_code=1 and sform_code=1, the output segmentation has the fields qform_code=0 (incorrect) and sform_code=2. 

This issue was fixed in ivadomed 2.7.4, [see PR](https://github.com/ivadomed/ivadomed/pull/714)
For more details on q/sform conventions, see https://github.com/neuropoly/spinalcordtoolbox/issues/3283

## Linked issues

Fixes #3284
Related to https://github.com/ivadomed/ivadomed/issues/711