### PR TITLE
Fix faulty check for `arguments.set_sform_to_qform`

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -190,7 +190,7 @@ def main(argv=None):
         parser.error("Multi-image input is only supported for the '-concat' and '-omc' arguments.")
 
     # Apply initialization steps to all input images first
-    if arguments.set_sform_to_qform is not None:
+    if arguments.set_sform_to_qform:
         [im.set_sform_to_qform() for im in im_in_list]
 
     # Most sct_image options don't accept multi-image input, so here we simply separate out the first image
@@ -310,7 +310,7 @@ def main(argv=None):
         im_out = [ displacement_to_abs_fsl(im_in, spaces[0], spaces[1]) ]
 
     # If this argument is used standalone, simply pass the input image to the output (sform was set for im_in earlier)
-    elif arguments.set_sform_to_qform is not None:
+    elif arguments.set_sform_to_qform:
         im_out = [im_in]
 
     else:


### PR DESCRIPTION
It uses action="store_true", so the default value is actually False, not None.

<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Because `-set-sform-to-qform` uses `action="store_true"`, it's default value is `False`.

This means that the check `if arguments.set_sform_to_qform is not None` was wrong. This PR replaces it with `if arguments.set_sform_to_qform`.

Some alternate solutions:

* Setting `default=None` for the argument. This would change it from `True/False` to `True/None` which means we could use `if <> is not None` consistently for every argument.
* Setting [`default=argparse.SUPPRESS`](https://stackoverflow.com/a/48004525) for each argument.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3311.