### PR TITLE
(WIP) Only load data in `Image` when the data is requested

### DIFF
--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -417,12 +417,11 @@ class Image(object):
         :param path: path of the file from which the image will be loaded
         :return:
         """
-
-        self.im_file = nib.load(path)
+        self.absolutepath = path
+        self.im_file = nib.load(self.absolutepath)
         # NOTE: We no longer pre-load the data. We now wait until it's requested, using the 'data' getter method.
         # self._data = self.im_file.get_data()
         self.hdr = self.im_file.header
-        self.absolutepath = path
         if path != self.absolutepath:
             logger.debug("Loaded %s (%s) orientation %s shape %s", path, self.absolutepath, self.orientation, self.dim[0:3])
         else:

--- a/spinalcordtoolbox/image.py
+++ b/spinalcordtoolbox/image.py
@@ -378,8 +378,10 @@ class Image(object):
         from copy import deepcopy
         if image is not None:
             self.im_file = deepcopy(image.im_file)
-            # NOTE: We no longer pre-load the data. We now wait until it's requested, using the 'data' getter method.
-            # self._data = self.im_file.get_data()
+            # Normally, we don't preload the data, and take it from self.im_file_get_data() in the 'data' getter method.
+            # However, if there is no self.im_file, we need to copy over the data from the original immediately.
+            if self.im_file is None:
+                self._data = deepcopy(image.data)
             self.hdr = deepcopy(image.hdr)
             self._path = deepcopy(image._path)
         else:


### PR DESCRIPTION
<!-- Hi, and thank you for submitting a Pull Request! The checklist below is a brief summary of steps found in the NeuroPoly Contributing Guidelines, which can be found here: https://www.neuro.polymtl.ca/software/contributing. 
-->

## Checklist

#### GitHub

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've applied a [release milestone](https://github.com/neuropoly/spinalcordtoolbox/milestones) (major, minor, patch) in line with [Semantic Versioning guidelines](https://github.com/neuropoly/spinalcordtoolbox/wiki/Misc%3A-Creating-a-new-release#convention-for-naming-releases) 
- [ ] I've assigned a reviewer

<!-- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

#### PR contents

- [ ] I've consulted [SCT's internal developer documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki) to ensure my contribution is in line with any relevant design decisions
- [ ] I've added [relevant tests](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Tests) for my contribution
- [ ] I've updated the [relevant documentation](https://github.com/neuropoly/spinalcordtoolbox/wiki/Programming%3A-Documentation) for my changes, including argparse descriptions, docstrings, and ReadTheDocs tutorial pages

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

This PR tries to:

* Replicate [`nibabel` lazyloading functionality](https://nipy.org/nibabel/images_and_memory.html) without having to overhaul SCT's very deep usage of our custom `Image` class.
* Be a more thorough solution than https://github.com/neuropoly/spinalcordtoolbox/pull/3315 with comparable results. 

For the same command tested in that PR, I get ` 427.15s user 66.09s system 186% cpu 4:24.60 total`, which is still a ~1.5m improvement. The upside is, this improvement applies to SCT as a whole.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Fixes #3271.