### PR TITLE
(WIP) Test the impact of `tensorflow==1.13.1` + Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-18.04
     container: archlinux
     steps:
@@ -64,7 +64,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-18.04
     container: debian:sid
     steps:
@@ -81,7 +81,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-18.04
     container: debian:testing
     steps:
@@ -98,7 +98,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-18.04
     container: debian:10
     steps:
@@ -115,7 +115,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-16.04 # use an older ubuntu's kernel to closer emulate the older Debian
     container: debian:9
     steps:
@@ -145,7 +145,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-16.04 # use an older ubuntu's kernel to closer emulate the older Debian
     container: centos:7
     steps:
@@ -171,7 +171,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-16.04
     steps:
       - name: Dependencies
@@ -196,7 +196,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    #if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    ## if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     if: false # overloaded on Github currently, and we're not really using it yet.
     runs-on: macos-11.0
     steps:
@@ -214,7 +214,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: windows-2019
     defaults:
       run:
@@ -248,7 +248,7 @@ jobs:
     # TODO: when actions supports using ${{env}} in job.*.if and not just job.*.steps.*.if, use this:
     #if: ${{ env.NIGHTLY }}
     # in the meantime, copy-paste this:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: windows-2019
     defaults:
       run:

--- a/install_sct
+++ b/install_sct
@@ -628,14 +628,6 @@ else
 fi
 (
   pip install -r "$REQUIREMENTS_FILE" &&
-  # `tensorflow-tensorboard` is installed by `tensorflow==1.5.0` but is not needed,
-  # and conflicts with the other installation of `tensorboard`. So, we uninstall here.
-  # This is hacky, and should be removed as soon as we stop using `tensorflow==1.5.0`.
-  # See https://github.com/neuropoly/spinalcordtoolbox/issues/3035 for more info.
-  pip uninstall -y tensorflow-tensorboard &&
-  pip uninstall -y tensorboard &&
-  pip install tensorboard &&
-  # install sct itself
   print info "Installing spinalcordtoolbox..." &&
   pip install -e .
 ) ||

--- a/install_sct
+++ b/install_sct
@@ -587,8 +587,8 @@ esac
 # Run conda installer
 run bash "$TMP_DIR/miniconda.sh" -p "$SCT_DIR/$PYTHON_DIR" -b -f
 
-# create py3.6 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-python/bin/conda create -y -n venv_sct python=3.6
+# create py3.7 venv (checking to see impact on test suite)
+python/bin/conda create -y -n venv_sct python=3.7
 
 # make sure that there is no conflict with local python install by making venv_sct an isolated environment.
 # workaround for https://github.com/conda/conda/issues/7173

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ requirements-parser
 scipy
 scikit-image
 scikit-learn
-tensorflow==1.5.0
+tensorflow==1.13.1
 # PyTorch's Linux/Windows distribution is very large due to its GPU support,
 # but we only need that for training models. For users, use the CPU-only version
 # (only available directly from the PyTorch project).


### PR DESCRIPTION
See https://github.com/neuropoly/spinalcordtoolbox/issues/3227#issuecomment-821897302 for context:

> Just as a backup plan, I can also quickly test the "upgrading tensorflow" approach to see if we can still use Python 3.7 with SCT's current state (without deprecating anything). Even if we don't end up going that route, it might be useful preparation for the inevitable change later this year.