### PR TITLE
Unset `PYTHONNOUSERSITE` in environment before calling batch script

### DIFF
--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -198,7 +198,7 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
     })
     # PYTHONNOUSERSITE is originally set in compat/launcher.py. We unset here so that it doesn't affect non-SCT commands
     # in user's pipeline scripts. See: https://github.com/neuropoly/spinalcordtoolbox/issues/3200.
-    del envir['PYTHONNOUSERSITE']
+    envir.pop('PYTHONNOUSERSITE', None)
 
     # Ship the job out, merging stdout/stderr and piping to log file
     try:

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -196,6 +196,9 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
         'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS': str(itk_threads),
         'SCT_PROGRESS_BAR': 'off'
     })
+    # PYTHONNOUSERSITE is originally set in compat/launcher.py. We unset here so that it doesn't affect non-SCT commands
+    # in user's pipeline scripts. See: https://github.com/neuropoly/spinalcordtoolbox/issues/3200.
+    del envir['PYTHONNOUSERSITE']
 
     # Ship the job out, merging stdout/stderr and piping to log file
     try:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR adds step 3:

1. `sct_run_batch` is called.
2. `PYTHONNOUSERSITE` is set to True in `compat/launcher.py` for the context of `sct_run_batch`.
3. **`PYTHONNOUSERSITE` is unset for the context of the pipeline shell script.**
4. (Optional) A pipeline script calls `sct_<function>`.
5. (Optional) `PYTHONNOUSERSITE` is set to True in `compat/launcher.py`, but only in the context of `sct_<function>`.

Step 3 is needed because `PYTHONNOUSERSITE=True` would leak into `sct_run_batch` pipeline shell scripts and affect non-SCT commands. Specifically, the command `gradunwarp` couldn't access its dependencies if they were installed in the user's site packages directory.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3200.