### PR TITLE
Various fixes to sct_image -display-warp

### DIFF
--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -488,7 +488,6 @@ def multicomponent_split(im):
 
 
 def multicomponent_merge(im_in_list: Sequence[Image]):
-    from numpy import zeros
     # WARNING: output multicomponent is not optimal yet, some issues may be related to the use of this function
 
     im_0 = im_in_list[0]
@@ -498,7 +497,7 @@ def multicomponent_merge(im_in_list: Sequence[Image]):
     new_shape.append(len(im_in_list))
     new_shape = tuple(new_shape)
 
-    data_out = zeros(new_shape)
+    data_out = np.zeros(new_shape)
     for i, im in enumerate(im_in_list):
         dat = im.data
         if len(dat.shape) == 2:
@@ -521,7 +520,6 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
     if im_grid:
         fname_grid = im_grid.absolutepath
     else:
-        from numpy import zeros
         tmp_dir = tmp_create()
         status, out = run_proc(['fslhd', fname_warp])
         curdir = os.getcwd()
@@ -532,10 +530,10 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
         nx = int(out[out.find(dim1):][len(dim1):out[out.find(dim1):].find('\n')])
         ny = int(out[out.find(dim2):][len(dim2):out[out.find(dim2):].find('\n')])
         nz = int(out[out.find(dim3):][len(dim3):out[out.find(dim3):].find('\n')])
-        sq = zeros((step, step))
+        sq = np.zeros((step, step))
         sq[step - 1] = 1
         sq[:, step - 1] = 1
-        dat = zeros((nx, ny, nz))
+        dat = np.zeros((nx, ny, nz))
         for i in range(0, dat.shape[0], step):
             for j in range(0, dat.shape[1], step):
                 for k in range(dat.shape[2]):

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -521,15 +521,9 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
         fname_grid = im_grid.absolutepath
     else:
         tmp_dir = tmp_create()
-        status, out = run_proc(['fslhd', fname_warp])
+        nx, ny, nz = im_warp.data.shape[0:3]
         curdir = os.getcwd()
         os.chdir(tmp_dir)
-        dim1 = 'dim1           '
-        dim2 = 'dim2           '
-        dim3 = 'dim3           '
-        nx = int(out[out.find(dim1):][len(dim1):out[out.find(dim1):].find('\n')])
-        ny = int(out[out.find(dim2):][len(dim2):out[out.find(dim2):].find('\n')])
-        nz = int(out[out.find(dim3):][len(dim3):out[out.find(dim3):].find('\n')])
         sq = np.zeros((step, step))
         sq[step - 1] = 1
         sq[:, step - 1] = 1
@@ -539,12 +533,11 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
                 for k in range(dat.shape[2]):
                     if dat[i:i + step, j:j + step, k].shape == (step, step):
                         dat[i:i + step, j:j + step, k] = sq
-        fname_grid = 'grid_' + str(step) + '.nii.gz'
         im_grid = Image(param=dat)
         grid_hdr = im_warp.hdr
         im_grid.hdr = grid_hdr
-        im_grid.absolutepath = fname_grid
-        im_grid.save()
+        fname_grid = 'grid_' + str(step) + '.nii.gz'
+        im_grid.save(fname_grid)
         fname_grid_resample = add_suffix(fname_grid, '_resample')
         run_proc(['sct_resample', '-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample])
         fname_grid = os.path.join(tmp_dir, fname_grid_resample)

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -18,7 +18,7 @@ import numpy as np
 from nibabel import Nifti1Image
 from nibabel.processing import resample_from_to
 
-import spinalcordtoolbox
+from spinalcordtoolbox.scripts import sct_apply_transfo, sct_resample
 from spinalcordtoolbox.image import (Image, concat_data, add_suffix, change_orientation, split_img_data, pad_image,
                                      create_formatted_header_string, HEADER_FORMATS)
 from spinalcordtoolbox.utils.shell import SCTArgumentParser, Metavar, display_viewer_syntax
@@ -539,12 +539,12 @@ def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
         fname_grid = 'grid_' + str(step) + '.nii.gz'
         im_grid.save(fname_grid)
         fname_grid_resample = add_suffix(fname_grid, '_resample')
-        run_proc(['sct_resample', '-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample])
+        sct_resample.main(argv=['-i', fname_grid, '-f', '3x3x1', '-x', 'nn', '-o', fname_grid_resample])
         fname_grid = os.path.join(tmp_dir, fname_grid_resample)
         os.chdir(curdir)
     path_warp, file_warp, ext_warp = extract_fname(fname_warp)
     grid_warped = os.path.join(path_warp, extract_fname(fname_grid)[1] + '_' + file_warp + ext_warp)
-    run_proc(['sct_apply_transfo', '-i', fname_grid, '-d', fname_grid, '-w', fname_warp, '-o', grid_warped])
+    sct_apply_transfo.main(argv=['-i', fname_grid, '-d', fname_grid, '-w', fname_warp, '-o', grid_warped])
     if rm_tmp:
         rmtree(tmp_dir)
 

--- a/spinalcordtoolbox/scripts/sct_image.py
+++ b/spinalcordtoolbox/scripts/sct_image.py
@@ -517,9 +517,9 @@ def multicomponent_merge(im_in_list: Sequence[Image]):
 
 
 def visualize_warp(im_warp: Image, im_grid: Image = None, step=3, rm_tmp=True):
-    fname_warp = im_warp.absolutepath()
+    fname_warp = im_warp.absolutepath
     if im_grid:
-        fname_grid = im_grid.absolutepath()
+        fname_grid = im_grid.absolutepath
     else:
         from numpy import zeros
         tmp_dir = tmp_create()

--- a/unit_testing/cli/test_cli_sct_image.py
+++ b/unit_testing/cli/test_cli_sct_image.py
@@ -1,8 +1,10 @@
 from pytest_console_scripts import script_runner
 import pytest
 import logging
+import os
 
 from spinalcordtoolbox.scripts import sct_image
+from spinalcordtoolbox.utils.sys import sct_test_path
 
 logger = logging.getLogger(__name__)
 
@@ -21,3 +23,11 @@ def test_sct_image_show_header_no_checks(output_format):
     """Run the CLI script without checking results. The rationale for not checking results is
     provided here: https://github.com/neuropoly/spinalcordtoolbox/pull/3317#issuecomment-811429547"""
     sct_image.main(argv=['-i', 'sct_testing_data/t2/t2.nii.gz', '-header', output_format])
+
+
+def test_sct_image_display_warp_check_output_exists():
+    """Run the CLI script and check that the warp image file was created."""
+    fname_in = 'warp_template2anat.nii.gz'
+    fname_out = 'grid_3_resample_' + fname_in
+    sct_image.main(argv=['-i', sct_test_path('t2', fname_in), '-display-warp'])
+    assert os.path.exists(sct_test_path('t2', fname_out))


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [x] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [x] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description

This PR fixes a few issues related to `sct_image -display-warp`:

- [x] Fixes usage of Image.absolutepath, causing a `TypeError`. Fixes #3336
- [x] Removes dependency to `fslhd`.
- [x] Removes calls to `run_proc` (no longer recommended, see dev wiki)

