### PR TITLE
Change `sct_apply_transfo -v 0` to match `isct_antsApplyTransform` output

### DIFF
--- a/spinalcordtoolbox/scripts/sct_apply_transfo.py
+++ b/spinalcordtoolbox/scripts/sct_apply_transfo.py
@@ -221,7 +221,7 @@ class Transform:
                       '-i', fname_src,
                       '-o', fname_out,
                       '-t'
-                      ] + fname_warp_list_invert + ['-r', fname_dest] + interp, verbose=verbose, is_sct_binary=True)
+                      ] + fname_warp_list_invert + ['-r', fname_dest] + interp, is_sct_binary=True)
 
         # if 4d, loop across the T dimension
         else:

--- a/spinalcordtoolbox/scripts/sct_label_vertebrae.py
+++ b/spinalcordtoolbox/scripts/sct_label_vertebrae.py
@@ -307,7 +307,7 @@ def main(argv=None):
             '-i', 'data.nii',
             '-s', 'segmentation.nii',
             '-r', str(remove_temp_files),
-            '-v', str(verbose),
+            '-v', '0',
         ])
         cache_save(cachefile, cache_sig)
 
@@ -323,7 +323,7 @@ def main(argv=None):
                             '-w', 'warp_curve2straight.nii.gz',
                             '-o', 'segmentation_straight.nii',
                             '-x', 'linear',
-                            '-v', str(verbose)])
+                            '-v', '0'])
 
     # Threshold segmentation at 0.5
     img = Image('segmentation_straight.nii')
@@ -391,7 +391,7 @@ def main(argv=None):
                                 '-w', 'warp_curve2straight.nii.gz',
                                 '-o', 'labelz_straight.nii.gz',
                                 '-x', 'nn',
-                                '-v', str(verbose)])
+                                '-v', '0'])
         # get z value and disk value to initialize labeling
         printv('\nGet z and disc values from straight label...', verbose)
         init_disc = get_z_and_disc_values_from_label('labelz_straight.nii.gz')
@@ -425,7 +425,7 @@ def main(argv=None):
                             '-w', 'warp_straight2curve.nii.gz',
                             '-o', 'segmentation_labeled.nii',
                             '-x', 'nn',
-                            '-v', str(verbose)])
+                            '-v', '0'])
 
     if clean_labels:
         # Clean labeled segmentation

--- a/spinalcordtoolbox/scripts/sct_warp_template.py
+++ b/spinalcordtoolbox/scripts/sct_warp_template.py
@@ -123,7 +123,7 @@ def warp_label(path_label, folder_label, file_label, fname_src, fname_transfo, p
                                     '-w', fname_transfo,
                                     '-o', os.path.join(path_out, folder_label, template_label_file[i]),
                                     '-x', get_interp(template_label_file[i], list_labels_nn),
-                                    '-v', str(verbose)])
+                                    '-v', '0'])
         # Copy list.txt
         copy(os.path.join(path_label, folder_label, file_label), os.path.join(path_out, folder_label))
 

--- a/spinalcordtoolbox/straightening.py
+++ b/spinalcordtoolbox/straightening.py
@@ -525,7 +525,7 @@ class SpinalCordStraightener(object):
                                     '-w', 'tmp.curve2straight.nii.gz',
                                     '-o', 'tmp.anat_rigid_warp.nii.gz',
                                     '-x', 'spline',
-                                    '-v', str(verbose)])
+                                    '-v', '0'])
 
 
         if self.accuracy_results:
@@ -539,7 +539,7 @@ class SpinalCordStraightener(object):
                                     '-w', 'tmp.curve2straight.nii.gz',
                                     '-o', 'tmp.centerline_straight.nii.gz',
                                     '-x', 'nn',
-                                    '-v', str(verbose)])
+                                    '-v', '0'])
             file_centerline_straight = Image('tmp.centerline_straight.nii.gz', verbose=verbose)
             nx, ny, nz, nt, px, py, pz, pt = file_centerline_straight.dim
             coordinates_centerline = file_centerline_straight.getNonZeroCoordinates(sorting='z')


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [X] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

In #3272, the last remaining calls to `isct_antsApplyTransform` were replaced with `sct_apply_transfo`. But, the default output for  `sct_apply_transfo` is much noisier, which in turn makes scripts like `sct_warp_template` much noisier.

So, this PR:

* Tweaks  `sct_apply_transfo -v 0` so it will have identical output to the old `isct_antsApplyTransform` command.
* Changes all of the calls from #3272 to use `-v 0`.

Now all of the calls should behave as they were before. e.g.:

```
--
Spinal Cord Toolbox (git-jn/3352-fix-sct_apply_transfo-verbosity-d71d79824f61533623b32b672c8efc3148e461e5)
sct_warp_template -d fmri_mean.nii.gz -w warp_template2fmri.nii.gz -a 1 -s 1 -qc ~/qc-example-fmri/
--

Check parameters:
  Working directory ........ /home/joshua/repos/spinalcordtoolbox/sct_example_data/fmri
  Destination image ........ fmri_mean.nii.gz
  Warping field ............ warp_template2fmri.nii.gz
  Path template ............ /home/joshua/repos/spinalcordtoolbox/data/PAM50
  Output folder ............ label

WARP TEMPLATE:
/home/joshua/repos/spinalcordtoolbox/bin/isct_antsApplyTransforms -d 3 -i /home/joshua/repos/spinalcordtoolbox/data/PAM50/template/PAM50_t1.nii.gz -o label/template/PAM50_t1.nii.gz -t warp_template2fmri.nii.gz -r fmri_mean.nii.gz -n Linear # in /home/joshua/repos/spinalcordtoolbox/sct_example_data/fmri
/home/joshua/repos/spinalcordtoolbox/bin/isct_antsApplyTransforms -d 3 -i /home/joshua/repos/spinalcordtoolbox/data/PAM50/template/PAM50_t2.nii.gz -o label/template/PAM50_t2.nii.gz -t warp_template2fmri.nii.gz -r fmri_mean.nii.gz -n Linear # in /home/joshua/repos/spinalcordtoolbox/sct_example_data/fmri
/home/joshua/repos/spinalcordtoolbox/bin/isct_antsApplyTransforms -d 3 -i /home/joshua/repos/spinalcordtoolbox/data/PAM50/template/PAM50_t2s.nii.gz -o label/template/PAM50_t2s.nii.gz -t warp_template2fmri.nii.gz -r fmri_mean.nii.gz -n Linear # in /home/joshua/repos/spinalcordtoolbox/sct_example_data/fmri
[...]
```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3352.