### PR TITLE
Handle affine matrix mismatches better by exposing `-set-qform-to-sform`

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -303,11 +303,10 @@ class Image(object):
                              "please report this on github at https://github.com/neuropoly/spinalcordtoolbox/issues "
                              " or on the SCT forum https://forum.spinalcordmri.org/.")
             else:
-                dummy_reaffined = re.sub("\\.(.*)", "_same-affine.\\1", self.absolutepath)
-                logger.error("Image {} has different qform and sform matrices. This can produce incorrect results. "
-                             "Consider setting the two matrices to be equal by running:\n"
-                             "sct_image -i {} -set-sform-to-qform -o {}.".format(
-                    self._path, self._path, dummy_reaffined))
+                logger.error(f"Image {self._path} has different qform and sform matrices. This can produce incorrect "
+                             f"results. Please use 'sct_image -i {self._path} -header' to check that both affine "
+                             f"matrices are valid. Then, consider running either 'sct_image -set-sform-to-qform' or "
+                             f"'sct_image -set-qform-to-sform' to fix any discrepancies you may find.")
             raise ValueError("Image sform does not match qform")
 
 

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -97,9 +97,17 @@ def get_parser():
         help='Copy the header of the source image (specified in -i) to the destination image (specified here) '
              'and save it into a new image (specified in -o)',
         required = False)
-    header.add_argument(
+    affine_fixes = header.add_mutually_exclusive_group(required=False)
+    affine_fixes.add_argument(
         '-set-sform-to-qform',
         help="Set the input image's sform matrix equal to its qform matrix. Use this option when you "
+             "need to enforce matching sform and qform matrices. This option can be used by itself, or in combination "
+             "with other functions.",
+        action='store_true'
+    )
+    affine_fixes.add_argument(
+        '-set-qform-to-sform',
+        help="Set the input image's qform matrix equal to its sform matrix. Use this option when you "
              "need to enforce matching sform and qform matrices. This option can be used by itself, or in combination "
              "with other functions.",
         action='store_true'
@@ -192,6 +200,8 @@ def main(argv=None):
     # Apply initialization steps to all input images first
     if arguments.set_sform_to_qform:
         [im.set_sform_to_qform() for im in im_in_list]
+    elif arguments.set_qform_to_sform:
+        [im.set_qform_to_sform() for im in im_in_list]
 
     # Most sct_image options don't accept multi-image input, so here we simply separate out the first image
     # TODO: Extend the options so that they iterate through the list of images (to support multi-image input)
@@ -309,8 +319,8 @@ def main(argv=None):
             spaces.append(None)
         im_out = [ displacement_to_abs_fsl(im_in, spaces[0], spaces[1]) ]
 
-    # If this argument is used standalone, simply pass the input image to the output (sform was set for im_in earlier)
-    elif arguments.set_sform_to_qform:
+    # If these arguments are used standalone, simply pass the input image to the output (the affines were set earlier)
+    elif arguments.set_sform_to_qform or arguments.set_qform_to_sform:
         im_out = [im_in]
 
     else:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [X] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [X] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #3249, we learned that our current recommendation (`-set-sform-to-qform`) is not sufficient to fix all affine mismatch issues. So, this PR makes the following changes:

* Exposes the complementary operation (`-set-qform-to-sform`)
* Broadens the error message so that users are encouraged to inspect the affine matrices and understand how to fix their own affine matrices.

### Future work

I also wanted to point users to a documentation page about what valid affines look like (so that users can learn how to spot issues). But, there's not really a good page to link! 

* Nibabel has pages that are close (["Coordinate systems and affines"](https://nipy.org/nibabel/coordinate_systems.html), ["The NIFTI affines"](https://nipy.org/nibabel/nifti_images.html#the-nifti-affines)) but those pages contain a lot of extraneous information that could confuse/overwhelm readers. 
* The NIFTI-1 spec also has some useful pages (["Docs on qform and sform"](https://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields/nifti1fields_pages/qsform.html)), but these are written in a very technical way and don't seem friendly to non-developers.

So, if others feel it is worth the effort, I could also write a quick SCT documentation page on how to inspect the output of `sct_image -header`. But, this PR could also be sufficient on its own.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3249.
Depends on #3317. 