### PR TITLE
Throw error during installation if `$SCT_DIR` contains spaces

### DIFF
--- a/install_sct
+++ b/install_sct
@@ -504,6 +504,13 @@ Do you agree? [y]es/[n]o: "
   fi
 done
 
+space_regex="[[:space:]]+"
+if [[ $SCT_DIR =~ $space_regex ]]; then
+  die "ERROR: Install directory $SCT_DIR contains spaces.\n\
+       SCT uses conda, which does not permit spaces in installation paths.\n\
+       More details can be found here: https://github.com/ContinuumIO/anaconda-issues/issues/716"
+fi
+
 # update PATH environment?
 add_to_path=""
 while [[ ! "$add_to_path" =~ ^([Yy](es)?|[Nn]o?)$ ]]; do


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Spaces are not permitted by the Miniconda install script. We could let it fail by itself, but the error happens after the Miniconda script is downloaded (time-consuming), and the message itself is quite bare:

```bash
ERROR: Cannot install into directories with spaces  # Cannot install what? Unclear if it's an SCT or conda issue
```

So, this PR adds a check that fails earlier, and provides more info so that the user will know that it's an upstream issue.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #2785.
Fixes #3364.
