### PR TITLE
Fully isolate the conda env by its site.py

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -325,6 +325,17 @@ if [ "$(uname)" = "Darwin" ]; then
   (command -v realpath >/dev/null) || realpath() {
     python3 -c 'import sys, os; [print(os.path.realpath(f)) for f in sys.argv[1:]]' "$@"
   }
+
+
+  # glue over the difference between how BSD and GNU sed work with -i
+  # https://code-examples.net/en/q/56e314
+  sed_i() {
+    sed -i '' "$@"
+  }
+else
+  sed_i() {
+    sed -i "$@"
+  }
 fi
 
 # ======================================================================================================================
@@ -557,9 +568,6 @@ fi
 # Install Python
 # ----------------------------------------------------------------------------------------------------------------------
 
-# We make sure that there is no conflict with local python install by unsetting PYTHONPATH and forcing PYTHONNOUSERSITE
-unset PYTHONPATH
-export PYTHONNOUSERSITE=1
 
 # Remove old python folder
 print info "Installing conda..."
@@ -581,6 +589,15 @@ run bash "$TMP_DIR/miniconda.sh" -p "$SCT_DIR/$PYTHON_DIR" -b -f
 
 # create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
 python/bin/conda create -y -n venv_sct python=3.6
+
+# make sure that there is no conflict with local python install by making venv_sct an isolated environment.
+# workaround for https://github.com/conda/conda/issues/7173
+# see also
+# * https://github.com/neuropoly/spinalcordtoolbox/pull/3067
+# * https://github.com/neuropoly/spinalcordtoolbox/issues/3200
+# this needs to be added very early in python's boot process
+# so using sitecustomize.py or even just appending to the file are impossible.
+sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$SCT_DIR/$PYTHON_DIR/envs/venv_sct/lib/python"*"/site.py"
 
 # activate miniconda
 # shellcheck disable=SC1091

--- a/spinalcordtoolbox/compat/launcher.py
+++ b/spinalcordtoolbox/compat/launcher.py
@@ -24,9 +24,6 @@ def main():
     if "ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS" not in os.environ:
         env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(multiprocessing.cpu_count())
 
-    # Prevent user site packages from interfering with SCT dependencies (See issue #3067)
-    env["PYTHONNOUSERSITE"] = "True"
-
     command = os.path.basename(sys.argv[0])
     pkg_dir = os.path.dirname(sct.__file__)
 

--- a/spinalcordtoolbox/scripts/sct_run_batch.py
+++ b/spinalcordtoolbox/scripts/sct_run_batch.py
@@ -196,9 +196,6 @@ def run_single(subj_dir, script, script_args, path_segmanual, path_data, path_da
         'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS': str(itk_threads),
         'SCT_PROGRESS_BAR': 'off'
     })
-    # PYTHONNOUSERSITE is originally set in compat/launcher.py. We unset here so that it doesn't affect non-SCT commands
-    # in user's pipeline scripts. See: https://github.com/neuropoly/spinalcordtoolbox/issues/3200.
-    envir.pop('PYTHONNOUSERSITE', None)
 
     # Ship the job out, merging stdout/stderr and piping to log file
     try:


### PR DESCRIPTION

## Motivation

The fix for https://github.com/neuropoly/spinalcordtoolbox/issues/3067 turned out to be pretty complicated: https://github.com/neuropoly/spinalcordtoolbox/issues/3200

This is a cleaner fix for that issue, inspired by @takluyver's helpful observation https://github.com/conda/conda/issues/7173#issuecomment-389190657 that `site.py` [is the canonical place to manage this sort of thing](https://docs.python.org/3/library/site.html#site.ENABLE_USER_SITE) -- @takluyver, I know you mitigated your opinion later while helping users, but for us, we're using conda to build a sort of .appimage or .app/ folder, with protected, pinned dependencies, and intentionally not exposing conda to our users, so isolating the entire python site is *exactly* what we need!

This turns a 7 line fix into a 1 line fix: just set `site.ENABLE_USER_SITE` for the env. That isolates it to python programs run in the env, and can't leak accidentally.


## Proof

To demonstrate this is right, I ran `sct_run_batch` because that's what we had problems with in #3200, feeding it this script:

```
$ cat ../hello.sh 
#!/bin/sh

(
set | grep PATH=
python3 -c 'import sys; print(sys.path)'
) | tee /tmp/hello.log
```

I also had to make a dataset it would accept; I culled https://github.com/spine-generic/data-multi-subject/ down to just

