### PR TITLE
Update model and fixed default output suffix

### DIFF
--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -71,7 +71,7 @@ MODELS = {
     },
     "model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg": {
         "url": [
-            "https://github.com/ivadomed/model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg/archive/r20210331.zip"
+            "https://github.com/ivadomed/model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg/archive/r20210401.zip"
         ],
         "description": "Grey/white matter seg on exvivo human T2w.",
         "contrasts": ["t2"],

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -71,7 +71,7 @@ MODELS = {
     },
     "model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg": {
         "url": [
-            "https://github.com/ivadomed/model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg/archive/r20210401.zip"
+            "https://github.com/ivadomed/model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg/archive/r20210401_v2.zip"
         ],
         "description": "Grey/white matter seg on exvivo human T2w.",
         "contrasts": ["t2"],

--- a/spinalcordtoolbox/deepseg/models.py
+++ b/spinalcordtoolbox/deepseg/models.py
@@ -69,12 +69,12 @@ MODELS = {
         "contrasts": ["t2", "t1"],
         "default": False,
     },
-    "model_seg_mice_gm-wm_dwi_unet2d-multichannel-softseg": {
+    "model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg": {
         "url": [
-            "https://github.com/ivadomed/model_seg_mice_gm-wm_dwi_unet2d-multichannel-softseg/archive/r20210220.zip"
+            "https://github.com/ivadomed/model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg/archive/r20210331.zip"
         ],
-        "description": "Grey/white matter seg on exvivo mouse DWI.",
-        "contrasts": ["dwi"],
+        "description": "Grey/white matter seg on exvivo human T2w.",
+        "contrasts": ["t2"],
         "default": False,
     }
 }
@@ -98,9 +98,9 @@ TASKS = {
     'seg_tumor-edema-cavity_t1-t2':
         {'description': 'Multiclass cord tumor segmentation.',
          'models': ['findcord_tumor', 'model_seg_sctumor-edema-cavity_t2-t1_unet3d-multichannel']},
-    'seg_mice_gm-wm_dwi':
-        {'description': 'Grey/white matter seg on exvivo mouse DWI.',
-         'models': ['model_seg_mice_gm-wm_dwi_unet2d-multichannel-softseg']}
+    'seg_exvivo_gm-wm_t2':
+        {'description': 'Grey/white matter seg on exvivo human T2w.',
+         'models': ['model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg']}
 }
 
 

--- a/spinalcordtoolbox/scripts/sct_deepseg.py
+++ b/spinalcordtoolbox/scripts/sct_deepseg.py
@@ -51,7 +51,7 @@ def get_parser():
     input_output.add_argument(
         "-o",
         help="Output file name. In case of multi-class segmentation, class-specific suffixes will be added. By default,"
-             "suffix '_seg' will be added and output extension will be .nii.gz.",
+             "the suffix specified in the packaged model will be added and output extension will be .nii.gz.",
         metavar=Metavar.str)
 
     seg = parser.add_argument_group('\nTASKS')


### PR DESCRIPTION
## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [x] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
In this PR:
- [x] Correct the parser of `sct_deepseg -o` regarding the default output suffix
- [x] Add a new release of the [model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg](https://github.com/ivadomed/model_seg_exvivo_gm-wm_t2_unet2d-multichannel-softseg)
- [ ] ONNX instead of PT version in order to speed up segmentation process (see #3309) 

## Linked issues
Resolves #3278, Resolves #3279
