### PR TITLE
Drop `yes |` from the docs

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y wget unzip git bzip2
 RUN wget https://github.com/neuropoly/spinalcordtoolbox/archive/master.zip
 RUN unzip master.zip
 WORKDIR spinalcordtoolbox-master
-RUN yes | ./install_sct
+RUN ./install_sct -y
 RUN echo "export PATH=/root/sct_dev/bin:$PATH" >>~/.bashrc

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -123,7 +123,7 @@ Windows subsystem for Linux (WSL) is available on Windows 10 and it makes it pos
 
    .. code:: sh
 
-      yes | ./install_sct
+      ./install_sct -y
 
    To complete the installation of these software run:
 
@@ -171,12 +171,12 @@ Ubuntu-based installation
    docker run -it ubuntu
    # Now, inside Docker container, install dependencies
    apt-get update
-   yes | apt install git curl bzip2 libglib2.0-0 gcc
+   apt install -y git curl bzip2 libglib2.0-0 gcc
    # Note for above: libglib2.0-0 is required by PyQt
    # Install SCT
    git clone https://github.com/neuropoly/spinalcordtoolbox.git sct
    cd sct
-   yes | ./install_sct
+   ./install_sct -y
    export PATH="/sct/bin:${PATH}"
    # Test SCT
    sct_testing
@@ -198,7 +198,7 @@ CentOS7-based installation
    # Install SCT
    git clone https://github.com/neuropoly/spinalcordtoolbox.git sct
    cd sct
-   yes | ./install_sct
+   ./install_sct -y
    export PATH="/sct/bin:${PATH}"
    # Test SCT
    sct_testing
@@ -400,7 +400,7 @@ Next, install ``FSLeyes`` using ``conda-forge``:
 
 .. code-block:: sh
 
-    yes | conda install -c conda-forge fsleyes
+    conda install -c conda-forge -y fsleyes
 
 
 Install from FSL

--- a/documentation/source/user_section/installation.rst
+++ b/documentation/source/user_section/installation.rst
@@ -94,7 +94,7 @@ Windows subsystem for Linux (WSL) is available on Windows 10 and it makes it pos
 
    .. code-block:: sh
 
-      sudo apt-get -y update
+      sudo apt-get update
       sudo apt-get -y install gcc
       sudo apt-get -y install unzip
       sudo apt-get install -y python-pip python


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

#### PR contents


## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I dropped `yes | ` from our installer while doing https://github.com/neuropoly/spinalcordtoolbox/pull/3125, but it's still in the docs and people are still using it. It's not that it doesn't work, it's just that it can break in unusual circumstances.

## Linked issues

https://github.com/neuropoly/spinalcordtoolbox/pull/3125