```
$ ls -l ../datalad/spine-generic/data-multi-subject/
total 128
-rwxr-xr-x 1 kousu kousu  3087 Feb  2 15:10 CHANGES.md
-rwxr-xr-x 1 kousu kousu  3467 Aug 16  2020 dataset_description.json
drwxr-xr-x 3 kousu kousu  4096 Aug 16  2020 derivatives
-rw-r--r-- 1 kousu kousu  2922 Feb  2 15:16 exclude.yml
-rw-r--r-- 1 kousu kousu  1078 Feb  2 15:10 LICENSE
-rwxr-xr-x 1 kousu kousu  1175 Feb  2 15:16 participants.json
-rwxr-xr-x 1 kousu kousu 41123 Feb  2 15:16 participants.tsv
-rwxr-xr-x 1 kousu kousu  1952 Feb  2 15:10 README.md
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-ucl01
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-ucl02
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-ucl03
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-ucl04
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-ucl05
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-ucl06
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf01
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf02
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf03
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf04
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf05
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf06
drwxr-xr-x 4 kousu kousu  4096 Aug 16  2020 sub-unf07
```

This is the command I used to test:

```
$ ./python/envs/venv_sct/bin/sct_run_batch -script ../hello.sh -path-data ../datalad/spine-generic/data-multi-subject/
$ cat /tmp/hello.log
```




0. Reinstall

    ```
    $ git checkout master
    $ rm -rf python
    $ ./install_sct -y
    ```


There are four conditions to consider: what happens when running `sct_run_batch` inside `venv_sct`, what happens outside? x 
what happens before the patch, and what happens after?

(`master` == 3f4b37e09448ba23e9571c4f77645412621c6106 here)


1. *out* of venv *before* patch


    ```
    $ ./python/envs/venv_sct/bin/sct_run_batch -script ../hello.sh -path-data ../datalad/spine-generic/data-multi-subject/
    $ cat /tmp/hello.log
    PATH=/opt/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
    ['', '/usr/lib/python39.zip', '/usr/lib/python3.9', '/usr/lib/python3.9/lib-dynload', '/home/kousu/.local/lib/python3.9/site-packages', '/home/kousu/src/xmpp/bridges/xmpp-smpp', '/home/kousu/src/neuropoly/sysadmin/infersent-data-model1/src', '/usr/lib/python3.9/site-packages']
    ```

2. *in* venv *before* patch

    ```
    $ . python/bin/activate 
    (base) $ conda activate venv_sct
    (venv_sct) $ ./python/envs/venv_sct/bin/sct_run_batch -script ../hello.sh -path-data ../datalad/spine-generic/data-multi-subject/
    (venv_sct) $ cat /tmp/hello.log
    PATH=/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/bin:/opt/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
    ['', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python36.zip', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6/lib-dynload', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6/site-packages', '/home/kousu/src/neuropoly/spinalcordtoolbox']
    ```

    ```
    (venv_sct) $ conda deactivate
    (base) $ conda deactivate
    $
    ```

3. *out* of venv *after* patch

    Note: I cheated here; I didn't do a fresh reinstall but patched the existing conda env directly, but I'm 99% sure that this is accurate:

    ```
    $ git checkout ng/nousersite
    $ sed -i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "python/envs/venv_sct/lib/python3.6/site.py"
    $ grep ENABLE_USER_SITE "python/envs/venv_sct/lib/python3.6/site.py" | head -n 1 # verify the patch
    ENABLE_USER_SITE = False
    $ ./python/envs/venv_sct/bin/sct_run_batch -script ../hello.sh -path-data ../datalad/spine-generic/data-multi-subject/
    $ cat /tmp/hello.log
    PATH=/opt/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
    ['', '/usr/lib/python39.zip', '/usr/lib/python3.9', '/usr/lib/python3.9/lib-dynload', '/home/kousu/.local/lib/python3.9/site-packages', '/home/kousu/src/xmpp/bridges/xmpp-smpp', '/home/kousu/src/neuropoly/sysadmin/infersent-data-model1/src', '/usr/lib/python3.9/site-packages']
    ```

4. *in* venv *after* patch

    ```
    $ . python/bin/activate 
    (base) $ conda activate venv_sct
    (venv_sct) $ ./python/envs/venv_sct/bin/sct_run_batch -script ../hello.sh -path-data ../datalad/spine-generic/data-multi-subject/
    $ cat /tmp/hello.log
    PATH=/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/bin:/opt/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
    ['', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python36.zip', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6/lib-dynload', '/home/kousu/src/neuropoly/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6/site-packages', '/home/kousu/src/neuropoly/spinalcordtoolbox']
    ```


## Analysis


The environment within the venv is identical in both old and new, and same with outside. So this patch seems to safely accomplish the same goal.
