### PR TITLE
Added flag -s-template-id to use another segmentation (e.g. white matter) for registration to template

### DIFF
--- a/spinalcordtoolbox/registration/landmarks.py
+++ b/spinalcordtoolbox/registration/landmarks.py
@@ -41,6 +41,7 @@ ini_param_trans_x = 270.0  # pix
 ini_param_trans_y = -150.0  # pix
 initial_step = 2
 
+
 def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1):
     """
     Register two NIFTI volumes containing landmarks
@@ -101,6 +102,7 @@ def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', ve
                                                            points_moving_barycenter[2]))
     text_file.close()
 
+    
 def getNeighbors(point, set_points, k=1):
     '''
     Locate most similar neighbours

--- a/spinalcordtoolbox/registration/landmarks.py
+++ b/spinalcordtoolbox/registration/landmarks.py
@@ -41,7 +41,7 @@ ini_param_trans_x = 270.0  # pix
 ini_param_trans_y = -150.0  # pix
 initial_step = 2
 
-def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1, path_qc=None):
+def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', verbose=1):
     """
     Register two NIFTI volumes containing landmarks
     :param fname_src: fname of source landmarks
@@ -84,7 +84,7 @@ def register_landmarks(fname_src, fname_dest, dof, fname_affine='affine.txt', ve
     # estimate transformation
     # N.B. points_src and points_dest are inverted below, because ITK uses inverted transformation matrices, i.e., src->dest is defined in dest instead of src.
     # (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_dest, points_src, constraints=dof, verbose=verbose, path_qc=path_qc)
-    (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_src, points_dest, constraints=dof, verbose=verbose, path_qc=path_qc)
+    (rotation_matrix, translation_array, points_moving_reg, points_moving_barycenter) = getRigidTransformFromLandmarks(points_src, points_dest, constraints=dof, verbose=verbose)
     # writing rigid transformation file
     # N.B. x and y dimensions have a negative sign to ensure compatibility between Python and ITK transfo
     text_file = open(fname_affine, 'w')
@@ -200,7 +200,7 @@ def minimize_transform(params, points_dest, points_src, constraints):
     return SSE(np.matrix(points_dest), points_src_reg)
 
 
-def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0, path_qc=None):
+def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_Tz_Rx_Ry_Rz', verbose=0):
     """
     Compute affine transformation to register landmarks
     :param points_src:
@@ -254,11 +254,7 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
     logger.info(f"Center:\n {points_src_barycenter}")
     logger.info(f"Translation:\n {translation_array}")
 
-    if verbose == 2 and path_qc is not None:
-        try:
-            os.makedirs(path_qc)
-        except FileExistsError:
-            pass
+    if verbose == 2:
 
         import matplotlib
         # use Agg to prevent display
@@ -288,14 +284,14 @@ def getRigidTransformFromLandmarks(points_dest, points_src, constraints='Tx_Ty_T
         ax.set_aspect('auto')
         plt.legend()
         # plt.show()
-        plt.savefig(os.path.join(path_qc, 'getRigidTransformFromLandmarks_plot.png'))
+        plt.savefig('getRigidTransformFromLandmarks_plot.png')
 
         fig2 = plt.figure()
         plt.plot(sse_results)
         plt.grid()
         plt.title('#Iterations: ' + str(res.nit) + ', #FuncEval: ' + str(res.nfev) + ', Error: ' + str(res.fun))
         plt.show()
-        plt.savefig(os.path.join(path_qc, 'getRigidTransformFromLandmarks_iterations.png'))
+        plt.savefig(os.path.join('getRigidTransformFromLandmarks_iterations.png'))
 
     # transform numpy matrix to list structure because it is easier to handle
     points_src_reg = points_src_reg.tolist()

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -30,6 +30,7 @@ from spinalcordtoolbox.registration.register import *
 from spinalcordtoolbox.registration.landmarks import *
 from spinalcordtoolbox.types import Coordinate
 from spinalcordtoolbox.utils import *
+from spinalcordtoolbox.utils import Metavar
 from spinalcordtoolbox import __data_dir__
 import spinalcordtoolbox.image as msct_image
 import spinalcordtoolbox.labels as sct_labels

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -139,9 +139,9 @@ def get_parser():
         '-s-template-id',
         metavar=Metavar.int,
         type=int,
-        help="Segmentation from the template to associate with the flag '-s'. Typically, the spinal cord segmentation "
-             "is used, but if it is available, the white matter mask would produced better registration results. The ID"
-             "is indicated in the file 'template/info_label.txt' of the template indicated by the flag '-t'.",
+        help="Segmentation from the template to be used by flag '-s'. By default, the spinal cord segmentation "
+             "is used, but if available, a different segmentation could produce better registration results. The ID"
+             "is an integer indicated in the file 'template/info_label.txt' of the template indicated by the flag '-t'.",
         default=3
         )
     optional.add_argument(
@@ -1288,4 +1288,3 @@ def register(src, dest, step, param):
 if __name__ == "__main__":
     init_sct()
     main(sys.argv[1:])
-

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -136,6 +136,15 @@ def get_parser():
         help="Show this help message and exit."
     )
     optional.add_argument(
+        '-s-template-id',
+        metavar=Metavar.int,
+        type=int,
+        help="Segmentation from the template to associate with the flag '-s'. Typically, the spinal cord segmentation "
+             "is used, but if it is available, the white matter mask would produced better registration results. The ID"
+             "is indicated in the file 'template/info_label.txt' of the template indicated by the flag '-t'.",
+        default=3
+        )
+    optional.add_argument(
         '-l',
         metavar=Metavar.file,
         help="R|One or two labels (preferred) located at the center of the spinal cord, on the mid-vertebral slice. "
@@ -339,7 +348,7 @@ def main(argv=None):
         file_template_labeling = get_file_label(os.path.join(path_template, 'template'), id_label=7)  # label = spinal cord mask with discrete vertebral levels
     id_label_dct = {'T1': 0, 'T2': 1, 'T2S': 2}
     file_template = get_file_label(os.path.join(path_template, 'template'), id_label=id_label_dct[contrast_template.upper()])  # label = *-weighted template
-    file_template_seg = get_file_label(os.path.join(path_template, 'template'), id_label=3)  # label = spinal cord mask (binary)
+    file_template_seg = get_file_label(os.path.join(path_template, 'template'), id_label=arguments.s_template_id)
 
     # start timer
     start_time = time.time()

--- a/spinalcordtoolbox/scripts/sct_register_to_template.py
+++ b/spinalcordtoolbox/scripts/sct_register_to_template.py
@@ -140,9 +140,10 @@ def get_parser():
         '-s-template-id',
         metavar=Metavar.int,
         type=int,
-        help="Segmentation from the template to be used by flag '-s'. By default, the spinal cord segmentation "
-             "is used, but if available, a different segmentation could produce better registration results. The ID"
-             "is an integer indicated in the file 'template/info_label.txt' of the template indicated by the flag '-t'.",
+        help="Segmentation file ID to use for registration. The ID is an integer indicated in the file "
+             "'template/info_label.txt'. This 'info_label.txt' file corresponds to the template indicated by the flag "
+             "'-t'. By default, the spinal cord segmentation is used (ID=3), but if available, a different segmentation"
+             " such as white matter segmentation could produce better registration results.",
         default=3
         )
     optional.add_argument(


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

Currently, the function assumes that the user inputs the cord segmentation with the flag `-s`. SCT then automatically associates `-s` with the file with ID=3 from **info_label.txt** file:

https://github.com/neuropoly/spinalcordtoolbox/blob/6d70ad82fbd9ba7961fc1ef7fbb7ebca70ac6fc7/spinalcordtoolbox/scripts/sct_register_to_template.py#L342

This ID label is supposed to correspond to the spinal cord mask.

However, in some cases where the white matter mask is available, the user might want to use it for registration, as it would provide better registration performance.

In this case, we need to specify somehow that another segmentation ID file should be used.

In this PR we introduce the flag `-s-template-id`, which indicates which file to select to be associated with `-s`. By default, the value would be "3" to ensure retro-compatibility.

## Linked issues
Fixes #3297
