### PR TITLE
3301 qc entry for moco functions

### DIFF
--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -668,8 +668,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
     elif process in ['sct_dmri_moco', 'sct_fmri_moco']:
         plane = 'Axial'
         qcslice_type = qcslice.Axial([Image(fname_in1), Image(fname_in2), Image(fname_seg)])
-        qcslice_operations = [QcImage.grid] # grid will be added in future PR
-        def qcslice_layout(x): return x.mosaic_through_time() # mosaic_through_time will be added in future PR
+        qcslice_operations = [QcImage.grid]  # grid will be added in future PR
+        def qcslice_layout(x): return x.mosaic_through_time()  # mosaic_through_time will be added in future PR
     # Sagittal orientation, display vertebral labels
     elif process in ['sct_label_vertebrae']:
         plane = 'Sagittal'

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -535,6 +535,7 @@ def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overla
               dpi=300,
               stretch_contrast_method='contrast_stretching',
               angle_line=None,
+              fps=None,
               dataset=None,
               subject=None):
     """
@@ -553,6 +554,7 @@ def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overla
     :param dpi: int: Output resolution of the image
     :param stretch_contrast_method: Method for stretching contrast. See QcImage
     :param angle_line: [float]: See generate_qc()
+    :param fps: [float]: Frame rate for output gif images
     :param dataset: str: Dataset name
     :param subject: str: Subject name
     :return:
@@ -563,7 +565,7 @@ def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overla
 
     if qcslice is not None:
         @QcImage(report, 'none', qcslice_operations, stretch_contrast_method=stretch_contrast_method,
-                 angle_line=angle_line)
+                 angle_line=angle_line, fps=fps)
         def layout(qslice):
             # This will call qc.__call__(self, func):
             return qcslice_layout(qslice)
@@ -605,8 +607,8 @@ def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overla
         print("WARNING! Platform undetectable.")
 
 
-def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args=None, path_qc=None, dataset=None,
-                subject=None, path_img=None, process=None):
+def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args=None, path_qc=None, fps=None,
+                dataset=None, subject=None, path_img=None, process=None):
     """
     Generate a QC entry allowing to quickly review results. This function is the entry point and is called by SCT
     scripts (e.g. sct_propseg).
@@ -618,6 +620,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
     each slice, for slice that don't have an angle to display, a nan is expected. To be used for assessing cord orientation.
     :param args: args from parent function
     :param path_qc: str: Path to save QC report
+    :param fps: float: Frame rate for output gif images
     :param dataset: str: Dataset name
     :param subject: str: Subject name
     :param path_img: dict: Path to image to display (e.g., a graph), instead of computing the image from MRI.
@@ -715,7 +718,8 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
         qcslice_operations=qcslice_operations,
         qcslice_layout=qcslice_layout,
         stretch_contrast_method='equalized',
-        angle_line=angle_line
+        angle_line=angle_line,
+        fps=fps,
     )
 
 

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -661,6 +661,12 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
         qcslice_type = qcslice.Axial([Image(fname_in1), Image(fname_seg)])
         qcslice_operations = [QcImage.template]
         def qcslice_layout(x): return x.mosaic()
+    # Axial orientation, switch between gif image (before and after motion correction) and grid overlay
+    elif process in ['sct_dmri_moco', 'sct_fmri_moco']:
+        plane = 'Axial'
+        qcslice_type = qcslice.Axial([Image(fname_in1), Image(fname_in2), Image(fname_seg)])
+        qcslice_operations = [QcImage.grid] # grid will be added in future PR
+        def qcslice_layout(x): return x.mosaic_through_time() # mosaic_through_time will be added in future PR
     # Sagittal orientation, display vertebral labels
     elif process in ['sct_label_vertebrae']:
         plane = 'Sagittal'

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -622,7 +622,7 @@ def generate_qc(fname_in1, fname_in2=None, fname_seg=None, angle_line=None, args
     each slice, for slice that don't have an angle to display, a nan is expected. To be used for assessing cord orientation.
     :param args: args from parent function
     :param path_qc: str: Path to save QC report
-    :param fps: float: Frame rate for output gif images
+    :param fps: float: Number of frames per second for output gif images
     :param dataset: str: Dataset name
     :param subject: str: Subject name
     :param path_img: dict: Path to image to display (e.g., a graph), instead of computing the image from MRI.

--- a/spinalcordtoolbox/reports/qc.py
+++ b/spinalcordtoolbox/reports/qc.py
@@ -63,7 +63,7 @@ class QcImage(object):
     # _seg_colormap = plt.cm.autumn
 
     def __init__(self, qc_report, interpolation, action_list, stretch_contrast=True,
-                 stretch_contrast_method='contrast_stretching', angle_line=None):
+                 stretch_contrast_method='contrast_stretching', angle_line=None, fps=None):
         """
         :param qc_report: QcReport: The QC report object
         :param interpolation: str: Type of interpolation used in matplotlib
@@ -71,6 +71,7 @@ class QcImage(object):
         :param stretch_contrast: adjust image so as to improve contrast
         :param stretch_contrast_method: str: {'contrast_stretching', 'equalized'}: Method for stretching contrast
         :param angle_line: float: See generate_qc()
+        :param fps: float: Frame rate for output gif images
         """
         self.qc_report = qc_report
         self.interpolation = interpolation
@@ -78,6 +79,7 @@ class QcImage(object):
         self._stretch_contrast = stretch_contrast
         self._stretch_contrast_method = stretch_contrast_method
         self._angle_line = angle_line
+        self._fps = fps
         self._centermass = None  # center of mass returned by slice.Axial.get_center()
     """
     action_list contain the list of images that has to be generated.
@@ -554,7 +556,7 @@ def add_entry(src, process, args, path_qc, plane, path_img=None, path_img_overla
     :param dpi: int: Output resolution of the image
     :param stretch_contrast_method: Method for stretching contrast. See QcImage
     :param angle_line: [float]: See generate_qc()
-    :param fps: [float]: Frame rate for output gif images
+    :param fps: float: Frame rate for output gif images
     :param dataset: str: Dataset name
     :param subject: str: Subject name
     :return:

--- a/spinalcordtoolbox/scripts/sct_qc.py
+++ b/spinalcordtoolbox/scripts/sct_qc.py
@@ -29,7 +29,8 @@ def get_parser():
                         help='SCT function associated with the QC report to generate',
                         choices=('sct_propseg', 'sct_deepseg_sc', 'sct_deepseg_gm', 'sct_register_multimodal',
                                  'sct_register_to_template', 'sct_warp_template', 'sct_label_vertebrae',
-                                 'sct_detect_pmj', 'sct_label_utils', 'sct_get_centerline'),
+                                 'sct_detect_pmj', 'sct_label_utils', 'sct_get_centerline', 'sct_fmri_moco',
+                                 'sct_dmri_moco'),
                         required=True)
     parser.add_argument('-s',
                         metavar='SEG',


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
This PR introduce entry for sct_fmri_moco and sct_dmri moco in QC report.

- In `sct_qc,` add `sct_fmri_moco` and `sct_dmri_moco` as sct function choicies
- In `generate_qc`, `add entry` and `QcImage`, add fps parameter for frame rate of output gif images
- In `generate_qc`, add fps parameter for frame rate of output gif images
- In `generate_qc`, add entry for `sct_fmri_moco` and `sct_dmri_moco`

## Linked issues
Fixes #3301 
